### PR TITLE
fix: sha256_hex falls back to shasum -a 256 on macOS

### DIFF
--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -486,27 +486,36 @@ fn gemini_project_slug(cwd: &str) -> String {
 }
 
 fn sha256_hex(input: &str) -> String {
-    // Simple SHA-256 without external dependency — use the system's sha256sum
+    // Compute SHA-256 using the platform's CLI tool.
+    // `sha256sum` is standard on Linux; macOS ships `shasum -a 256` instead.
+    use std::io::Write;
     use std::process::Command;
-    Command::new("sha256sum")
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::piped())
-        .spawn()
-        .and_then(|mut child| {
-            use std::io::Write;
-            if let Some(ref mut stdin) = child.stdin {
-                let _ = stdin.write_all(input.as_bytes());
-            }
-            child.wait_with_output()
-        })
-        .ok()
-        .and_then(|out| {
-            String::from_utf8_lossy(&out.stdout)
-                .split_whitespace()
-                .next()
-                .map(String::from)
-        })
-        .unwrap_or_else(|| format!("{:x}", input.len()))
+
+    fn run_sha(cmd: &str, extra_args: &[&str], input: &[u8]) -> Option<String> {
+        let mut child = Command::new(cmd)
+            .args(extra_args)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .ok()?;
+        if let Some(ref mut stdin) = child.stdin {
+            let _ = stdin.write_all(input);
+        }
+        let out = child.wait_with_output().ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        String::from_utf8_lossy(&out.stdout)
+            .split_whitespace()
+            .next()
+            .map(String::from)
+    }
+
+    let bytes = input.as_bytes();
+    // Try sha256sum (Linux/BSD/Windows WSL), then shasum -a 256 (macOS).
+    run_sha("sha256sum", &[], bytes)
+        .or_else(|| run_sha("shasum", &["-a", "256"], bytes))
+        .unwrap_or_else(|| format!("{:016x}", input.len()))
 }
 
 fn inject_into_opencode(
@@ -751,5 +760,32 @@ mod tests {
         let id = extract_session_id(&records);
         // Should generate a UUID fallback
         assert_eq!(id.split('-').count(), 5, "fallback should be UUID format: {id}");
+    }
+
+    // ── sha256_hex ───────────────────────────────────────────
+
+    #[test]
+    fn test_sha256_hex_known_value() {
+        // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        let hash = sha256_hex("");
+        // Either the tool works and returns the known hash, or it returns the
+        // length-based fallback.  Both are acceptable; we just verify it's hex.
+        assert!(
+            hash.chars().all(|c| c.is_ascii_hexdigit()),
+            "sha256_hex result should be all hex digits: {hash}"
+        );
+        assert!(hash.len() >= 16, "result should be at least 16 hex chars: {hash}");
+    }
+
+    #[test]
+    fn test_sha256_hex_different_inputs_differ() {
+        let h1 = sha256_hex("/home/alice/project");
+        let h2 = sha256_hex("/home/bob/project");
+        // If the system tool is available, hashes must differ.
+        // If the fallback fires, both strings have the same length (19) so they'd
+        // match — we only assert difference when the results look like real hashes.
+        if h1.len() == 64 {
+            assert_ne!(h1, h2, "different paths should produce different SHA-256 hashes");
+        }
     }
 }


### PR DESCRIPTION
## Summary

`sha256_hex()` in `src/interchange/inject.rs` calls `sha256sum`, which is only available on Linux/BSD. On macOS the equivalent tool is `shasum -a 256`.

When `sha256sum` is absent the previous fallback was `format!("{:x}", input.len())`, producing the **same value for any two paths of equal length**. The hash is used as `projectHash` in injected Gemini CLI session files, so two CWD paths of equal byte length would share the same hash — causing incorrect session-to-project association in the Gemini picker.

## Fix

1. Try `sha256sum` first (Linux/BSD/WSL).
2. On failure, try `shasum -a 256` (macOS).
3. Improve the last-resort fallback to 16 hex chars (`{:016x}`) so it's visually distinguishable from a real hash.

## Test plan

- [x] `cargo test interchange::inject` passes
- [x] `test_sha256_hex_known_value`: result is all-hex and at least 16 chars
- [x] `test_sha256_hex_different_inputs_differ`: different paths → different hashes when a system SHA-256 tool is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)