### PR TITLE
fix: use npm_global_command() in update_claude() for consistent sudo handling

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -542,7 +542,7 @@ impl AgentManager {
 
     /// Update Claude Code via npm
     fn update_claude(&self) -> io::Result<String> {
-        let output = Command::new("npm")
+        let output = crate::version::VersionManager::npm_global_command()
             .args(["install", "-g", "@anthropic-ai/claude-code@latest"])
             .output()?;
 


### PR DESCRIPTION
## Summary

- `update_claude()` in `src/agents.rs` was calling `Command::new("npm")` directly
- Every other npm-based update path (`update_npm_agent()` for Gemini/OpenCode, and all of `version.rs`) goes through `VersionManager::npm_global_command()`
- `npm_global_command()` prepends `sudo -n` when the npm global prefix is root-owned (e.g. system npm installs)

## Impact

On systems with a root-owned npm global prefix, `unleash update claude` would fail with a permissions error while `unleash update gemini` and `unleash update opencode` would succeed — a confusing asymmetry with no visible explanation.

## Fix

One-line change: replace `Command::new("npm")` with `crate::version::VersionManager::npm_global_command()` in `update_claude()`, making it consistent with all other npm update paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)