### PR TITLE
fix: three bugs in interchange/sessions.rs

### DIFF
--- a/src/interchange/sessions.rs
+++ b/src/interchange/sessions.rs
@@ -191,10 +191,10 @@ fn discover_codex() -> Vec<SessionInfo> {
     walk_codex_dir(&codex_dir, &mut sessions);
 
     // Also check session_index.jsonl for names
-    let index_path = dirs::home_dir()
-        .unwrap()
-        .join(".codex")
-        .join("session_index.jsonl");
+    let Some(home) = dirs::home_dir() else {
+        return sessions;
+    };
+    let index_path = home.join(".codex").join("session_index.jsonl");
     if index_path.exists() {
         if let Ok(content) = std::fs::read_to_string(&index_path) {
             for line in content.lines() {
@@ -419,9 +419,10 @@ fn format_epoch_ms(ms: u64) -> String {
     let days = hours / 24;
     let years = days / 365;
     let year = 1970 + years;
-    // Simple ISO approximation (good enough for sorting)
+    // Simple ISO approximation (good enough for sorting).
+    // Clamp month to 1-12: remaining_days can reach 364, giving month=13 without the clamp.
     let remaining_days = days - years * 365;
-    let month = remaining_days / 30 + 1;
+    let month = (remaining_days / 30 + 1).min(12);
     let day = remaining_days % 30 + 1;
     format!("{year:04}-{month:02}-{day:02}T00:00:00Z")
 }
@@ -443,13 +444,28 @@ mod tests {
     fn test_discover_all_doesnt_crash() {
         // Should not panic even if CLI dirs don't exist
         let sessions = discover_all();
-        // We can't assert count since it depends on the machine
-        assert!(sessions.len() >= 0);
+        // We can't assert count since it depends on the machine; just verify no panic.
+        let _ = sessions.len();
     }
 
     #[test]
     fn test_format_epoch_ms() {
         let ts = format_epoch_ms(1774800000000);
         assert!(ts.starts_with("2026-"));
+    }
+
+    #[test]
+    fn test_format_epoch_ms_no_month_13() {
+        // Regression: remaining_days >= 360 used to produce month=13.
+        // Test timestamps near Dec 26-31 of several years.
+        // Exact day 360 of 1970 = 1970-12-27 ~ 31104000000 ms
+        let ts = format_epoch_ms(31_104_000_000);
+        let month: u32 = ts[5..7].parse().unwrap();
+        assert!(month >= 1 && month <= 12, "month={} out of range in '{}'", month, ts);
+
+        // Also verify a timestamp at end of a later year
+        let ts2 = format_epoch_ms(1_735_603_200_000); // ~2024-12-31
+        let month2: u32 = ts2[5..7].parse().unwrap();
+        assert!(month2 >= 1 && month2 <= 12, "month={} out of range in '{}'", month2, ts2);
     }
 }


### PR DESCRIPTION
## Summary

Three bugs fixed in `src/interchange/sessions.rs`:

### 1. `discover_codex()` panic when HOME is unset

The function guards against `dirs::home_dir()` returning `None` at the top (line 181), but then calls `.unwrap()` unconditionally on line 194-196 when looking for the session index file. On systems where `HOME` is unset, this panics instead of returning the partial sessions list safely.

**Fix:** Use `let Some(home) = dirs::home_dir() else { return sessions; }`.

### 2. `format_epoch_ms()` generates invalid month 13

The function uses a 30-day-month approximation. When `remaining_days >= 360` (approximately late December), `remaining_days / 30 + 1` equals 13, producing invalid ISO dates like `"2026-13-01"`. Since sessions are sorted lexicographically by `updated_at`, month=13 strings incorrectly sort after valid dates and corrupt the session list order.

**Fix:** Clamp month to 12 with `.min(12)`.

### 3. Tautological assertion triggers compiler warning

`assert!(sessions.len() >= 0)` is always true for `usize` and triggers `#[warn(unused_comparisons)]`. The test intent is just "doesn't panic".

**Fix:** Replace with `let _ = sessions.len()`.

## Test plan

- [ ] `cargo build` — no warnings (verified: fixed unused_comparisons warning)
- [ ] `cargo test --lib` — 288 passed, 0 failed (verified)
- [ ] New regression test `test_format_epoch_ms_no_month_13` verifies month is 1-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)