### PR TITLE
fix: respect CODEX_HOME env var in Codex session discovery and injection

### DIFF
--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -243,11 +243,10 @@ fn inject_into_codex(
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|_| source.directory.clone());
 
-    // Write to Codex sessions directory
+    // Write to Codex sessions directory, respecting CODEX_HOME if set.
     let now = chrono_like_now();
-    let codex_home = dirs::home_dir()
-        .ok_or_else(|| ConvertError::InvalidFormat("No home dir".into()))?
-        .join(".codex");
+    let codex_home = codex_home_dir()
+        .ok_or_else(|| ConvertError::InvalidFormat("No home dir".into()))?;
     let codex_dir = codex_home
         .join("sessions")
         .join(&now[..4])  // year
@@ -550,6 +549,14 @@ fn inject_into_opencode(
 }
 
 // === Helpers ===
+
+/// Return the Codex home directory, respecting the `CODEX_HOME` env var.
+fn codex_home_dir() -> Option<std::path::PathBuf> {
+    if let Some(home) = std::env::var_os("CODEX_HOME") {
+        return Some(std::path::PathBuf::from(home));
+    }
+    dirs::home_dir().map(|h| h.join(".codex"))
+}
 
 fn extract_session_id(records: &[HubRecord]) -> String {
     records.iter().find_map(|r| {

--- a/src/interchange/sessions.rs
+++ b/src/interchange/sessions.rs
@@ -176,10 +176,18 @@ fn read_claude_title(path: &PathBuf) -> Option<String> {
 
 // === Codex discovery ===
 
+/// Return the Codex home directory, respecting the `CODEX_HOME` env var.
+fn codex_home_dir() -> Option<std::path::PathBuf> {
+    if let Some(home) = std::env::var_os("CODEX_HOME") {
+        return Some(std::path::PathBuf::from(home));
+    }
+    dirs::home_dir().map(|h| h.join(".codex"))
+}
+
 fn discover_codex() -> Vec<SessionInfo> {
     let mut sessions = Vec::new();
-    let codex_dir = match dirs::home_dir() {
-        Some(h) => h.join(".codex").join("sessions"),
+    let codex_dir = match codex_home_dir() {
+        Some(h) => h.join("sessions"),
         None => return sessions,
     };
 
@@ -191,10 +199,10 @@ fn discover_codex() -> Vec<SessionInfo> {
     walk_codex_dir(&codex_dir, &mut sessions);
 
     // Also check session_index.jsonl for names
-    let index_path = dirs::home_dir()
-        .unwrap()
-        .join(".codex")
-        .join("session_index.jsonl");
+    let index_path = match codex_home_dir() {
+        Some(h) => h.join("session_index.jsonl"),
+        None => return sessions,
+    };
     if index_path.exists() {
         if let Ok(content) = std::fs::read_to_string(&index_path) {
             for line in content.lines() {


### PR DESCRIPTION
## Summary

`CODEX_HOME` is documented as a user-settable env var to override the Codex home directory, but two places were ignoring it:

1. **`sessions.rs` `discover_codex()`** — hardcoded `~/.codex/sessions` and `~/.codex/session_index.jsonl` → `unleash sessions` would not find sessions when `CODEX_HOME` is set.
2. **`inject.rs` `inject_into_codex()`** — hardcoded `~/.codex` for writing the crossloaded session → the injected session would be written to the wrong location.

**Fix:** Add a `codex_home_dir()` helper in each file that checks `CODEX_HOME` first, falling back to `~/.codex`.

**Bonus:** Replace the `dirs::home_dir().unwrap()` in the `session_index.jsonl` lookup (would panic if the OS reports no home dir) with a safe `Option` chain that returns early instead.

## Test plan

- [ ] `CODEX_HOME=/tmp/codex-test unleash sessions` discovers sessions under `/tmp/codex-test/sessions/`
- [ ] `CODEX_HOME=/tmp/codex-test unleash claude -x codex:session` writes the injected file under `/tmp/codex-test/sessions/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)