### PR TITLE
fix: remove stray eprintln in update_codex that corrupts progress display

### DIFF
--- a/src/updater.rs
+++ b/src/updater.rs
@@ -707,7 +707,7 @@ fn update_codex(tx: &mpsc::Sender<(usize, LineState)>, index: usize) -> io::Resu
     let result = manager.update_agent(AgentType::Codex)?;
 
     let version = get_installed_version(AgentType::Codex).unwrap_or_else(|| "latest".into());
-    eprintln!("{}", result);
+    let _ = result; // result is a status string; progress is reported via tx
     Ok(version)
 }
 


### PR DESCRIPTION
## Bug

When running \`unleash update codex\`, a stray \`eprintln!\` in \`update_codex()\`
writes to stderr mid-animation, corrupting the progress display.

## Root cause

All four \`update_*\` functions (Claude, Codex, Gemini, OpenCode) report progress
through the mpsc \`tx\` channel so \`ProgressRenderer\` can draw animated lines
in-place using ANSI cursor-up sequences. Only \`update_codex\` had an additional
\`eprintln!(\"{}\", result)\` after the update completed:

```rust
let version = get_installed_version(AgentType::Codex).unwrap_or_else(|| "latest".into());
eprintln!("{}", result);  // ← writes mid-animation, garbles terminal
Ok(version)
```

This writes to stderr while the renderer is still managing the cursor position,
causing visual corruption on any terminal. This is clearly a leftover debug
\`eprintln!\` — no other update function does this.

## Fix

Remove the \`eprintln!\`. Progress is already reported via the \`tx\` channel.

## Test plan

- [ ] Run \`unleash update codex\` and verify the progress animation renders cleanly
- [ ] Verify no spurious output appears on stderr during the Codex update

🤖 Generated with [Claude Code](https://claude.com/claude-code)