### PR TITLE
fix: add missing subcommands to RESERVED_NAMES

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -409,6 +409,7 @@ impl ProfileManager {
     /// Names reserved for unleash subcommands — cannot be used as profile names
     const RESERVED_NAMES: &[&str] = &[
         "version", "auth", "auth-check", "hooks", "agents", "update", "help",
+        "install", "uninstall", "sessions", "convert",
         "config", "plugins",
     ];
 
@@ -827,6 +828,34 @@ theme = "#ffff00"
 
         assert_eq!(profile1.agent_cli_path, profile2.agent_cli_path);
         assert_eq!(profile1.theme, profile2.theme);
+    }
+
+    #[test]
+    fn test_reserved_names_block_save() {
+        let (manager, _temp) = test_manager();
+
+        // Actual subcommands must be blocked
+        for name in &["version", "auth", "auth-check", "hooks", "agents", "update",
+                      "install", "uninstall", "sessions", "convert", "help"] {
+            let profile = Profile::new(name);
+            assert!(
+                manager.save_profile(&profile).is_err(),
+                "Expected save to fail for reserved name '{name}'"
+            );
+        }
+
+        // Future-reserved names
+        for name in &["config", "plugins"] {
+            let profile = Profile::new(name);
+            assert!(
+                manager.save_profile(&profile).is_err(),
+                "Expected save to fail for reserved name '{name}'"
+            );
+        }
+
+        // Normal names should succeed
+        let profile = Profile::new("my-workflow");
+        assert!(manager.save_profile(&profile).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `sessions`, `convert`, `install`, and `uninstall` are all real clap subcommands, but they were missing from `RESERVED_NAMES` in `ProfileManager`
- This means a user could name a profile `sessions` (save succeeds), but `unleash sessions` would always invoke the sessions subcommand — the profile would be silently unreachable
- Added all four missing names to `RESERVED_NAMES` alongside the existing entries
- Added a regression test that asserts every known subcommand name is blocked by `save_profile`

## Repro

```bash
# Before this fix, this would succeed:
unleash profile create sessions
# And then 'unleash sessions' would list sessions, never running the profile
```

## Test plan

- [ ] `cargo test test_reserved_names_block_save` passes
- [ ] Full `cargo test` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)