### PR TITLE
fix: unleash agents check (no arg) now checks all four agents

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -663,7 +663,7 @@ pub fn run() -> io::Result<()> {
                             )
                         })?]
                     } else {
-                        vec![AgentType::Claude, AgentType::Codex]
+                        AgentType::all().to_vec()
                     };
 
                     for agent_type in agents_to_check {


### PR DESCRIPTION
## Summary

- `unleash agents check` with no positional arg was hard-coded to only check Claude and Codex, silently skipping Gemini and OpenCode.
- Changed the default from `vec![AgentType::Claude, AgentType::Codex]` to `AgentType::all().to_vec()` so all registered agents are checked.

## Repro

```bash
# Before: only prints Claude Code and Codex
unleash agents check

# After: prints Claude Code, Codex, Gemini CLI, OpenCode
unleash agents check
```

## Test plan

- [ ] `unleash agents check` without args outputs status for all four agents
- [ ] `unleash agents check claude` still works (single agent path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)