### PR TITLE
docs: clarify unleash version manages Claude Code only, add --install

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -75,12 +75,15 @@ unleash update --check      # Dry run, show available updates
 
 ### `unleash version`
 
-Show installed agent versions.
+Manage Claude Code versions (install, list, switch).
 
 ```bash
-unleash version             # Current installed versions
-unleash version --list      # All available versions
+unleash version                   # Show installed Claude Code version
+unleash version --list            # List all available Claude Code versions
+unleash version --install 2.1.87  # Install a specific Claude Code version
 ```
+
+> For all agents' versions at a glance, use `unleash agents status`.
 
 ### `unleash auth`
 


### PR DESCRIPTION
## Problem

The `unleash version` command in `docs/cli-reference.md` had two issues:

1. **Misleading description** — "Show installed agent versions" implies all four agents, but `unleash version` only manages Claude Code versions. (For all agents, `unleash agents status` is the right command.)

2. **Missing `--install` example** — the command supports `--install <version>` to switch Claude Code versions, but this wasn't documented.

## Fix

- Update description to "Manage Claude Code versions (install, list, switch)"
- Add `--install 2.1.87` example
- Add a pointer to `unleash agents status` for multi-agent version info

## Before / After

**Before:**
```
### `unleash version`

Show installed agent versions.

unleash version             # Current installed versions
unleash version --list      # All available versions
```

**After:**
```
### `unleash version`

Manage Claude Code versions (install, list, switch).

unleash version                   # Show installed Claude Code version
unleash version --list            # List all available Claude Code versions
unleash version --install 2.1.87  # Install a specific Claude Code version

> For all agents' versions at a glance, use `unleash agents status`.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)