### PR TITLE
fix: avoid spawning claude --version twice in show_current_json

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -1708,10 +1708,9 @@ pub fn show_current() -> io::Result<()> {
 pub fn show_current_json() {
     let cu_version = env!("CARGO_PKG_VERSION");
     let vm = VersionManager::new();
-    let claude_code_version = vm
-        .get_installed_version()
-        .unwrap_or_else(|| "not installed".to_string());
-    let is_installed = vm.get_installed_version().is_some();
+    let installed = vm.get_installed_version();
+    let is_installed = installed.is_some();
+    let claude_code_version = installed.unwrap_or_else(|| "not installed".to_string());
 
     let output = VersionOutput {
         unleash_version: cu_version.to_string(),


### PR DESCRIPTION
## Problem

`show_current_json()` in `src/version.rs` called `get_installed_version()` twice in succession, spawning the `claude --version` subprocess twice:

```rust
// Before — two subprocess spawns:
let claude_code_version = vm.get_installed_version()
    .unwrap_or_else(|| "not installed".to_string());
let is_installed = vm.get_installed_version().is_some();  // redundant!
```

The second call was only needed to check `is_some()`, but the `Option` from the first call was already discarded rather than reused.

## Fix

Cache the result of the first call:

```rust
// After — one subprocess spawn:
let installed = vm.get_installed_version();
let is_installed = installed.is_some();
let claude_code_version = installed.unwrap_or_else(|| "not installed".to_string());
```

## Impact

Every `unleash version --json` call previously spawned `claude --version` twice. On systems where `claude` is slow to start (e.g., npm-installed, large nvm setup), this added measurable latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)