### PR TITLE
fix: crossload profile-name stripping handles custom profile names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,7 +380,6 @@ pub fn run() -> io::Result<()> {
             let mut crossload_query = String::new();
             let mut filtered_args = Vec::new();
             let mut skip_next = false;
-            let known_profiles = ["claude", "claude-code", "codex", "gemini", "gemini-cli", "opencode"];
             for (i, arg) in args.iter().enumerate() {
                 if skip_next {
                     skip_next = false;
@@ -395,8 +394,10 @@ pub fn run() -> io::Result<()> {
                     }
                 } else if let Some(val) = arg.strip_prefix("--crossload=") {
                     crossload_query = val.to_string();
-                } else if i == 0 && known_profiles.contains(&arg.as_str()) {
-                    // Skip profile name — it's not a CLI arg
+                } else if i == 0 && !arg.starts_with('-') {
+                    // First positional arg is the profile name — skip it.
+                    // This handles both built-in profiles (claude, codex, …) and
+                    // custom user-defined profiles without a hardcoded allow-list.
                     continue;
                 } else {
                     filtered_args.push(arg.clone());


### PR DESCRIPTION
## Summary

In wrapper reentry mode, the crossload path needed to strip the profile name from args before forwarding to the launcher. It did so with a hardcoded allow-list:

```rust
let known_profiles = ["claude", "claude-code", "codex", "gemini", "gemini-cli", "opencode"];
if i == 0 && known_profiles.contains(&arg.as_str()) {
    continue; // skip profile name
}
```

Custom profiles (`work`, `my-claude`, `client-a`, etc.) are not in this list. Their name would be included in `filtered_args` and forwarded to the agent as an unexpected positional argument, likely causing an error or wrong behavior.

## Fix

Replace the hardcoded allow-list with a general rule: the first positional argument (index 0, not starting with `-`) is the profile name and should be skipped.

```rust
} else if i == 0 && !arg.starts_with('-') {
    // First positional arg is the profile name — skip it.
    continue;
}
```

Flag-first invocations like `unleash -x codex:session` (no profile prefix) continue to work correctly because `-x` starts with `-` and won't be stripped.

## Test plan

- [ ] `cargo test` passes
- [ ] Custom profile with crossload works: `unleash my-profile -x codex:session`
- [ ] Built-in profiles still work: `unleash claude -x codex:session`
- [ ] Flag-first invocation works: `unleash -x codex:session`

🤖 Generated with [Claude Code](https://claude.com/claude-code)