### PR TITLE
fix: remove stray eprintln! in update_codex and use npm_global_command for uninstall

### DIFF
--- a/src/updater.rs
+++ b/src/updater.rs
@@ -569,7 +569,7 @@ fn uninstall_agent(agent_type: AgentType) -> io::Result<()> {
 
     // Try npm uninstall first for agents with npm packages
     if let Some(ref package) = def.npm_package {
-        if let Ok(output) = Command::new("npm")
+        if let Ok(output) = crate::version::VersionManager::npm_global_command()
             .args(["uninstall", "-g", package])
             .output()
         {
@@ -704,10 +704,9 @@ fn update_codex(tx: &mpsc::Sender<(usize, LineState)>, index: usize) -> io::Resu
     ));
 
     let mut manager = crate::agents::AgentManager::new()?;
-    let result = manager.update_agent(AgentType::Codex)?;
+    manager.update_agent(AgentType::Codex)?;
 
     let version = get_installed_version(AgentType::Codex).unwrap_or_else(|| "latest".into());
-    eprintln!("{}", result);
     Ok(version)
 }
 


### PR DESCRIPTION
## Summary

Two bugs found in `src/updater.rs`:

- **Stray `eprintln!` in `update_codex()`**: A debug line `eprintln!("{}", result)` was left in the update_codex worker thread. Since update_codex runs in a background thread during the parallel update animation, this eprintln fires mid-render and corrupts the terminal progress display. Same pattern as #27/#29.

- **Bare `Command::new("npm")` in `uninstall_agent()`**: The npm uninstall path used `Command::new("npm")` directly instead of `VersionManager::npm_global_command()`, bypassing the `sudo -n` wrapper needed when the npm global prefix is root-owned. This causes permission errors on those systems. Same pattern as #28/#33.

## Test plan

- [ ] `cargo build` passes — no warnings (verified)
- [ ] `cargo test --lib` passes — 287 tests, 0 failures (verified)
- [ ] Manual: `unleash update codex` should show clean progress animation without garbled output
- [ ] Manual: on root-owned npm prefix, `unleash uninstall gemini` should succeed without permission error

🤖 Generated with [Claude Code](https://claude.com/claude-code)