### PR TITLE
fix: detect and abort infinite recursion when agent_cli_path = "unleash"

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -193,7 +193,31 @@ pub fn run(auto_mode: bool, prompt: Option<String>, extra_args: Vec<String>) -> 
 fn find_agent_command() -> io::Result<PathBuf> {
     // Check AGENT_CMD environment variable
     if let Ok(cmd) = env::var("AGENT_CMD") {
-        return Ok(PathBuf::from(cmd));
+        let cmd_path = PathBuf::from(&cmd);
+
+        // Guard against recursive invocation: if AGENT_CMD resolves to the current
+        // executable, a profile has agent_cli_path = "unleash" (the default for
+        // Profile::new). Running unleash-as-agent would loop forever. Detect this
+        // by comparing canonicalized paths and fail with a helpful error.
+        if let Ok(current_exe) = std::env::current_exe() {
+            let resolved_cmd = which::which(&cmd).unwrap_or_else(|_| cmd_path.clone());
+            let canon_cmd = resolved_cmd.canonicalize().unwrap_or(resolved_cmd);
+            let canon_exe = current_exe.canonicalize().unwrap_or(current_exe);
+            if canon_cmd == canon_exe {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "AGENT_CMD is set to '{}' which resolves to the unleash binary itself.\n\
+                         This would cause infinite recursion.\n\
+                         Set agent_cli_path in your profile to the actual agent binary \
+                         (e.g. 'claude', 'codex', 'gemini', 'opencode').",
+                        cmd
+                    ),
+                ));
+            }
+        }
+
+        return Ok(cmd_path);
     }
 
     // Default to 'claude' in PATH


### PR DESCRIPTION
## Summary

`Profile::new()` and `Profile::default()` set `agent_cli_path = "unleash"` (the intent is TUI context, where the TUI sets `AGENT_CMD` to the real binary before spawning). When such a profile is run from the CLI:

1. `run_agent_with_polyfill` sets `AGENT_CMD = "unleash"` and calls `launcher::run()`
2. The launcher spawns `unleash <polyfill-args>` with `AGENT_UNLEASH=1 AGENT_CMD=unleash`
3. The child `unleash` sees `is_wrapper_reentry = true`, calls `launcher::run()` again
4. Which reads `AGENT_CMD = "unleash"` and spawns itself again → **infinite loop**

## Fix

In `find_agent_command()`, canonicalize both the resolved `AGENT_CMD` path and `current_exe()`. If they point to the same binary, return an error with a clear message pointing the user to set `agent_cli_path` to the actual agent binary.

## Repro

```toml
# ~/.config/unleash/profiles/myprofile.toml
name = "myprofile"
agent_cli_path = "unleash"   # Profile::new() default — triggers the bug
```

```bash
unleash myprofile   # Would loop forever before this fix
```

## Test plan

- [ ] `cargo test` passes
- [ ] `unleash myprofile` with `agent_cli_path = "unleash"` now prints an informative error and exits
- [ ] Normal profiles (`agent_cli_path = "claude"` etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)