### PR TITLE
fix: add UserPromptSubmit and SessionEnd to hooks add error message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -591,7 +591,7 @@ pub fn run() -> io::Result<()> {
                     let hook_event = HookEvent::from_str(&event).ok_or_else(|| {
                         io::Error::new(
                             io::ErrorKind::InvalidInput,
-                            format!("Unknown hook event: {}. Valid events: Stop, PreToolUse, PostToolUse, PreCompact, Notification, SessionStart, SubagentStart, SubagentStop, Setup", event),
+                            format!("Unknown hook event: {}. Valid events: Stop, PreToolUse, PostToolUse, PreCompact, Notification, SessionStart, SubagentStart, SubagentStop, Setup, UserPromptSubmit, SessionEnd", event),
                         )
                     })?;
                     manager.register_hook(hook_event, &command, matcher.as_deref())?;


### PR DESCRIPTION
## Summary

The error message shown by `unleash hooks add <unknown-event>` listed 9 of the 11 valid `HookEvent` variants, missing `UserPromptSubmit` and `SessionEnd`. A user trying to register a hook for these events would see:

```
Unknown hook event: UserPromptSubmit. Valid events: Stop, PreToolUse, PostToolUse, PreCompact, Notification, SessionStart, SubagentStart, SubagentStop, Setup
```

…which incorrectly implies `UserPromptSubmit` is not a valid event. (Both are fully supported by the `HookEvent` enum and `from_str`; only the error hint was stale.)

## Test plan

- [ ] `unleash hooks add UserPromptSubmit "my-cmd"` succeeds (not blocked by error path)
- [ ] `unleash hooks add BogusEvent "my-cmd"` shows the updated list including `UserPromptSubmit` and `SessionEnd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)