### PR TITLE
fix: update OpenCode GitHub repo from anomalyco to sst

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -288,7 +288,7 @@ impl AgentDefinition {
                 model_flag: "-m".to_string(),
                 effort_flag: None,
             },
-            github_repo: Some("anomalyco/opencode".to_string()),
+            github_repo: Some("sst/opencode".to_string()),
             npm_package: Some("opencode-ai".to_string()),
             enabled: true,
         }


### PR DESCRIPTION
## Summary

- Updates `github_repo` in `AgentDefinition::opencode()` from `"anomalyco/opencode"` to `"sst/opencode"`

The `anomalyco` GitHub organization was renamed to `sst`. The canonical URL is now `github.com/sst/opencode`.

**Impact**: The `get_latest_github_version` function builds a GitHub API URL from this field and calls it with `curl -s` (no `-L` redirect-following flag). With the stale `anomalyco/opencode` slug, the API returns a 301 whose body fails JSON parsing, silently returning `None` for the latest version. This means `unleash update opencode` could not detect available updates via GitHub. (In practice, the npm path via `opencode-ai` is tried first and succeeds, but the GitHub fallback was broken.)

## Test plan

- [ ] `unleash update opencode --check` returns a valid latest version

🤖 Generated with [Claude Code](https://claude.com/claude-code)