### PR TITLE
perf: avoid reading Gemini input file twice in convert_command

### DIFF
--- a/src/interchange/mod.rs
+++ b/src/interchange/mod.rs
@@ -110,8 +110,7 @@ pub fn convert_command(
             codex::to_hub(reader)?
         }
         "gemini" | "gemini-cli" => {
-            let data = std::fs::read(input)?;
-            gemini::to_hub(&data)?
+            gemini::to_hub(input_data.as_bytes())?
         }
         "opencode" => {
             let messages: Vec<serde_json::Value> = serde_json::from_str(&input_data)?;


### PR DESCRIPTION
## Summary

`convert_command` reads the input file into `input_data` via `read_to_string` on the first line of the function. The Gemini branch then called `std::fs::read(input)` again for the same file to get `&[u8]`.

This PR replaces the second file read with `input_data.as_bytes()`, which is already in memory.

## Test plan

- [ ] `cargo test` passes
- [ ] Manual: `unleash convert --from gemini session.db` still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)