### PR TITLE
fix: cap month to 12 in chrono_like_now to prevent invalid filenames

### DIFF
--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -591,12 +591,13 @@ fn chrono_like_now() -> String {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    // Rough conversion (good enough for filenames)
+    // Rough conversion (good enough for filenames).
+    // Cap month at 12: remaining_days can be up to 364, and 364/30+1 = 13.
     let days = secs / 86400;
     let years = days / 365;
     let year = 1970 + years;
     let remaining = days - years * 365;
-    let month = remaining / 30 + 1;
+    let month = (remaining / 30 + 1).min(12);
     let day = remaining % 30 + 1;
     let hour = (secs % 86400) / 3600;
     let min = (secs % 3600) / 60;
@@ -716,7 +717,7 @@ mod tests {
         let hour: u32 = ts[11..13].parse().unwrap();
         let min: u32 = ts[14..16].parse().unwrap();
         let sec: u32 = ts[17..19].parse().unwrap();
-        assert!((1..=13).contains(&month), "month out of range: {month}");
+        assert!((1..=12).contains(&month), "month out of range: {month}");
         assert!((1..=31).contains(&day), "day out of range: {day}");
         assert!(hour < 24, "hour out of range: {hour}");
         assert!(min < 60, "min out of range: {min}");


### PR DESCRIPTION
## Summary

`chrono_like_now()` in `inject.rs` has the same integer overflow as `format_epoch_ms` in `sessions.rs` (fixed in PR #18): `remaining_days` can be up to 364, and `364 / 30 + 1 = 13`, producing invalid month numbers.

`chrono_like_now` is used directly in **Codex session file paths** during crossload injection:
```rust
codex_dir.join(format!("rollout-{now}-{session_id}.jsonl"))
```
So this produces filenames like `rollout-2025-13-01T22-30-00-<uuid>.jsonl`, which are confusing and wrong (though valid on Linux filesystems).

Also fixes the test assertion: `(1..=13).contains(&month)` was documenting the bug rather than guarding against it — changed to `(1..=12)`.

## Test plan

- [ ] `cargo test interchange::inject` passes
- [ ] `test_chrono_like_now_valid_ranges` now asserts month ≤ 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)