### PR TITLE
docs: add missing reserved names to profiles.md

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -15,7 +15,7 @@ Unleash creates four default profiles on first run:
 
 Select a profile from the TUI, or edit the TOML files directly.
 
-**Reserved names:** `version`, `auth`, `auth-check`, `hooks`, `agents`, `update`, `help`, `config`, `plugins`.
+**Reserved names:** `version`, `auth`, `auth-check`, `hooks`, `agents`, `install`, `uninstall`, `update`, `sessions`, `convert`, `help`, `config`, `plugins`.
 
 ## Full Example
 


### PR DESCRIPTION
## Summary

The \"Reserved names\" line in `profiles.md` was missing four subcommands that are actually registered in the CLI: `install`, `uninstall`, `sessions`, and `convert`. If a user created a profile with one of these names, the subcommand would be unreachable and the user would get confusing behavior.

This is the companion documentation fix for the code correction in PR #9 (fix/reserved-profile-names).

## Test plan

- [ ] Verify all entries in `RESERVED_NAMES` in `src/config.rs` are listed in `profiles.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)