### PR TITLE
fix: update stale default model in restart-handler.sh to claude-sonnet-4-6

### DIFF
--- a/plugins/bundled/process-restart/hooks-handlers/restart-handler.sh
+++ b/plugins/bundled/process-restart/hooks-handlers/restart-handler.sh
@@ -49,7 +49,7 @@ if [[ -z "${SESSION_ID}" ]]; then
 fi
 
 # Get current model from environment or use default
-MODEL="${CLAUDE_MODEL:-claude-sonnet-4-5}"
+MODEL="${CLAUDE_MODEL:-claude-sonnet-4-6}"
 
 # Get git branch if in a git repository
 GIT_BRANCH=""


### PR DESCRIPTION
## Summary

- `restart-handler.sh` had a hardcoded fallback `MODEL="${CLAUDE_MODEL:-claude-sonnet-4-5}"` that is used when `CLAUDE_MODEL` isn't set in the environment
- `claude-sonnet-4-5` is an outdated model; the current default is `claude-sonnet-4-6`
- This value is written to `restart-state.json` and displayed by `session-restore.sh` in the restoration message after a restart, so it should reflect the actual current model

## Fix

Update the hardcoded fallback from `claude-sonnet-4-5` to `claude-sonnet-4-6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)