### PR TITLE
docs: fix env var classification and plugins table rendering

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -10,6 +10,8 @@ These can be set before launching `unleash` to change behavior.
 | `AU_HYPRLAND_FOCUS` | Hyprland window transparency during agent work | `1` (on) |
 | `HOOK_NO_SOUND` | Suppress notification sounds from hooks | unset |
 | `EDITOR` / `VISUAL` | Editor for TUI text input fields | system default |
+| `AGENT_UNLEASH_ROOT` | Path to the unleash installation directory (read by plugins and hooks) | unset |
+| `CODEX_HOME` | Override Codex home directory (used to locate Codex sessions and history) | `~/.codex` |
 
 ### Examples
 
@@ -38,12 +40,10 @@ runtime environment.
 | `AGENT_CMD` | Which agent binary is running (`claude`, `codex`, `gemini`, `opencode`) |
 | `AGENT_UNLEASH` | Set to `1` when running under the unleash wrapper |
 | `AGENT_WRAPPER_PID` | PID of the wrapper process (used by plugins and Hyprland focus) |
-| `AGENT_UNLEASH_ROOT` | Path to the unleash installation directory |
 | `UNLEASH_POLYFILL_ACTIVE` | Set to `1` when polyfill flag translation is active |
 | `BASH_DEFAULT_TIMEOUT_MS` | Default bash timeout for agent tools (set to `999999999` ~11.5 days) |
 | `BASH_MAX_TIMEOUT_MS` | Max bash timeout (set to `999999999`) |
 | `MCP_TOOL_TIMEOUT` | MCP tool timeout (set to `999999999`) |
-| `CODEX_HOME` | Override Codex home directory (read from environment if already set) |
 
 ### Timeout Variables
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -10,7 +10,6 @@ when launching an agent.
 | **auto-mode** | Autonomous operation -- agent keeps working without user prompts | `--auto` / `-a` flag, or `defaults.auto = true` in profile |
 | **process-restart** | Restart agent while preserving session state | `unleash-refresh` command |
 | **mcp-refresh** | Detect MCP config changes and notify for reload | Automatic via PreToolUse hook |
-
 | **hyprland-focus** | Window transparency while agent works (Hyprland only) | `AU_HYPRLAND_FOCUS=0` to disable |
 | **omnihook** | Unified hook handler with voice input integration and FIFO wakeup | Automatic |
 


### PR DESCRIPTION
## Summary

- Moves `AGENT_UNLEASH_ROOT` and `CODEX_HOME` from the "Set by Unleash" section to the "User-Controllable" section in `docs/environment-variables.md`. These variables are only **read** by unleash (users must set them before launching); unleash does not set them itself. The previous placement was misleading.
- Removes a spurious blank line splitting the Plugin Index table in `docs/plugins.md`. The blank row caused the last two table entries (`hyprland-focus`, `omnihook`) to render as plain text instead of table rows in CommonMark-compliant renderers.

## Test plan

- [ ] Render `docs/environment-variables.md` and verify `AGENT_UNLEASH_ROOT` / `CODEX_HOME` appear under User-Controllable
- [ ] Render `docs/plugins.md` and verify all 5 plugins appear in the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)