### PR TITLE
fix: use npm_global_command() in install_version fallback paths

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -638,7 +638,7 @@ impl VersionManager {
 
         // Fallback: try npm
         if Self::has_npm() {
-            let output = Command::new("npm")
+            let output = Self::npm_global_command()
                 .args([
                     "install",
                     "-g",
@@ -1142,13 +1142,15 @@ impl VersionManager {
         // Fallback: try npm
         if Self::has_npm() {
             let _ = log_tx.send("Native install failed, trying npm fallback...".to_string());
+            let use_sudo = Self::npm_global_needs_sudo();
             let _ = log_tx.send(format!(
-                "Running: npm install -g @anthropic-ai/claude-code@{}",
+                "Running: {}npm install -g @anthropic-ai/claude-code@{}",
+                if use_sudo { "sudo " } else { "" },
                 version
             ));
 
             let (ok, stdout, stderr) = Self::run_streaming(
-                Command::new("npm").args([
+                Self::npm_global_command().args([
                     "install",
                     "-g",
                     "--force",


### PR DESCRIPTION
## Summary

- `install_version()` used bare `Command::new("npm")` for the Claude Code npm fallback install, bypassing the `sudo -n` wrapper
- `install_version_streaming()` had the same issue, plus a log message that didn't reflect the actual command being run
- Both now use `Self::npm_global_command()` (and `Self::npm_global_needs_sudo()` for the log message) to match the pattern used by `update_claude()` (fixed in #28)

## Root Cause

`VersionManager::npm_global_command()` prepends `sudo -n` when the npm global prefix is root-owned. Without it, `npm install -g` fails with a permission error on systems where `/usr/local/lib/node_modules` is owned by root.

## Test plan

- [ ] `cargo build` passes (verified)
- [ ] `cargo test --lib` passes — 287 tests, 0 failures (verified)
- [ ] Manual: on a system with root-owned npm prefix, `unleash version install` should succeed without permission error

🤖 Generated with [Claude Code](https://claude.com/claude-code)