### PR TITLE
fix: parse_wrapper_launch_args does not consume flag as -p/--prompt value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,10 @@ fn parse_wrapper_launch_args(
         if parse_prompt_flags {
             if arg == "-p" || arg == "--prompt" {
                 if prompt.is_none() {
-                    prompt = args.get(i + 1).cloned();
+                    prompt = args.get(i + 1).filter(|v| !v.starts_with('-')).cloned();
                 }
-                i += if i + 1 < args.len() { 2 } else { 1 };
+                let has_value = args.get(i + 1).filter(|v| !v.starts_with('-')).is_some();
+                i += if has_value { 2 } else { 1 };
                 continue;
             }
             if let Some(value) = arg.strip_prefix("--prompt=") {
@@ -943,6 +944,25 @@ mod tests {
         assert!(!is_wrapper_command("unleashed"));
         assert!(!is_wrapper_command("u"));
         assert!(!is_wrapper_command("claude"));
+    }
+
+    #[test]
+    fn test_parse_wrapper_prompt_does_not_consume_flag_as_value() {
+        // Regression: `-p --continue` must not treat `--continue` as the prompt value.
+        // `-p` is consumed (it's a value-flag pair with no valid value), `--continue` passes through.
+        let args = vec!["-p".to_string(), "--continue".to_string()];
+        let (_, prompt, pass_args) = parse_wrapper_launch_args(args, true);
+        assert_eq!(prompt, None);
+        assert_eq!(pass_args, vec!["--continue".to_string()]);
+    }
+
+    #[test]
+    fn test_parse_wrapper_prompt_equals_with_flag_value() {
+        // `--prompt=fix it --continue` must preserve --continue as a pass arg
+        let args = vec!["--prompt=fix it".to_string(), "--continue".to_string()];
+        let (_, prompt, pass_args) = parse_wrapper_launch_args(args, true);
+        assert_eq!(prompt.as_deref(), Some("fix it"));
+        assert_eq!(pass_args, vec!["--continue".to_string()]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Same greedy flag-value consumption bug as fixed in `parse_from_raw()` (PR #30), but in the wrapper reentry path (`parse_wrapper_launch_args` in `src/lib.rs`).

**Before:** `unleash claude -p --continue` in wrapper reentry mode would set `prompt = Some("--continue")`, treating the flag as the prompt text and losing `--continue` entirely.

**After:** `-p`/`--prompt` only consume the next arg as a value when it doesn't start with `-`. If the following arg is a flag, `-p` is consumed without setting a prompt value, and the flag passes through to `pass_args`.

The `--prompt=value` form is unaffected (value is embedded in the arg, not consumed from the next position).

## Root cause

`parse_wrapper_launch_args()` is the mirror of `parse_from_raw()` for the wrapper reentry code path (when `AGENT_UNLEASH=1` and `AGENT_CMD` are set). Both had the same bug; #30 fixed `parse_from_raw`, this PR fixes `parse_wrapper_launch_args`.

## Test plan

- [ ] Two new regression tests pass (verified: `cargo test --lib`, 289 passed)
- [ ] `unleash claude -p --continue` in wrapper reentry should not treat `--continue` as the prompt value

🤖 Generated with [Claude Code](https://claude.com/claude-code)