### PR TITLE
fix: remove stray eprintln! calls in install_codex_binary() that corrupt progress display

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -633,7 +633,6 @@ impl AgentManager {
         fs::create_dir_all(&tmp_dir)?;
         let tmp_archive = tmp_dir.join(&asset_name);
 
-        eprintln!("Downloading Codex {} ({})...", version, asset_name);
         let dl_output = Command::new("curl")
             .args(["-fsSL", "-o", &tmp_archive.to_string_lossy(), &download_url])
             .output()?;
@@ -646,7 +645,6 @@ impl AgentManager {
         }
 
         // Extract — codex binary is at the root of the tar.gz
-        eprintln!("Extracting...");
         let extract_output = Command::new("tar")
             .args(["xzf", &tmp_archive.to_string_lossy(), "-C", &tmp_dir.to_string_lossy()])
             .output()?;


### PR DESCRIPTION
## Summary

- `install_codex_binary()` in `src/agents.rs` had two bare `eprintln!` calls that fire during the parallel update animation
- Same class of bug as #27 (stray `eprintln!` in `updater.rs::update_codex`)

## Call chain

```
updater.rs::update_codex()          ← runs in a background thread
  → AgentManager::update_agent()
    → AgentManager::update_codex()
      → AgentManager::install_codex_binary()
          eprintln!("Downloading Codex {} ({})...", ...)  ← corrupts terminal
          ...
          eprintln!("Extracting...")                       ← corrupts terminal
```

## Fix

Remove both `eprintln!` calls. Progress during the install is already communicated via the `mpsc` tx channel used by the animated progress display — these prints have no effect other than corrupting the terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)