### PR TITLE
feat: JSON output for agents info and agents list

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -334,7 +334,7 @@ UNIFIED FLAGS (before --):
   -a, --auto           Enable auto-mode
   -e, --effort <LEVEL> Reasoning effort level (e.g., high, low)"#)]
 pub struct Cli {
-    /// Output results as JSON (supported by: auth, version)
+    /// Output results as JSON (supported by: auth, version, sessions, agents info, agents list)
     #[arg(long, global = true)]
     pub json: bool,
 

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -34,6 +34,19 @@ pub struct AuthCheckOutput {
     pub details: Option<String>,
 }
 
+/// Agent information output (for `unleash agents info --json` and `unleash agents list --json`)
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AgentInfoOutput {
+    pub agent_type: String,
+    pub name: String,
+    pub binary: String,
+    pub description: String,
+    pub github_repo: Option<String>,
+    pub npm_package: Option<String>,
+    pub enabled: bool,
+    pub installed_version: Option<String>,
+}
+
 /// Generic success response
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SuccessOutput {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -617,6 +617,7 @@ pub fn run() -> io::Result<()> {
         Some(Commands::Agents { action }) => {
             use agents::{AgentManager, AgentType};
             use cli::AgentsAction;
+            let json = cli.json;
 
             let mut manager = match AgentManager::new() {
                 Ok(m) => m,
@@ -644,13 +645,39 @@ pub fn run() -> io::Result<()> {
                     Ok(())
                 }
                 Some(AgentsAction::List) => {
-                    println!("Available Agents:\n");
-                    for agent in manager.list_agents() {
-                        let status = if agent.enabled { "enabled" } else { "disabled" };
-                        println!(
-                            "  {} ({}) - {} [{}]",
-                            agent.name, agent.binary, agent.description, status
-                        );
+                    // Clone agent definitions first to avoid borrow conflicts when
+                    // calling get_installed_version (which takes &mut self).
+                    let defs: Vec<_> = manager.list_agents().into_iter().cloned().collect();
+                    if json {
+                        let items: Vec<json_output::AgentInfoOutput> = defs
+                            .iter()
+                            .map(|def| {
+                                let installed = manager
+                                    .get_installed_version(def.agent_type)
+                                    .ok()
+                                    .flatten();
+                                json_output::AgentInfoOutput {
+                                    agent_type: format!("{:?}", def.agent_type).to_lowercase(),
+                                    name: def.name.clone(),
+                                    binary: def.binary.clone(),
+                                    description: def.description.clone(),
+                                    github_repo: def.github_repo.clone(),
+                                    npm_package: def.npm_package.clone(),
+                                    enabled: def.enabled,
+                                    installed_version: installed,
+                                }
+                            })
+                            .collect();
+                        json_output::print_json(&items);
+                    } else {
+                        println!("Available Agents:\n");
+                        for agent in &defs {
+                            let status = if agent.enabled { "enabled" } else { "disabled" };
+                            println!(
+                                "  {} ({}) - {} [{}]",
+                                agent.name, agent.binary, agent.description, status
+                            );
+                        }
                     }
                     Ok(())
                 }
@@ -711,23 +738,38 @@ pub fn run() -> io::Result<()> {
                         )
                     })?;
 
-                    if let Some(def) = manager.get_agent(agent_type) {
-                        println!("Agent: {}", def.name);
-                        println!("Binary: {}", def.binary);
-                        println!("Description: {}", def.description);
-                        if let Some(repo) = &def.github_repo {
-                            println!("GitHub: https://github.com/{}", repo);
-                        }
-                        if let Some(npm) = &def.npm_package {
-                            println!("NPM: {}", npm);
-                        }
-                        println!("Enabled: {}", def.enabled);
-
-                        // Get installed version
-                        if let Ok(Some(v)) = manager.get_installed_version(agent_type) {
-                            println!("Installed: v{}", v);
+                    // Clone to release the immutable borrow before calling
+                    // get_installed_version which takes &mut self.
+                    if let Some(def) = manager.get_agent(agent_type).cloned() {
+                        let installed = manager.get_installed_version(agent_type).ok().flatten();
+                        if json {
+                            let info = json_output::AgentInfoOutput {
+                                agent_type: format!("{:?}", def.agent_type).to_lowercase(),
+                                name: def.name.clone(),
+                                binary: def.binary.clone(),
+                                description: def.description.clone(),
+                                github_repo: def.github_repo.clone(),
+                                npm_package: def.npm_package.clone(),
+                                enabled: def.enabled,
+                                installed_version: installed,
+                            };
+                            json_output::print_json(&info);
                         } else {
-                            println!("Installed: not found");
+                            println!("Agent: {}", def.name);
+                            println!("Binary: {}", def.binary);
+                            println!("Description: {}", def.description);
+                            if let Some(repo) = &def.github_repo {
+                                println!("GitHub: https://github.com/{}", repo);
+                            }
+                            if let Some(npm) = &def.npm_package {
+                                println!("NPM: {}", npm);
+                            }
+                            println!("Enabled: {}", def.enabled);
+                            if let Some(v) = installed {
+                                println!("Installed: v{}", v);
+                            } else {
+                                println!("Installed: not found");
+                            }
                         }
                     }
                     Ok(())

--- a/src/pixel_art.rs
+++ b/src/pixel_art.rs
@@ -643,11 +643,14 @@ fn parse_ansi_line_to_spans_gradient(
 /// Extract raw RGB colors from an ANSI sequence without transforming them.
 /// Returns (fg, bg) as Option<(u8,u8,u8)>.
 #[cfg(feature = "tui")]
+type OptRgb = Option<(u8, u8, u8)>;
+
+#[cfg(feature = "tui")]
 fn parse_gradient_sequence_colors(
     seq: &str,
-    mut fg: Option<(u8, u8, u8)>,
-    mut bg: Option<(u8, u8, u8)>,
-) -> (Option<(u8, u8, u8)>, Option<(u8, u8, u8)>) {
+    mut fg: OptRgb,
+    mut bg: OptRgb,
+) -> (OptRgb, OptRgb) {
     let parts: Vec<&str> = seq.split(';').collect();
     let mut i = 0;
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3231,7 +3231,7 @@ impl App {
         let agent_name = self.npm_dialog_pending
             .as_ref()
             .map(|(a, _)| a.display_name())
-            .unwrap_or_else(|| "this agent".into());
+            .unwrap_or("this agent");
 
         let lines = vec![
             Line::default(),

--- a/tests/test-headless.sh
+++ b/tests/test-headless.sh
@@ -8,6 +8,10 @@
 
 set -euo pipefail
 
+# Isolate from the unleash wrapper environment so subcommand routing tests
+# behave the same whether run inside or outside an unleash session.
+unset AGENT_UNLEASH AGENT_CMD 2>/dev/null || true
+
 # Find binary - prefer fast profile, then release, then debug
 if [[ -n "${AU_BIN:-}" ]]; then
     BIN="$AU_BIN"
@@ -205,6 +209,30 @@ if run_headless "$BIN" invalid-subcommand; then
     fail "invalid subcommand" "should exit non-zero"
 else
     pass "invalid subcommand exits non-zero"
+fi
+
+# ─── 16. unleash agents info --json ─────────────────────────────
+echo "[16] unleash agents info claude --json"
+if run_headless "$BIN" agents info claude --json; then
+    if echo "$OUT" | python3 -c "import json,sys; d=json.load(sys.stdin); exit(0 if 'agent_type' in d else 1)" 2>/dev/null; then
+        pass "agents info claude --json produces valid JSON with agent_type"
+    else
+        fail "agents info claude --json" "missing agent_type field: $OUT"
+    fi
+else
+    fail "agents info claude --json" "non-zero exit code"
+fi
+
+# ─── 17. unleash agents list --json ─────────────────────────────
+echo "[17] unleash agents list --json"
+if run_headless "$BIN" agents list --json; then
+    if echo "$OUT" | python3 -c "import json,sys; items=json.load(sys.stdin); exit(0 if isinstance(items, list) and len(items) > 0 else 1)" 2>/dev/null; then
+        pass "agents list --json produces valid JSON array"
+    else
+        fail "agents list --json" "not a non-empty JSON array: $OUT"
+    fi
+else
+    fail "agents list --json" "non-zero exit code"
 fi
 
 # ─── Cleanup ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `unleash agents info <agent> --json` and `unleash agents list --json` always printed a human-readable format, ignoring the global `--json` flag.
- Add `AgentInfoOutput` struct with fields: `agent_type`, `name`, `binary`, `description`, `github_repo`, `npm_package`, `enabled`, `installed_version`.
- `agents info <agent> --json` → single JSON object; `agents list --json` → JSON array.
- Fix borrow-checker issue: clone `AgentDefinition` before calling `get_installed_version` (which takes `&mut self`).
- Update `--json` flag docstring to enumerate all supported subcommands.
- Add headless tests for the new JSON paths; isolate tests from wrapper env vars.
- Fix two pre-existing clippy warnings.

## Test plan

- [ ] `cargo test` — 287 tests pass
- [ ] `cargo clippy` — zero warnings
- [ ] `bash tests/test-headless.sh` — 17/17 pass
- [ ] `unleash agents info claude --json` — valid JSON with `agent_type`, `installed_version`, etc.
- [ ] `unleash agents info gemini --json` — works for other agents
- [ ] `unleash agents list --json` — valid JSON array with all agents
- [ ] `unleash agents info claude` (no `--json`) — still prints human-readable format

🤖 Generated with [Claude Code](https://claude.com/claude-code)