### PR TITLE
docs: add and update Claude Code internal reference docs

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -40,6 +40,11 @@ runtime environment.
 | `AGENT_WRAPPER_PID` | PID of the wrapper process (used by plugins and Hyprland focus) |
 | `AGENT_UNLEASH_ROOT` | Path to the unleash installation directory |
 | `UNLEASH_POLYFILL_ACTIVE` | Set to `1` when polyfill flag translation is active |
+| `DISABLE_TELEMETRY` | Blocks all Claude Code analytics/telemetry (set to `1`) |
+| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | Blocks Claude Code analytics, auto-updates, release notes, feature flags (set to `1`) |
+| `GEMINI_TELEMETRY_ENABLED` | Gemini CLI telemetry master switch (set to `false`) |
+| `OPENCODE_DISABLE_SHARE` | Blocks OpenCode session sharing (set to `1`) |
+| `OPENCODE_DISABLE_AUTOUPDATE` | Blocks OpenCode update checks (set to `1`) |
 | `BASH_DEFAULT_TIMEOUT_MS` | Default bash timeout for agent tools (set to `999999999` ~11.5 days) |
 | `BASH_MAX_TIMEOUT_MS` | Max bash timeout (set to `999999999`) |
 | `MCP_TOOL_TIMEOUT` | MCP tool timeout (set to `999999999`) |

--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -6,8 +6,13 @@ Reference documentation for unleash developers. Not user-facing.
 
 ### Claude Code (`claude-code/`)
 
-- [CLI Format](claude-code/CLI_FORMAT.md) — JSONL transcripts, 12+ message types
+- [CLI Format](claude-code/CLI_FORMAT.md) — JSONL transcripts, 12+ message types, path encoding, source-verified
 - [XML Message Signatures](claude-code/XML_MESSAGE_SIGNATURES.md) — Native XML tags for custom rendering and agent messages
+- [Hooks](claude-code/HOOKS.md) — All 27 hook events, 4 types, input/output schemas, asyncRewake, once flag
+- [Telemetry](claude-code/TELEMETRY.md) — All telemetry systems, env vars to block them, Statsig + OTEL details
+- [Plugins](claude-code/PLUGINS.md) — `--plugin-dir` internals, manifest schema, hooks.json format, `${CLAUDE_PLUGIN_ROOT}`
+- [Tools](claude-code/TOOLS.md) — Built-in tool names, input schemas, hook matcher patterns, allowed-tools
+- [Plugin Development Guide](claude-code/plugin-development.md) — Developer workflow: scaffolding, testing, PR process
 
 ### Codex (`codex/`)
 

--- a/docs/internal/claude-code/CLI_FORMAT.md
+++ b/docs/internal/claude-code/CLI_FORMAT.md
@@ -1,7 +1,7 @@
 # Claude Code Conversation Storage Format
 
 > **Internal developer reference for unleash contributors.**
-> Last verified: 2026-03-29, Claude Code v2.1.87
+> Last verified: 2026-03-31, verified against source
 
 ---
 
@@ -17,23 +17,34 @@ All Claude Code persistent data lives under `~/.claude/`.
 │       ├── <SESSION_UUID>/
 │       │   └── subagents/
 │       │       └── agent-<ID>.jsonl   # Subagent (tool-spawned) transcripts
+│       │       └── agent-<ID>.meta.json  # Subagent metadata
 │       └── memory/
 │           └── MEMORY.md              # Auto-persisted project memory
 ├── sessions/                          # Active session metadata
 │   └── <PID>.json                     # One file per running process
-├── history.jsonl                      # Global conversation index
+├── history.jsonl                      # Prompt history for search/recall
+├── paste-cache/                       # Content-addressed storage for large pastes
+├── image-cache/                       # Per-session image storage
+│   └── <SESSION_ID>/
+├── tool-results/                      # Externalized tool result storage
+├── remote-agents/                     # Remote agent connection metadata
+├── workflows/                         # Workflow run grouping
+│   └── <RUN_ID>/
 ├── settings.json                      # User-level settings
 └── CLAUDE.md                          # User-level global instructions
 ```
 
 ### Path encoding
 
-Project directories use the absolute path with `/` replaced by `-` and the leading slash dropped. Examples:
+Project directories use the absolute path with **all non-alphanumeric characters** replaced by `-` (regex `[^a-zA-Z0-9]` -> `-`). Paths exceeding 200 characters are truncated and suffixed with a hash to avoid collisions.
+
+Examples:
 
 | Actual path | Encoded directory name |
 |---|---|
 | `/home/me/ht/unleash` | `-home-me-ht-unleash` |
 | `/home/me/projects/foo` | `-home-me-projects-foo` |
+| `/home/me/projects/foo.bar` | `-home-me-projects-foo-bar` |
 
 ---
 
@@ -49,17 +60,29 @@ Each conversation is a single **JSONL** (JSON Lines) file named `<UUID>.jsonl`. 
 
 UUIDs are v4 format. File size grows unbounded for the lifetime of a session; there is no rotation or splitting.
 
+**Write batching**: Writes are queued in memory and flushed at 100ms intervals. The JSONL file is not immediately consistent with in-memory state; there is a brief window where the most recent entries have not yet been written to disk.
+
 ### History index
 
-`~/.claude/history.jsonl` is a separate JSONL file where each line records a past conversation for display in the session picker. Fields:
+`~/.claude/history.jsonl` is a JSONL file used for **prompt history search** (the fuzzy-search session picker). Each line records a past conversation. This file is NOT used by `--continue` to find the most recent session (see Section 7).
 
 | Field | Type | Description |
 |---|---|---|
 | `display` | string | First user message (truncated), shown in picker UI |
-| `pastedContents` | string[] | Any pasted text from that first message |
-| `timestamp` | string | ISO 8601 timestamp |
+| `pastedContents` | `Record<number, StoredPastedContent>` | Pasted content from that first message (see below) |
+| `timestamp` | number | Epoch milliseconds |
 | `project` | string | Encoded project path |
 | `sessionId` | string | UUID linking to the `.jsonl` transcript |
+
+**`StoredPastedContent` structure**: Each entry in `pastedContents` is keyed by a numeric ID and contains:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | number | Paste identifier |
+| `type` | string | Paste type |
+| `content` / `contentHash` | string | Inline content for small pastes, or a content-addressed hash for large pastes stored in `~/.claude/paste-cache/` |
+| `mediaType` | string | MIME type of the pasted content |
+| `filename` | string | Original filename if applicable |
 
 ### Session metadata
 
@@ -70,9 +93,17 @@ UUIDs are v4 format. File size grows unbounded for the lifetime of a session; th
 | `pid` | number | OS process ID |
 | `sessionId` | string | UUID of the active conversation |
 | `cwd` | string | Working directory |
-| `startedAt` | string | ISO 8601 start time |
+| `startedAt` | number | Epoch milliseconds |
 | `kind` | string | Session type (e.g. `"interactive"`, `"headless"`) |
-| `entrypoint` | string | How Claude Code was launched (e.g. `"cli"`, `"sdk"`) |
+| `entrypoint` | string | How Claude Code was launched (e.g. `"cli"`, `"sdk-ts"`, `"sdk-py"`) |
+| `messagingSocketPath` | string | Unix socket path for IPC messaging |
+| `name` | string | Session display name |
+| `logPath` | string | Path to session log file |
+| `agent` | boolean | Whether this is an agent/subagent session |
+| `status` | string | Current status: `"busy"`, `"idle"`, or `"waiting"` |
+| `waitingFor` | string | What the session is waiting for (when status is `"waiting"`) |
+| `updatedAt` | number | Epoch milliseconds of last status update |
+| `bridgeSessionId` | string | Session ID of the bridge connection (if applicable) |
 
 These files are cleaned up when the process exits normally. Stale files from crashed processes may linger.
 
@@ -102,6 +133,7 @@ Every line in a `.jsonl` transcript shares these **universal top-level fields**:
 | `type` | string | yes | Message type discriminator (see Section 4) |
 | `uuid` | string | yes | Unique ID for this message |
 | `parentUuid` | string | yes | UUID of the preceding message in the conversation chain |
+| `logicalParentUuid` | string | no | UUID of the logical parent (may differ from `parentUuid` in branched conversations) |
 | `timestamp` | string | yes | ISO 8601 with milliseconds |
 | `sessionId` | string | yes | Session UUID this message belongs to |
 | `version` | string | yes | Claude Code version that wrote this line |
@@ -110,10 +142,22 @@ Every line in a `.jsonl` transcript shares these **universal top-level fields**:
 | `isSidechain` | boolean | yes | `true` if this message is part of a branched/sidechain conversation |
 | `userType` | string | yes | `"external"` for human, `"internal"` for system-generated |
 | `promptId` | string | no | Links related request/response pairs in the same exchange |
+| `agentId` | string | no | Identifier of the agent that produced this message |
+| `teamName` | string | no | Team name in multi-agent contexts |
+| `agentName` | string | no | Display name of the agent |
+| `agentColor` | string | no | UI color assigned to the agent |
+| `entrypoint` | string | no | How the session was launched: `"cli"`, `"sdk-ts"`, `"sdk-py"`, etc. |
+| `slug` | string | no | Short identifier slug |
+| `sourceToolAssistantUUID` | string | no | UUID of the assistant message whose tool call produced this message |
+| `isMeta` | boolean | no | `true` on user messages that are system-generated metadata, not actual human input |
 
 ---
 
 ## 4. Message Types
+
+### Transcript message types
+
+Only four message types are persisted to the conversation transcript: `user`, `assistant`, `attachment`, and `system`. Other entry types (metadata, state) are also stored in the JSONL file but are not part of the conversational transcript.
 
 ### `user`
 
@@ -132,40 +176,44 @@ Human input. `role` is always `"user"`.
 - A **string** for plain text input
 - An **array** of content blocks when delivering tool results back to the model (see Section 5)
 
+The `isMeta` field, when `true`, indicates this is a system-generated metadata message rather than actual human input.
+
 ### `assistant`
 
-Model response. Contains the full API response envelope.
+Model response. The API response fields (`role`, `content`, `model`, `usage`, `stop_reason`, `id`) are nested inside a `message` sub-object:
 
 ```json
 {
   "type": "assistant",
-  "role": "assistant",
-  "model": "claude-opus-4-6-20250327",
-  "id": "msg_01ABC...",
-  "content": [
-    {
-      "type": "thinking",
-      "thinking": "Let me examine the config...",
-      "signature": "ErUBCkYI..."
-    },
-    {
-      "type": "text",
-      "text": "Here is the config file contents:"
-    },
-    {
-      "type": "tool_use",
-      "id": "toolu_01XYZ...",
-      "name": "Read",
-      "input": { "file_path": "/home/me/.config/app/config.json" }
-    }
-  ],
-  "usage": { ... },
-  "stop_reason": "tool_use",
+  "message": {
+    "role": "assistant",
+    "model": "claude-opus-4-6-20250327",
+    "id": "msg_01ABC...",
+    "content": [
+      {
+        "type": "thinking",
+        "thinking": "Let me examine the config...",
+        "signature": "ErUBCkYI..."
+      },
+      {
+        "type": "text",
+        "text": "Here is the config file contents:"
+      },
+      {
+        "type": "tool_use",
+        "id": "toolu_01XYZ...",
+        "name": "Read",
+        "input": { "file_path": "/home/me/.config/app/config.json" }
+      }
+    ],
+    "usage": { ... },
+    "stop_reason": "tool_use"
+  },
   ...universal fields
 }
 ```
 
-Key fields:
+Key fields inside `message`:
 
 | Field | Type | Description |
 |---|---|---|
@@ -175,9 +223,21 @@ Key fields:
 | `usage` | object | Token counts (see Section 6) |
 | `stop_reason` | string | `"end_turn"`, `"tool_use"`, `"max_tokens"`, `"stop_sequence"` |
 
+### `attachment`
+
+File attachments and hook outputs. This is the fourth transcript message type, used to carry file content, hook output, and other attached data into the conversation.
+
+```json
+{
+  "type": "attachment",
+  "content": "...",
+  ...universal fields
+}
+```
+
 ### `system`
 
-Internal system events, not shown to users.
+Internal system events. These are persisted to the transcript.
 
 ```json
 {
@@ -191,21 +251,51 @@ Internal system events, not shown to users.
 
 | Field | Type | Description |
 |---|---|---|
-| `subtype` | string | Event category (e.g. `"local_command"`) |
+| `subtype` | string | Event category (see below) |
 | `content` | string | Human-readable description |
 | `level` | string | Severity: `"info"`, `"warning"`, `"error"` |
 
+**System message subtypes**:
+
+| Subtype | Description |
+|---|---|
+| `informational` | General informational message |
+| `permission_retry` | Permission was denied, retrying |
+| `bridge_status` | Bridge connection status change |
+| `scheduled_task_fire` | A scheduled task was triggered |
+| `stop_hook_summary` | Summary from a Stop hook execution |
+| `turn_duration` | Turn timing information |
+| `away_summary` | Summary of activity while user was away |
+| `memory_saved` | Memory was persisted |
+| `agents_killed` | Subagents were terminated |
+| `api_metrics` | API performance metrics |
+| `local_command` | Local shell command was executed |
+| `compact_boundary` | Marks a compaction point in the transcript |
+| `microcompact_boundary` | Lighter compaction that clears specific tool results |
+| `api_error` | API error encountered |
+
+### `tombstone`
+
+Marks a message as deleted or invalidated. Used for message deletion and content replacement workflows.
+
+```json
+{
+  "type": "tombstone",
+  "targetUuid": "uuid-of-deleted-message",
+  ...universal fields
+}
+```
+
 ### `progress`
 
-Hook lifecycle events emitted by the plugin/hook system.
+Hook lifecycle events emitted by the plugin/hook system. **Note**: `progress` messages are NOT persisted to the transcript. They are transient events used during execution. Old transcripts may contain `progress` entries from earlier versions, but these are bridged/skipped on load.
 
 ```json
 {
   "type": "progress",
   "hookEvent": "PreToolUse",
   "toolName": "Bash",
-  "hookResult": { "decision": "approve" },
-  ...universal fields
+  "hookResult": { "decision": "approve" }
 }
 ```
 
@@ -230,32 +320,46 @@ Tracks queue state changes (relevant to auto-mode and message queuing).
 
 ### `file-history-snapshot`
 
-Captures file state for undo/restore functionality.
+Captures file state references for undo/restore functionality. Stores backup references, not inline content.
 
 ```json
 {
   "type": "file-history-snapshot",
-  "files": {
-    "/home/me/ht/unleash/src/lib.rs": {
-      "content": "...",
-      "hash": "abc123..."
-    }
-  },
+  "messageId": "uuid-of-associated-message",
+  "trackedFileBackups": [ ... ],
+  "timestamp": "2026-03-29T10:15:30.123Z",
   ...universal fields
 }
 ```
 
+| Field | Type | Description |
+|---|---|---|
+| `messageId` | string | UUID of the message this snapshot is associated with |
+| `trackedFileBackups` | array | List of backup file references |
+| `timestamp` | string | When the snapshot was taken |
+
 ### Metadata-only types
 
-These carry no conversational content. They store UI/session state inline in the transcript:
+These carry no conversational content. They store UI/session state inline in the JSONL file:
 
-| Type | Purpose | Key field |
+| Type | Purpose | Key field(s) |
 |---|---|---|
 | `pr-link` | GitHub PR URL associated with session | `url` |
 | `custom-title` | User-set conversation title | `title` |
 | `agent-name` | Display name for the agent | `name` |
 | `agent-color` | UI color preference | `color` |
 | `last-prompt` | Caches the most recent user prompt | `prompt` |
+| `ai-title` | AI-generated conversation title | `title` |
+| `task-summary` | AI-generated summary of the task | `summary` |
+| `tag` | Tags/labels applied to the session | `tag` |
+| `agent-setting` | Agent configuration change | setting key/value |
+| `attribution-snapshot` | Snapshot of file attribution state | attribution data |
+| `speculation-accept` | Speculative execution acceptance | speculation data |
+| `mode` | Mode change record (e.g. auto-mode toggle) | `mode` |
+| `worktree-state` | Git worktree state snapshot | worktree data |
+| `content-replacement` | Content replacement/substitution record | replacement data |
+| `marble-origami-commit` | Commit event in marble-origami workflow | commit data |
+| `marble-origami-snapshot` | Snapshot in marble-origami workflow | snapshot data |
 
 ---
 
@@ -265,7 +369,7 @@ Tool interactions span two messages: an `assistant` message containing `tool_use
 
 ### Tool Use (assistant -> tool)
 
-Appears as a content block inside an `assistant` message:
+Appears as a content block inside an `assistant` message's `message.content` array:
 
 ```json
 {
@@ -335,15 +439,29 @@ Some tool result messages include a `toolUseResult` object with execution metada
 
 ## 6. Token Tracking
 
-Every `assistant` message includes a `usage` object:
+Every `assistant` message includes a `usage` object nested inside `message`:
 
 ```json
 {
-  "usage": {
-    "input_tokens": 15234,
-    "output_tokens": 892,
-    "cache_creation_input_tokens": 4096,
-    "cache_read_input_tokens": 11138
+  "type": "assistant",
+  "message": {
+    "usage": {
+      "input_tokens": 15234,
+      "output_tokens": 892,
+      "cache_creation_input_tokens": 4096,
+      "cache_read_input_tokens": 11138,
+      "server_tool_use": {
+        "web_search_requests": 2,
+        "web_fetch_requests": 1
+      },
+      "service_tier": "standard",
+      "cache_creation": {
+        "ephemeral_1h_input_tokens": 1024,
+        "ephemeral_5m_input_tokens": 512
+      },
+      "inference_geo": "us"
+    },
+    ...
   }
 }
 ```
@@ -354,10 +472,21 @@ Every `assistant` message includes a `usage` object:
 | `output_tokens` | number | Tokens generated in the response |
 | `cache_creation_input_tokens` | number | Tokens written to prompt cache this turn |
 | `cache_read_input_tokens` | number | Tokens served from prompt cache |
+| `server_tool_use` | object | Server-side tool usage counts (`web_search_requests`, `web_fetch_requests`) |
+| `service_tier` | string | API service tier used for the request |
+| `cache_creation` | object | Granular cache creation breakdown (`ephemeral_1h_input_tokens`, `ephemeral_5m_input_tokens`) |
+| `inference_geo` | string | Geographic region where inference ran |
+
+Additional session-level tracking fields may appear on assistant messages:
+
+| Field | Type | Description |
+|---|---|---|
+| `iterations` | number | Number of agentic loop iterations in this turn |
+| `speed` | number | Tokens per second |
 
 **Cost calculation**: Total input = `input_tokens + cache_creation_input_tokens + cache_read_input_tokens`. Cache reads are billed at reduced rate. Cache creation tokens are billed at a premium over standard input.
 
-Summing `usage` across all `assistant` messages in a transcript gives total session consumption.
+Summing `usage` objects across all `assistant` messages in a transcript gives total session consumption.
 
 ---
 
@@ -370,10 +499,13 @@ Each conversation is identified by a v4 UUID, stored as `sessionId` in every mes
 ### Continuing sessions
 
 The `--continue` flag (or `-c`) resumes the most recent session. Claude Code:
-1. Reads `~/.claude/history.jsonl` to find the latest `sessionId`
-2. Loads the corresponding `.jsonl` file
-3. Replays the conversation into context
-4. Appends new messages to the same file
+1. Scans the project directory (`~/.claude/projects/<path>/`) for `.jsonl` files
+2. Selects the most recently modified file by **filesystem modification time**
+3. Loads the corresponding `.jsonl` file
+4. Replays the conversation into context
+5. Appends new messages to the same file
+
+**Note**: `history.jsonl` is NOT used by `--continue`. It serves only as the prompt history index for the fuzzy session picker. Session resumption is based on filesystem mtime of `.jsonl` transcript files.
 
 A specific session can be resumed by `--session <UUID>`.
 
@@ -383,21 +515,26 @@ When Claude Code spawns a subagent (e.g. via the Agent tool), the subagent's tra
 
 ```
 <SESSION_UUID>/subagents/agent-<ID>.jsonl
+<SESSION_UUID>/subagents/agent-<ID>.meta.json
 ```
 
-The `<ID>` is an incrementing integer. Subagent transcripts follow the same JSONL schema. The parent transcript references subagent results through tool_result messages.
+The `<ID>` is an incrementing integer. Subagent transcripts follow the same JSONL schema. The `.meta.json` file contains agent metadata (name, role, configuration). The parent transcript references subagent results through tool_result messages.
 
 ### Session lifecycle
 
 ```
 Process starts
-  → Creates ~/.claude/sessions/<PID>.json
-  → Creates or appends to ~/.claude/projects/<path>/<UUID>.jsonl
-  → Appends to ~/.claude/history.jsonl
+  -> Creates ~/.claude/sessions/<PID>.json
+  -> Creates or appends to ~/.claude/projects/<path>/<UUID>.jsonl
+  -> Appends to ~/.claude/history.jsonl (for prompt search)
+
+During session
+  -> Updates ~/.claude/sessions/<PID>.json (status, updatedAt)
+  -> Writes are batched in memory, flushed every 100ms
 
 Process exits
-  → Removes ~/.claude/sessions/<PID>.json
-  → Transcript file remains permanently
+  -> Removes ~/.claude/sessions/<PID>.json
+  -> Transcript file remains permanently
 ```
 
 ---
@@ -409,7 +546,7 @@ Claude Code scopes conversations and configuration by project path.
 ```
 ~/.claude/projects/-home-me-ht-unleash/
 ├── *.jsonl                    # Conversation transcripts
-├── */subagents/               # Subagent transcripts
+├── */subagents/               # Subagent transcripts + meta files
 ├── memory/
 │   └── MEMORY.md             # Auto-persisted learnings
 └── settings.json             # Project-level settings (optional)
@@ -510,7 +647,7 @@ Images appear as content blocks within message arrays, typically in `tool_result
 
 ### Storage implications
 
-Images are stored inline as base64 in the JSONL transcript. There is no external blob storage or deduplication. A single screenshot can add 1-5 MB to the transcript. This is the primary driver of large transcript files.
+Images are stored inline as base64 in the JSONL transcript, with additional caching in `~/.claude/image-cache/<session-id>/`. A single screenshot can add 1-5 MB to the transcript. This is the primary driver of large transcript files.
 
 When reading transcripts programmatically, be prepared for very long lines containing base64 image data.
 
@@ -544,7 +681,7 @@ Long tool outputs may be truncated by Claude Code before storage. When this happ
 
 If Claude Code crashes or is killed (SIGKILL), the last line of the JSONL file may be:
 - Truncated (invalid JSON) - the line was being written when the process died
-- Missing entirely - the message was buffered but not flushed
+- Missing entirely - the message was buffered but not flushed (writes are batched at 100ms intervals)
 
 Parsers should handle malformed trailing lines gracefully. All preceding lines will be valid JSON.
 
@@ -563,7 +700,7 @@ Failed tool executions produce an `is_error` field in the tool_result:
 
 ### Stop reasons
 
-The `stop_reason` field on assistant messages indicates why generation stopped:
+The `stop_reason` field on assistant messages (inside `message`) indicates why generation stopped:
 
 | Value | Meaning |
 |---|---|
@@ -577,10 +714,14 @@ The `stop_reason` field on assistant messages indicates why generation stopped:
 ## Appendix: Parsing Tips for unleash Developers
 
 1. **Line-by-line processing**: Each JSONL line is independent. Use streaming parsers for large files.
-2. **Type dispatch**: Switch on the `type` field first, then handle type-specific fields.
-3. **Reconstruct conversations**: Follow `parentUuid` chains to build the message tree. `isSidechain` marks branched explorations.
+2. **Type dispatch**: Switch on the `type` field first, then handle type-specific fields. Only `user`, `assistant`, `attachment`, and `system` are transcript messages; other types are metadata/state entries.
+3. **Reconstruct conversations**: Follow `parentUuid` chains to build the message tree. `isSidechain` marks branched explorations. Use `logicalParentUuid` when available for logical ordering.
 4. **Correlate tool calls**: Match `tool_use.id` in assistant messages to `tool_result.tool_use_id` in the next user message.
-5. **Calculate costs**: Sum `usage` objects across all assistant messages. Apply per-model pricing.
+5. **Calculate costs**: Sum `usage` objects (inside `message`) across all assistant messages. Apply per-model pricing.
 6. **Handle images**: Skip or truncate base64 `data` fields when you don't need image content. They dominate file size.
-7. **Detect active sessions**: Cross-reference `~/.claude/sessions/*.json` with transcript `sessionId` values to find live conversations.
+7. **Detect active sessions**: Cross-reference `~/.claude/sessions/*.json` with transcript `sessionId` values to find live conversations. Check the `status` field for busy/idle/waiting state.
 8. **promptId grouping**: Messages sharing the same `promptId` belong to the same request-response exchange (user prompt + assistant reply + tool calls within that turn).
+9. **Handle tombstones**: When processing transcripts, check for `tombstone` entries that invalidate earlier messages by `targetUuid`.
+10. **Write consistency**: Due to 100ms write batching, the on-disk file may lag slightly behind the in-memory state. Account for this when reading transcripts of active sessions.
+11. **Progress entries**: Skip `progress` type entries when loading transcripts. They are not part of the conversation and are only present in older transcripts.
+12. **Assistant message nesting**: Remember that `role`, `content`, `model`, `usage`, and `stop_reason` are inside `message`, not at the top level of assistant entries.

--- a/docs/internal/claude-code/HOOKS.md
+++ b/docs/internal/claude-code/HOOKS.md
@@ -1,0 +1,554 @@
+# Claude Code Hook System Reference
+
+> Last verified: 2026-03-31, verified against source
+
+This document provides a comprehensive reference for the Claude Code hook system,
+covering all supported events, hook types, input/output schemas, execution semantics,
+and permission resolution.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Hook Events](#hook-events)
+3. [Hook Types](#hook-types)
+4. [Hook Schema Fields](#hook-schema-fields)
+5. [Hook Input Data](#hook-input-data)
+6. [Hook Output Schema](#hook-output-schema)
+7. [Hook-Specific Output Variants](#hook-specific-output-variants)
+8. [Hook Execution Flow](#hook-execution-flow)
+9. [Hook Permission Resolution](#hook-permission-resolution)
+10. [Configuration Examples](#configuration-examples)
+
+---
+
+## Overview
+
+Hooks are user-defined callbacks that Claude Code invokes at specific points during a
+session lifecycle. They enable custom logic such as:
+
+- Approving or blocking tool usage
+- Injecting context into the conversation
+- Triggering external systems on events
+- Enforcing organizational policies
+- Implementing autonomous workflows (e.g., auto-mode stop hooks)
+
+Hooks are configured in `settings.json` (under the `hooks` key), registered
+programmatically via the SDK/plugin system, or attached at the session level by
+agents and skills.
+
+---
+
+## Hook Events
+
+There are **27** hook events. Each event fires at a specific point in the session
+lifecycle.
+
+### Lifecycle Events
+
+| Event | When it fires |
+|---|---|
+| `SessionStart` | Session begins (startup, resume, clear, or compact) |
+| `SessionEnd` | Session is ending |
+| `Setup` | Initial setup or periodic maintenance |
+| `Stop` | Model has finished responding and wants to stop |
+| `StopFailure` | Stop hook itself failed |
+| `PreCompact` | Before conversation compaction |
+| `PostCompact` | After conversation compaction |
+| `CwdChanged` | Working directory changed |
+| `InstructionsLoaded` | CLAUDE.md / instructions have been loaded |
+| `ConfigChange` | Configuration was modified |
+
+### Tool Events
+
+| Event | When it fires |
+|---|---|
+| `PreToolUse` | Before a tool is executed |
+| `PostToolUse` | After a tool completes successfully |
+| `PostToolUseFailure` | After a tool execution fails |
+
+### Permission Events
+
+| Event | When it fires |
+|---|---|
+| `PermissionRequest` | Tool is requesting permission from the user |
+| `PermissionDenied` | User or policy denied a permission request |
+
+### Agent Events
+
+| Event | When it fires |
+|---|---|
+| `SubagentStart` | A sub-agent is starting |
+| `SubagentStop` | A sub-agent has stopped |
+
+### User Interaction Events
+
+| Event | When it fires |
+|---|---|
+| `UserPromptSubmit` | User submits a prompt |
+| `Notification` | A notification is being sent |
+| `Elicitation` | An elicitation (question to user) is being presented |
+| `ElicitationResult` | User responded to an elicitation |
+
+### Task Events
+
+| Event | When it fires |
+|---|---|
+| `TaskCreated` | A new task was created |
+| `TaskCompleted` | A task has completed |
+| `TeammateIdle` | A teammate agent is idle |
+
+### Workspace Events
+
+| Event | When it fires |
+|---|---|
+| `WorktreeCreate` | A git worktree is being created |
+| `WorktreeRemove` | A git worktree is being removed |
+| `FileChanged` | A file changed on disk |
+
+---
+
+## Hook Types
+
+### Persistable Types (user-configurable in settings.json)
+
+| Type | Description | Execution model |
+|---|---|---|
+| `command` | Runs a shell command (bash or powershell). Input is piped via stdin; output is read from stdout as JSON. | Subprocess |
+| `prompt` | Sends a prompt to a lightweight LLM. The `$ARGUMENTS` placeholder in the prompt string is replaced with the JSON-serialized hook input. | LLM call |
+| `http` | Sends an HTTP POST with JSON body to a URL. Expects a JSON response conforming to the output schema. | Network request |
+| `agent` | Runs a full sub-agent with access to tools. The `$ARGUMENTS` placeholder in the prompt string is replaced with hook input. Most powerful but slowest. | Sub-agent |
+
+### Internal-Only Types (not user-configurable)
+
+| Type | Description |
+|---|---|
+| `callback` | Programmatic JavaScript callback, used internally by the SDK and plugin system. |
+| `function` | Session-scoped function, attached by agents or skills during a session. |
+
+---
+
+## Hook Schema Fields
+
+### Common Fields (all hook types)
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `type` | `"command"` \| `"prompt"` \| `"http"` \| `"agent"` | Yes | Hook type |
+| `if` | `string` | No | Pattern filter using permission rule syntax (e.g., `"Bash(git *)"`) |
+| `timeout` | `number` | No | Maximum execution time in seconds |
+| `statusMessage` | `string` | No | Custom text shown in the spinner while the hook runs |
+| `once` | `boolean` | No | If `true`, the hook is removed after its first execution |
+| `async` | `boolean` | No | If `true`, the hook runs in the background and does not block |
+| `asyncRewake` | `boolean` | No | Background hook that wakes the model when it exits with code 2 |
+
+### Command-Specific Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `command` | `string` | Yes | The shell command to execute |
+| `shell` | `"bash"` \| `"powershell"` | No | Shell to use (defaults to platform default) |
+
+### Prompt-Specific Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `prompt` | `string` | Yes | Prompt text; use `$ARGUMENTS` as placeholder for hook input |
+| `model` | `string` | No | Model to use for the LLM call |
+
+### HTTP-Specific Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `url` | `string` | Yes | URL to POST to |
+| `headers` | `object` | No | Additional HTTP headers |
+| `allowedEnvVars` | `string[]` | No | Environment variables whose values may be included in the request |
+
+### Agent-Specific Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `prompt` | `string` | Yes | Agent prompt; use `$ARGUMENTS` as placeholder for hook input |
+| `model` | `string` | No | Model to use for the agent |
+
+---
+
+## Hook Input Data
+
+Hook input is delivered as JSON via stdin (for `command` hooks), HTTP POST body
+(for `http` hooks), or substituted into the `$ARGUMENTS` placeholder (for `prompt`
+and `agent` hooks).
+
+### Base Fields (present on all events)
+
+| Field | Type | Description |
+|---|---|---|
+| `session_id` | `string` | Current session identifier |
+| `transcript_path` | `string` | Path to the conversation transcript file |
+| `cwd` | `string` | Current working directory |
+| `permission_mode` | `string` | Current permission mode |
+| `agent_id` | `string` | Identifier of the agent that triggered the event |
+| `agent_type` | `string` | Type of agent (e.g., `"main"`, `"subagent"`) |
+
+### Event-Specific Fields
+
+#### PreToolUse
+
+| Field | Type | Description |
+|---|---|---|
+| `tool_name` | `string` | Name of the tool about to be used |
+| `tool_input` | `object` | Parameters being passed to the tool |
+| `tool_use_id` | `string` | Unique identifier for this tool invocation |
+
+#### PostToolUse
+
+| Field | Type | Description |
+|---|---|---|
+| `tool_name` | `string` | Name of the tool that was used |
+| `tool_input` | `object` | Parameters that were passed to the tool |
+| `tool_response` | `any` | The tool's return value |
+| `tool_use_id` | `string` | Unique identifier for this tool invocation |
+
+#### PostToolUseFailure
+
+| Field | Type | Description |
+|---|---|---|
+| `tool_name` | `string` | Name of the tool that failed |
+| `tool_input` | `object` | Parameters that were passed to the tool |
+| `tool_use_id` | `string` | Unique identifier for this tool invocation |
+| `error` | `string` | Error message |
+| `is_interrupt` | `boolean` | Whether the failure was due to an interrupt |
+
+#### Stop
+
+| Field | Type | Description |
+|---|---|---|
+| `stop_hook_active` | `boolean` | Whether a stop hook is currently active |
+| `last_assistant_message` | `string` | The last message the model produced |
+
+#### SessionStart
+
+| Field | Type | Description |
+|---|---|---|
+| `source` | `string` | One of `"startup"`, `"resume"`, `"clear"`, `"compact"` |
+| `agent_type` | `string` | Type of agent starting |
+| `model` | `string` | Model being used |
+
+#### Setup
+
+| Field | Type | Description |
+|---|---|---|
+| `trigger` | `string` | One of `"init"` or `"maintenance"` |
+
+#### SubagentStop
+
+| Field | Type | Description |
+|---|---|---|
+| `stop_hook_active` | `boolean` | Whether a stop hook is currently active |
+| `agent_id` | `string` | Identifier of the sub-agent that stopped |
+| `agent_transcript_path` | `string` | Path to the sub-agent's transcript |
+| `agent_type` | `string` | Type of the sub-agent |
+| `last_assistant_message` | `string` | The last message the sub-agent produced |
+
+#### PermissionRequest
+
+| Field | Type | Description |
+|---|---|---|
+| `tool_name` | `string` | Tool requesting permission |
+| `tool_input` | `object` | Parameters the tool wants to use |
+| `permission_suggestions` | `array` | Suggested permission rules |
+
+#### PermissionDenied
+
+| Field | Type | Description |
+|---|---|---|
+| `tool_name` | `string` | Tool whose permission was denied |
+| `tool_input` | `object` | Parameters the tool wanted to use |
+| `tool_use_id` | `string` | Unique identifier for the tool invocation |
+| `reason` | `string` | Reason the permission was denied |
+
+---
+
+## Hook Output Schema
+
+Hook output is expected as JSON on stdout (for `command` hooks) or in the HTTP
+response body (for `http` hooks). For `prompt` and `agent` hooks, the system parses
+the model's response into the same schema.
+
+### Top-Level Output Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `continue` | `boolean` | Whether to continue normal execution |
+| `suppressOutput` | `boolean` | Whether to suppress output from this hook |
+| `stopReason` | `string` | If set, stop execution with this reason |
+| `decision` | `"approve"` \| `"block"` | High-level approval decision |
+| `reason` | `string` | Human-readable explanation of the decision |
+| `systemMessage` | `string` | Message to inject into the system context |
+| `hookSpecificOutput` | `object` | Event-specific output fields (see below) |
+
+### Async Output
+
+When a hook needs to signal that it is running asynchronously:
+
+```json
+{
+  "async": true,
+  "asyncTimeout": 300
+}
+```
+
+### Exit Code 2
+
+For `command` hooks, exit code **2** signals a blocking error. The hook is treated
+as having produced an error that should halt the current operation. When used with
+`asyncRewake`, exit code 2 wakes the model to process the hook's output.
+
+---
+
+## Hook-Specific Output Variants
+
+The `hookSpecificOutput` field varies by event type.
+
+### PreToolUse
+
+| Field | Type | Description |
+|---|---|---|
+| `permissionDecision` | `"allow"` \| `"deny"` \| `"ask"` | Permission verdict for this tool call |
+| `permissionDecisionReason` | `string` | Explanation for the decision |
+| `updatedInput` | `object` | Modified tool parameters (replaces original input) |
+| `additionalContext` | `string` | Extra context injected into the conversation |
+
+### PostToolUse
+
+| Field | Type | Description |
+|---|---|---|
+| `additionalContext` | `string` | Extra context injected after tool execution |
+| `updatedMCPToolOutput` | `any` | Replacement output for MCP tool results |
+
+### SessionStart
+
+| Field | Type | Description |
+|---|---|---|
+| `additionalContext` | `string` | Context injected at session start |
+| `initialUserMessage` | `string` | Override the initial user message |
+| `watchPaths` | `string[]` | File paths to watch for changes |
+
+### PermissionRequest
+
+The hook can respond with either an approval (with optional modifications) or a denial:
+
+**Approval:**
+
+| Field | Type | Description |
+|---|---|---|
+| `decision` | `"approve"` | Approve the permission request |
+| `updatedInput` | `object` | Modified tool parameters |
+| `updatedPermissions` | `array` | Modified permission rules |
+
+**Denial:**
+
+| Field | Type | Description |
+|---|---|---|
+| `decision` | `"deny"` | Deny the permission request |
+| `reason` | `string` | Reason for denial |
+
+### PermissionDenied
+
+| Field | Type | Description |
+|---|---|---|
+| `retry` | `boolean` | If `true`, retry the permission request |
+
+### Elicitation / ElicitationResult
+
+| Field | Type | Description |
+|---|---|---|
+| `action` | `"accept"` \| `"decline"` \| `"cancel"` | How to handle the elicitation |
+| `content` | `any` | Content for the elicitation response |
+
+---
+
+## Hook Execution Flow
+
+1. **Collection** -- Hooks are gathered from three sources:
+   - **Settings snapshot** -- hooks defined in `settings.json`
+   - **Registered hooks** -- hooks registered via the SDK or plugin system
+   - **Session hooks** -- hooks attached at runtime by agents or skills
+
+2. **Event matching** -- Each hook is matched against the current event name.
+   Pattern matching supports:
+   - Exact match (e.g., `"PreToolUse"`)
+   - Pipe-separated alternatives (e.g., `"PreToolUse|PostToolUse"`)
+   - Regular expressions
+
+3. **Condition filtering** -- If a hook has an `if` field, the condition is
+   evaluated using permission rule syntax. The hook only runs if the condition
+   matches. For example, `"if": "Bash(git *)"` restricts a `PreToolUse` hook to
+   only fire when the `Bash` tool is invoked with a command starting with `git`.
+
+4. **Parallel execution** -- All matched hooks run **in parallel**, each with its
+   own timeout. There is no guaranteed ordering between hooks for the same event.
+
+5. **Result merging** -- Results from all hooks are collected. Blocking decisions
+   (`deny`) take priority. If any hook denies, the operation is denied regardless
+   of other hooks' decisions.
+
+6. **Security gate** -- In interactive mode, all hooks require **workspace trust**.
+   Hooks from untrusted workspaces will not execute. This prevents malicious
+   repositories from injecting hooks via checked-in configuration.
+
+---
+
+## Hook Permission Resolution
+
+When a `PreToolUse` hook returns a `permissionDecision`, the following rules apply:
+
+| Hook decision | Effect |
+|---|---|
+| `"allow"` | Grants permission for this specific invocation, but does **NOT** override `deny` or `ask` rules in `settings.json`. If `settings.json` denies the tool, the denial wins. |
+| `"deny"` | **Final.** The tool call is blocked. No other hook or setting can override a deny. |
+| `"ask"` | Forces the interactive permission dialog, even if `settings.json` would otherwise allow it. |
+
+Key rules:
+
+- A hook `allow` is a "soft allow" -- it can be overruled by settings-level deny/ask rules.
+- A hook `deny` is a "hard deny" -- it is final and cannot be overruled.
+- A hook `ask` escalates to the user -- it forces manual confirmation.
+- When a hook provides `updatedInput`, the modified parameters replace the original
+  tool input for the remainder of the execution (including subsequent hooks and the
+  actual tool call).
+
+---
+
+## Configuration Examples
+
+### Basic Command Hook (settings.json)
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": "/path/to/validator.sh",
+        "if": "Bash(rm *)",
+        "timeout": 10,
+        "statusMessage": "Checking destructive command..."
+      }
+    ]
+  }
+}
+```
+
+### Prompt Hook for Code Review
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "prompt",
+        "prompt": "Review the following tool call for safety. Input: $ARGUMENTS. Respond with JSON containing a 'decision' field of 'approve' or 'block' and a 'reason' field.",
+        "if": "Edit(*)",
+        "timeout": 30
+      }
+    ]
+  }
+}
+```
+
+### HTTP Webhook on Session Events
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "http",
+        "url": "https://hooks.example.com/claude/session-start",
+        "headers": {
+          "Authorization": "Bearer ${API_TOKEN}"
+        },
+        "allowedEnvVars": ["API_TOKEN"],
+        "timeout": 15
+      }
+    ]
+  }
+}
+```
+
+### Async Background Hook with Rewake
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "type": "command",
+        "command": "/path/to/auto-continue.sh",
+        "async": true,
+        "asyncRewake": true,
+        "timeout": 300,
+        "statusMessage": "Checking if more work is needed..."
+      }
+    ]
+  }
+}
+```
+
+### Agent Hook for Complex Validation
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "agent",
+        "prompt": "You are a security reviewer. Analyze this tool call and decide if it should proceed: $ARGUMENTS",
+        "if": "Bash(*)",
+        "timeout": 60
+      }
+    ]
+  }
+}
+```
+
+### Multiple Hooks on the Same Event
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": "/path/to/audit-logger.sh",
+        "async": true
+      },
+      {
+        "type": "command",
+        "command": "/path/to/policy-check.sh",
+        "if": "Bash(curl *)|Bash(wget *)",
+        "timeout": 5
+      }
+    ]
+  }
+}
+```
+
+### One-Time Setup Hook
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "/path/to/first-run-setup.sh",
+        "once": true,
+        "statusMessage": "Running first-time setup..."
+      }
+    ]
+  }
+}
+```

--- a/docs/internal/claude-code/PLUGINS.md
+++ b/docs/internal/claude-code/PLUGINS.md
@@ -1,0 +1,331 @@
+# Claude Code Plugin System — Internal Reference
+
+Internal technical reference for the Claude Code `--plugin-dir` plugin loading system.
+For the developer workflow guide, see [plugin-development.md](plugin-development.md).
+
+Last verified: 2026-03-31 (Claude Code ~1.x)
+
+---
+
+## Overview
+
+Claude Code supports loading plugins via the `--plugin-dir` flag. Each invocation of `--plugin-dir` adds one plugin directory. Multiple flags can be passed to load multiple plugins:
+
+```bash
+claude --plugin-dir /path/to/plugin-a --plugin-dir /path/to/plugin-b
+```
+
+Unleash loads all bundled plugins automatically by scanning `plugins/bundled/` and emitting one `--plugin-dir` per subdirectory (see `src/launcher.rs:find_plugins()`).
+
+---
+
+## Plugin Directory Layout
+
+Claude Code scans the root of each `--plugin-dir` path for the following component directories:
+
+```
+plugin-root/
+├── .claude-plugin/
+│   └── plugin.json          # Manifest (required)
+├── commands/                # Slash commands (.md files)
+├── agents/                  # Agent definitions (.md files)
+├── skills/                  # Skill directories (each with SKILL.md)
+│   └── skill-name/
+│       └── SKILL.md
+├── hooks/
+│   └── hooks.json           # Hook configuration
+├── .mcp.json                # MCP server definitions
+└── README.md
+```
+
+**Key rule**: Component directories (`commands/`, `agents/`, `skills/`, `hooks/`) must be at the **plugin root level**, not inside `.claude-plugin/`.
+
+---
+
+## Plugin Manifest
+
+The manifest lives at `.claude-plugin/plugin.json`. It is primarily metadata — Claude Code does not currently gatekeep component loading based on manifest fields. The manifest is required for the plugin to be recognized.
+
+```json
+{
+  "name": "plugin-name",
+  "version": "1.0.0",
+  "description": "Brief description",
+  "author": {
+    "name": "Author Name",
+    "email": "author@example.com"
+  },
+  "keywords": ["optional", "tags"]
+}
+```
+
+**Verified fields**: `name`, `version`, `description`, `author` (object with `name`/`email`), `keywords` (array).
+
+No `dependencies`, `hooks`, `engines`, or other fields have been observed in the source. Keep the manifest minimal.
+
+---
+
+## `${CLAUDE_PLUGIN_ROOT}` Environment Variable
+
+When Claude Code executes a hook command from a plugin, it sets `CLAUDE_PLUGIN_ROOT` to the **absolute path** of that plugin's root directory. This makes hook scripts portable regardless of working directory.
+
+```bash
+# In hooks.json — always use ${CLAUDE_PLUGIN_ROOT}
+"command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/my-hook.sh"
+
+# Never use relative paths
+"command": "./hooks/scripts/my-hook.sh"  # WRONG — breaks when CWD differs
+```
+
+Unleash canonicalizes plugin paths to absolute paths before passing them via `--plugin-dir` (see `src/launcher.rs:find_plugin_dirs()`), which ensures `${CLAUDE_PLUGIN_ROOT}` is always a valid absolute path.
+
+---
+
+## hooks/hooks.json Format
+
+The hooks file uses a **wrapper object** with a `description` key at the top level, then a `hooks` key containing the event map:
+
+```json
+{
+  "description": "Human-readable description of this hook set",
+  "hooks": {
+    "EventName": [
+      {
+        "matcher": "ToolName",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/handler.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Critical**: The `description` top-level wrapper is **required** for plugin hooks. This differs from `settings.json` hooks which use the event map directly at the top level.
+
+### Event Names
+
+See [HOOKS.md](HOOKS.md) for the complete list. The most commonly used in plugins:
+
+| Event | Timing | Notes |
+|-------|--------|-------|
+| `PreToolUse` | Before tool runs | Can block (exit 2) |
+| `PostToolUse` | After tool completes | Observational |
+| `Stop` | Before agent stops | Can block (exit 2) |
+| `Notification` | On agent notification | Observational |
+| `SessionStart` | Session begins | Context loading |
+| `UserPromptSubmit` | On user message | Can modify input |
+
+### Matcher Field
+
+The `matcher` field is a regex pattern matched against the tool name for `PreToolUse`/`PostToolUse`. For other events, omit `matcher` or use `"*"`.
+
+```json
+{ "matcher": "Bash" }           // exact match
+{ "matcher": "Write|Edit" }     // alternation
+{ "matcher": ".*" }             // all tools
+```
+
+If `matcher` is omitted entirely for tool events, the hook fires for all tools.
+
+### Hook Types
+
+**`command`** — Shell command executed via `/bin/sh`:
+```json
+{
+  "type": "command",
+  "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/handler.sh",
+  "timeout": 30
+}
+```
+
+**`prompt`** — Claude evaluates a prompt about the current action:
+```json
+{
+  "type": "prompt",
+  "prompt": "Evaluate this action. Return 'approve' or 'deny' with reason.",
+  "timeout": 30
+}
+```
+
+**`http`** — HTTP request to external endpoint (less common):
+```json
+{
+  "type": "http",
+  "url": "https://example.com/webhook",
+  "timeout": 30
+}
+```
+
+### Hook Exit Codes
+
+For `command` type hooks on `PreToolUse` and `Stop`:
+
+| Exit Code | Meaning |
+|-----------|---------|
+| `0` | Approve / allow |
+| `1` | Non-fatal error (logged, continues) |
+| `2` | Block / deny (writes stderr to Claude) |
+
+Output JSON structure for blocking (write to stderr, exit 2):
+```json
+{
+  "decision": "deny",
+  "reason": "Human-readable reason shown to Claude",
+  "systemMessage": "Optional additional context"
+}
+```
+
+For `updatedInput` (modify tool input before execution), write JSON to stdout and exit 0:
+```json
+{
+  "updatedInput": { ...modified_tool_input... }
+}
+```
+
+---
+
+## Plugin vs. settings.json Hooks
+
+Claude Code loads hooks from two sources, merged at runtime:
+
+| Source | Format | Purpose |
+|--------|--------|---------|
+| `~/.claude/settings.json` `hooks` key | Event map directly | User-level default hooks |
+| Plugin `hooks/hooks.json` | `{ description, hooks: { event map } }` | Plugin-scoped hooks |
+
+Unleash's default hooks (e.g., `PreCompact`) are installed into `settings.json` by `HookManager`. Plugin hooks are loaded by Claude Code via `--plugin-dir` independently. They do **not** conflict — both sets run.
+
+**Important**: Unleash avoids installing plugin hooks into `settings.json`. Plugin hooks must live in `hooks/hooks.json` within the plugin directory, not in `settings.json`.
+
+---
+
+## MCP Server Configuration (.mcp.json)
+
+Plugin-level MCP servers are declared in `.mcp.json` at the plugin root:
+
+```json
+{
+  "mcpServers": {
+    "server-name": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server/index.js"],
+      "env": {
+        "MY_VAR": "${MY_VAR}"
+      }
+    }
+  }
+}
+```
+
+**Transport types** supported:
+- `stdio` (default): Local process, stdin/stdout communication
+- `sse`: Server-Sent Events (hosted servers, OAuth flows)
+- `http`: HTTP/REST based
+
+When using `stdio`, the `command` + `args` define the server process. When using `sse` or `http`, a `url` field is used instead.
+
+---
+
+## Commands
+
+Command files are Markdown with YAML frontmatter, placed in `commands/`:
+
+```markdown
+---
+name: command-name
+description: Brief description shown in help
+argument-hint: "[optional] [args]"
+allowed-tools: ["Read", "Bash", "Grep"]
+---
+
+# Command instructions for Claude...
+```
+
+**Frontmatter fields**:
+- `name` (required): Slash command name. Invoked as `/command-name`.
+- `description` (required): Shown in `/help` and command picker.
+- `argument-hint` (optional): Displayed as usage hint.
+- `allowed-tools` (optional): Restricts which tools Claude can use during this command.
+
+**Naming**: File name (`my-command.md`) determines the slug. The `name` in frontmatter can differ but conventionally matches.
+
+---
+
+## Agents
+
+Agent files are Markdown with YAML frontmatter, placed in `agents/`:
+
+```markdown
+---
+name: Agent Display Name
+description: |
+  When to invoke this agent. Include <example> blocks:
+  <example>user asks to "do X task"</example>
+model: claude-sonnet-4-6
+color: blue
+allowed-tools: ["Read", "Write", "Edit", "Bash"]
+---
+
+# Agent system prompt...
+```
+
+**Frontmatter fields**:
+- `name` (optional): Display name in UI.
+- `description` (required): Used by Claude to decide when to invoke this agent. Should include `<example>` trigger phrases.
+- `model` (optional): Specific Claude model ID. Defaults to session model.
+- `color` (optional): UI color hint (`red`, `green`, `blue`, `yellow`, `purple`, `orange`).
+- `allowed-tools` (optional): Restricts agent's available tools.
+
+---
+
+## Skills
+
+Skills are auto-activating knowledge modules. Each skill is a directory with a `SKILL.md` file:
+
+```
+skills/
+└── skill-name/
+    └── SKILL.md
+```
+
+`SKILL.md` frontmatter:
+```markdown
+---
+name: Skill Name
+description: This skill should be used when the user asks to "X" or "Y"...
+version: 1.0.0
+---
+
+# Skill content loaded into context...
+```
+
+**Activation**: Claude Code reads the `description` and includes the skill content in context when the description semantically matches the current task. The description should use natural trigger phrases.
+
+---
+
+## Loading Priority and Conflicts
+
+When multiple plugins define the same command name, the last loaded plugin wins (determined by `--plugin-dir` order). Unleash loads plugins in filesystem iteration order.
+
+Hook execution order when multiple plugins register the same event:
+- All matching hooks from all plugins run
+- `PreToolUse` blocks if **any** hook returns exit 2
+
+There is no explicit plugin priority or dependency system — keep plugins independent.
+
+---
+
+## Unleash-Specific: Plugin Discovery
+
+Unleash's `find_plugin_dirs()` (in `src/launcher.rs`) applies deduplication:
+
+1. Scans `plugins/bundled/` (relative to CWD — dev repo path)
+2. Falls back to `~/.local/share/unleash/plugins/` (installed path)
+3. **De-duplicates by directory name** — if a plugin exists in both locations, the repo version wins
+
+This prevents duplicate hook firing when developing locally (repo plugins shadow installed plugins of the same name).

--- a/docs/internal/claude-code/TELEMETRY.md
+++ b/docs/internal/claude-code/TELEMETRY.md
@@ -1,0 +1,208 @@
+# Claude Code Telemetry Systems
+
+Reference documentation for all telemetry, analytics, and non-inference network traffic in Claude Code.
+
+Last verified: 2026-03-31, verified against source.
+
+---
+
+## Table of Contents
+
+- [Telemetry Systems](#telemetry-systems)
+  - [Datadog Event Logging](#1-datadog-event-logging)
+  - [First-Party Event Logging (1P)](#2-first-party-event-logging-1p)
+  - [GrowthBook Feature Flags](#3-growthbook-feature-flags)
+  - [BigQuery Metrics (OTEL)](#4-bigquery-metrics-otel)
+  - [Customer OTEL Export](#5-customer-otel-export)
+  - [Transcript Sharing](#6-transcript-sharing)
+- [Non-Inference Endpoints](#non-inference-endpoints)
+- [Environment Variables](#environment-variables)
+- [Privacy Controls](#privacy-controls)
+- [Failed Event Retry Queue](#failed-event-retry-queue)
+- [Unleash Telemetry Blocking](#unleash-telemetry-blocking)
+
+---
+
+## Telemetry Systems
+
+### 1. Datadog Event Logging
+
+**Endpoint:** `https://http-intake.logs.us5.datadoghq.com/api/v2/logs`
+
+Datadog browser-style logging using a public client token (standard practice for Datadog browser SDK). Events are sent from an explicit allowlist of approximately 35-40 event names.
+
+**Key characteristics:**
+
+- Events are batched and flushed every 15 seconds
+- Metadata is restricted to boolean and number values only -- the type system explicitly forbids string values to prevent accidental logging of code, filepaths, or PII
+- MCP tool names are normalized to the generic string `"mcp"` (individual tool names are never sent)
+- Automatically disabled when:
+  - `NODE_ENV=test`
+  - Using a third-party provider (Bedrock, Vertex, Foundry)
+  - Telemetry is explicitly disabled via environment variable
+
+### 2. First-Party Event Logging (1P)
+
+**Endpoint:** `https://api.anthropic.com/api/event_logging/batch`
+
+Uses OpenTelemetry's `BatchLogRecordProcessor` to send `ClaudeCodeInternalEvent` protobuf messages to Anthropic's own backend.
+
+**Key characteristics:**
+
+- Batched with a 10-second flush interval and 200-event batch size
+- Failed events are persisted to `~/.claude/telemetry/` as JSON files for retry on the next session launch
+- This retry queue can grow to hundreds of MB if events consistently fail to send (see [Failed Event Retry Queue](#failed-event-retry-queue))
+- Uses authenticated requests tied to the user's session
+
+### 3. GrowthBook Feature Flags
+
+**Endpoint:** `https://api.anthropic.com/` (proxied)
+
+GrowthBook SDK with remote evaluation -- user attributes are sent to the server, which evaluates feature flags and returns results.
+
+**Key characteristics:**
+
+- Three SDK client keys are configured: external, Anthropic production, and Anthropic development
+- Results are cached to disk for offline use
+- Used for A/B experiments, feature gating, dynamic configuration, and killswitches
+- One such killswitch controls the analytics sink itself
+
+### 4. BigQuery Metrics (OTEL)
+
+**Endpoint:** `https://api.anthropic.com/api/claude_code/metrics`
+
+OpenTelemetry metric data points exported to Anthropic's metrics pipeline (backed by BigQuery).
+
+**Key characteristics:**
+
+- Gated by an organization-level opt-out setting
+- Standard OTEL metric format
+
+### 5. Customer OTEL Export
+
+**Endpoint:** User-configured via `OTEL_EXPORTER_OTLP_ENDPOINT`
+
+Enterprise customers can configure Claude Code to export OpenTelemetry data to their own collectors. This is the intended mechanism for organizations that want visibility into Claude Code usage.
+
+### 6. Transcript Sharing
+
+**Endpoint:** `https://api.anthropic.com/api/claude_code_shared_session_transcripts`
+
+Conversation transcripts can be sent to Anthropic under specific conditions.
+
+**Key characteristics:**
+
+- Triggered by feedback surveys (thumbs up/down) and frustration detection heuristics
+- A redaction pass is applied before transmission
+- Uses authenticated requests
+
+---
+
+## Non-Inference Endpoints
+
+All network traffic Claude Code makes beyond model inference, categorized by function.
+
+### Authentication and OAuth
+
+| Endpoint | Purpose |
+|---|---|
+| `platform.claude.com` | OAuth flow for account authentication |
+| `claude.com` | OAuth flow for account authentication |
+
+### Auto-Update
+
+| Endpoint | Purpose |
+|---|---|
+| GCS bucket (`storage.googleapis.com`) | Native binary update checks and downloads |
+| npm registry (`registry.npmjs.org`) | npm-based update checks and downloads |
+
+### Organization APIs
+
+| Endpoint | Purpose |
+|---|---|
+| `api.anthropic.com/.../settings` | Organization settings and preferences |
+| `api.anthropic.com/.../team_memory` | Shared team memory / context |
+| `api.anthropic.com/.../policy_limits` | Usage policy and rate limits |
+| `api.anthropic.com/.../grove` | Key-value storage API |
+
+### MCP Infrastructure
+
+| Endpoint | Purpose |
+|---|---|
+| `mcp-proxy.anthropic.com` | MCP proxy for remote tool servers |
+| MCP Registry endpoints | Discovery and registration of MCP servers |
+
+### Miscellaneous
+
+| Endpoint | Purpose |
+|---|---|
+| GitHub raw content (`raw.githubusercontent.com`) | Release notes fetching |
+
+---
+
+## Environment Variables
+
+| Variable | Effect |
+|---|---|
+| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | Nuclear option -- blocks ALL non-inference network traffic (telemetry, updates, feature flags, org APIs, everything) |
+| `DISABLE_TELEMETRY` | Blocks analytics subsystems only (Datadog, 1P event logging, feedback/transcripts) |
+| `CLAUDE_CODE_USE_BEDROCK` | Third-party provider mode -- auto-disables all analytics |
+| `CLAUDE_CODE_USE_VERTEX` | Third-party provider mode -- auto-disables all analytics |
+| `CLAUDE_CODE_USE_FOUNDRY` | Third-party provider mode -- auto-disables all analytics |
+| `OTEL_METRICS_EXPORTER=none` | Disable OpenTelemetry metrics export |
+| `OTEL_LOGS_EXPORTER=none` | Disable OpenTelemetry logs export |
+| `OTEL_TRACES_EXPORTER=none` | Disable OpenTelemetry traces export |
+| `NODE_ENV=test` | Test environment -- disables all analytics subsystems |
+
+### Recommended Combinations
+
+**Disable all telemetry but keep updates and feature flags:**
+```
+DISABLE_TELEMETRY=1
+```
+
+**Disable all non-inference traffic (full isolation):**
+```
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+```
+
+**Disable all OTEL exports:**
+```
+OTEL_METRICS_EXPORTER=none
+OTEL_LOGS_EXPORTER=none
+OTEL_TRACES_EXPORTER=none
+```
+
+---
+
+## Privacy Controls
+
+Claude Code implements several layers of privacy protection in its telemetry systems:
+
+- **Type-level PII prevention:** The `AnalyticsMetadata` type only permits boolean and number values. String values are rejected at compile time, making it structurally impossible to log code snippets, file paths, or free-text user data in analytics events.
+- **MCP tool name normalization:** Individual MCP tool names are replaced with the generic string `"mcp"` before being included in any analytics event.
+- **Proto field stripping:** Certain protobuf fields are stripped before events reach general-access backends, limiting exposure of sensitive metadata.
+- **Organization-level opt-out:** Organizations can disable metrics collection via the API.
+- **Sink killswitch:** Analytics sinks can be remotely disabled via GrowthBook feature flags.
+
+---
+
+## Failed Event Retry Queue
+
+**Location:** `~/.claude/telemetry/`
+
+When first-party (1P) event logging fails to deliver events (network errors, server errors, etc.), the failed events are serialized as individual JSON files in the telemetry directory. On the next session launch, Claude Code attempts to re-send these queued events.
+
+**Warning:** This directory can grow to hundreds of megabytes if events consistently fail to deliver, such as when telemetry endpoints are blocked at the network level but `DISABLE_TELEMETRY` is not set. In that scenario, events are generated, fail to send, get persisted to disk, and accumulate indefinitely.
+
+---
+
+## Unleash Telemetry Blocking
+
+Unleash automatically configures telemetry blocking for all agents it launches:
+
+1. **Sets `DISABLE_TELEMETRY=1`** -- disables Datadog, 1P event logging, and feedback/transcript sharing
+2. **Sets `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`** -- blocks all remaining non-inference traffic (updates, feature flags, org APIs)
+3. **Purges `~/.claude/telemetry/`** on each launch -- prevents the failed event retry queue from accumulating disk space
+
+No additional user configuration is required when running Claude Code through Unleash.

--- a/docs/internal/claude-code/TOOLS.md
+++ b/docs/internal/claude-code/TOOLS.md
@@ -1,0 +1,408 @@
+# Claude Code Built-in Tools — Internal Reference
+
+Reference for all built-in tools available to Claude Code agents. Useful for:
+- Writing hook matchers (`PreToolUse`/`PostToolUse`)
+- Understanding tool input/output schemas for hook scripts
+- Knowing which tools are read-only vs. write
+
+Last verified: 2026-03-31 (Claude Code ~1.x)
+
+---
+
+## Tool Names (for Hook Matchers)
+
+These are the exact tool names as they appear in the `tool_name` field of hook input JSON and in `matcher` patterns:
+
+| Tool | Category | Mutates FS? |
+|------|----------|-------------|
+| `Read` | File I/O | No |
+| `Write` | File I/O | Yes |
+| `Edit` | File I/O | Yes |
+| `MultiEdit` | File I/O | Yes |
+| `NotebookRead` | Notebook | No |
+| `NotebookEdit` | Notebook | Yes |
+| `Bash` | Shell | Yes (potentially) |
+| `Grep` | Search | No |
+| `Glob` | Search | No |
+| `LS` | Search | No |
+| `WebFetch` | Network | No |
+| `WebSearch` | Network | No |
+| `Agent` | Agent | Delegated |
+| `Task` | Agent | Delegated |
+| `TodoRead` | State | No |
+| `TodoWrite` | State | Yes |
+| `ExitPlanMode` | Control | No |
+| `EnterPlanMode` | Control | No |
+| `Skill` | Meta | No |
+
+MCP tools appear with the format `mcp__<server>__<tool>` (e.g., `mcp__playwright__browser_click`).
+
+---
+
+## Hook Input JSON Schema
+
+For `PreToolUse` and `PostToolUse` hooks, Claude Code sends JSON to the hook's stdin:
+
+```json
+{
+  "session_id": "uuid",
+  "transcript_path": "/path/to/session.jsonl",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": { ... }
+}
+```
+
+For `PostToolUse`, additional fields are present:
+```json
+{
+  "tool_response": { ... },
+  "tool_error": null
+}
+```
+
+---
+
+## Individual Tool Schemas
+
+### Read
+
+Reads a file from the local filesystem.
+
+```json
+{
+  "file_path": "/absolute/path/to/file",
+  "offset": 100,
+  "limit": 200
+}
+```
+
+- `file_path` (required): Absolute path.
+- `offset` (optional): Line number to start reading from (1-based).
+- `limit` (optional): Number of lines to read.
+
+Hook matcher: `"Read"`
+
+### Write
+
+Writes (or overwrites) a file.
+
+```json
+{
+  "file_path": "/absolute/path/to/file",
+  "content": "file content here"
+}
+```
+
+Hook matcher: `"Write"`
+
+### Edit
+
+Performs an exact string replacement in a file.
+
+```json
+{
+  "file_path": "/absolute/path/to/file",
+  "old_string": "text to find",
+  "new_string": "replacement text",
+  "replace_all": false
+}
+```
+
+- `replace_all` (optional, default false): Replace all occurrences vs. first only.
+
+Hook matcher: `"Edit"`
+
+### MultiEdit
+
+Multiple edits applied to one or more files atomically.
+
+```json
+{
+  "edits": [
+    {
+      "file_path": "/path/to/file",
+      "old_string": "old text",
+      "new_string": "new text",
+      "replace_all": false
+    }
+  ]
+}
+```
+
+Hook matcher: `"MultiEdit"`
+
+### Bash
+
+Executes a shell command.
+
+```json
+{
+  "command": "ls -la",
+  "timeout": 30000,
+  "description": "List files"
+}
+```
+
+- `command` (required): Shell command to run.
+- `timeout` (optional): Timeout in milliseconds. Defaults to `BASH_DEFAULT_TIMEOUT_MS` env var (unleash sets this to 999999999).
+- `description` (optional): Human-readable description (shown in UI).
+
+Hook matcher: `"Bash"`
+
+**Note**: This is the highest-risk tool. `PreToolUse` hooks that block dangerous Bash commands should check `tool_input.command`.
+
+### Grep
+
+Search file contents using regex.
+
+```json
+{
+  "pattern": "function\\s+\\w+",
+  "path": "/search/root",
+  "glob": "*.js",
+  "type": "js",
+  "output_mode": "content",
+  "-i": true,
+  "-n": true,
+  "-A": 2,
+  "-B": 2,
+  "head_limit": 100
+}
+```
+
+- `pattern` (required): Regex pattern (ripgrep syntax).
+- `path` (optional): Directory to search.
+- `glob` (optional): File glob filter.
+- `type` (optional): File type filter (ripgrep `--type`).
+- `output_mode`: `"content"` | `"files_with_matches"` | `"count"`.
+
+Hook matcher: `"Grep"`
+
+### Glob
+
+Find files by glob pattern.
+
+```json
+{
+  "pattern": "**/*.ts",
+  "path": "/search/root"
+}
+```
+
+Hook matcher: `"Glob"`
+
+### LS
+
+List directory contents.
+
+```json
+{
+  "path": "/directory/path"
+}
+```
+
+Hook matcher: `"LS"`
+
+### WebFetch
+
+Fetch a URL and return its content.
+
+```json
+{
+  "url": "https://example.com/page",
+  "prompt": "Extract the main content"
+}
+```
+
+Hook matcher: `"WebFetch"`
+
+### WebSearch
+
+Search the web.
+
+```json
+{
+  "query": "search terms"
+}
+```
+
+Hook matcher: `"WebSearch"`
+
+### Agent
+
+Spawn a subagent. The Agent tool is used for complex multi-step research or tasks delegated to a specialized agent.
+
+```json
+{
+  "prompt": "Task description for the agent",
+  "subagent_type": "general-purpose",
+  "description": "Short description",
+  "model": "claude-sonnet-4-6"
+}
+```
+
+Hook matcher: `"Agent"` or `"Task"`
+
+### TodoRead / TodoWrite
+
+Manage the in-session todo list.
+
+**TodoWrite** input:
+```json
+{
+  "todos": [
+    {
+      "id": "1",
+      "content": "Task description",
+      "status": "pending",
+      "priority": "high"
+    }
+  ]
+}
+```
+
+`status` values: `"pending"` | `"in_progress"` | `"completed"`
+`priority` values: `"high"` | `"medium"` | `"low"`
+
+Hook matchers: `"TodoRead"`, `"TodoWrite"`
+
+### NotebookRead / NotebookEdit
+
+Read or edit Jupyter notebook cells.
+
+**NotebookEdit** input:
+```json
+{
+  "notebook_path": "/path/to/notebook.ipynb",
+  "cell_id": "cell-uuid",
+  "new_source": "print('hello')",
+  "cell_type": "code",
+  "edit_mode": "replace"
+}
+```
+
+Hook matchers: `"NotebookRead"`, `"NotebookEdit"`
+
+### Skill
+
+Invokes a named skill (loads skill content into context).
+
+```json
+{
+  "skill": "skill-name",
+  "args": "optional arguments"
+}
+```
+
+Hook matcher: `"Skill"`
+
+---
+
+## MCP Tool Names
+
+MCP tools are namespaced: `mcp__<server-name>__<tool-name>`
+
+Examples from the playwright MCP server:
+```
+mcp__playwright__browser_navigate
+mcp__playwright__browser_click
+mcp__playwright__browser_type
+mcp__playwright__browser_screenshot
+```
+
+To match all playwright tools in a hook:
+```json
+{ "matcher": "mcp__playwright__.*" }
+```
+
+To match all MCP tools:
+```json
+{ "matcher": "mcp__.*" }
+```
+
+---
+
+## Tool Categories for Hook Patterns
+
+Common matcher patterns for hooks:
+
+```json
+// All file-writing tools
+{ "matcher": "Write|Edit|MultiEdit|NotebookEdit" }
+
+// All shell execution
+{ "matcher": "Bash" }
+
+// All network access
+{ "matcher": "WebFetch|WebSearch|mcp__.*" }
+
+// All read-only tools (for auditing)
+{ "matcher": "Read|Grep|Glob|LS|NotebookRead|WebFetch|WebSearch|TodoRead" }
+
+// All state-mutating tools
+{ "matcher": "Write|Edit|MultiEdit|Bash|TodoWrite|NotebookEdit" }
+```
+
+---
+
+## `allowed-tools` in Commands and Agents
+
+Command and agent frontmatter can restrict which tools are available:
+
+```yaml
+allowed-tools: ["Read", "Bash", "Grep", "Glob"]
+```
+
+- Tools not in the list are unavailable to Claude during that command/agent session
+- Omitting `allowed-tools` allows all tools
+- MCP tools can be included: `"mcp__playwright__browser_navigate"`
+- Use this to scope agent capabilities and reduce risk surface
+
+---
+
+## Hook Input: Full Example
+
+Complete hook input for a `PreToolUse` on `Bash`:
+
+```json
+{
+  "session_id": "3f7a8b2c-1234-5678-abcd-ef0123456789",
+  "transcript_path": "/home/user/.claude/projects/-home-user-myproject/3f7a8b2c.jsonl",
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "rm -rf /tmp/test",
+    "timeout": 30000,
+    "description": "Clean up temp files"
+  }
+}
+```
+
+Hook script to block dangerous commands:
+
+```bash
+#!/bin/bash
+input=$(cat)
+cmd=$(echo "$input" | jq -r '.tool_input.command // ""')
+
+if echo "$cmd" | grep -qE 'rm -rf /[^t]|dd if=|mkfs'; then
+  echo '{"decision":"deny","reason":"Dangerous command pattern detected"}' >&2
+  exit 2
+fi
+exit 0
+```
+
+---
+
+## Tool Response Shapes (PostToolUse)
+
+The `tool_response` field in `PostToolUse` hooks varies by tool:
+
+**Read**: Returns file contents as string
+**Write/Edit**: Returns confirmation message
+**Bash**: Returns `{ "stdout": "...", "stderr": "...", "exit_code": 0 }`
+**Grep/Glob**: Returns matching lines or file paths as string
+**WebFetch**: Returns page content as string
+
+Note: The exact shape can vary across Claude Code versions. Parse defensively.

--- a/docs/internal/claude-code/XML_MESSAGE_SIGNATURES.md
+++ b/docs/internal/claude-code/XML_MESSAGE_SIGNATURES.md
@@ -1,9 +1,9 @@
 # Claude Code Native XML Tags — Complete Reference
 
-> **Last verified:** 2026-03-30, Claude Code v2.1.87
+> **Last verified:** 2026-03-31, verified against source + live observation
 > **Source issue:** [#222](https://github.com/heiervang-technologies/unleash/issues/222)
 
-Research into the XML tags that Claude Code natively uses for custom renders, system messages, and agent communication. Compiled from Piebald-AI system prompt extractions, Yuyz0112 runtime reverse engineering, cs50victor teams reimplementation, and live observation.
+Research into the XML tags that Claude Code natively uses for custom renders, system messages, and agent communication. Compiled from Piebald-AI system prompt extractions, Yuyz0112 runtime reverse engineering, cs50victor teams reimplementation, live observation, and source code review (2026-03-31).
 
 ## Why This Matters
 

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -213,7 +213,7 @@ impl AgentDefinition {
                 },
                 fork: ForkStrategy::Flag("--fork-session".to_string()),
                 yolo_flag: Some("--dangerously-skip-permissions".to_string()),
-                model_flag: "-m".to_string(),
+                model_flag: "--model".to_string(),
                 effort_flag: Some("--effort".to_string()),
             },
             github_repo: Some("anthropics/claude-code".to_string()),

--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -562,8 +562,25 @@ fn extract_session_id(records: &[HubRecord]) -> String {
 }
 
 fn encode_claude_project_path(dir: &str) -> String {
-    // Claude encodes /home/me/project as -home-me-project (leading dash, slashes to dashes)
-    dir.replace('/', "-")
+    // Claude replaces ALL non-alphanumeric chars with dashes, and truncates at 200 chars with hash
+    let encoded: String = dir
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+    if encoded.len() > 200 {
+        let hash = simple_hash(&encoded);
+        format!("{}-{:x}", &encoded[..200], hash)
+    } else {
+        encoded
+    }
+}
+
+fn simple_hash(s: &str) -> u64 {
+    let mut h: u64 = 0;
+    for b in s.bytes() {
+        h = h.wrapping_mul(31).wrapping_add(b as u64);
+    }
+    h
 }
 
 fn uuid_v4() -> String {

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -317,6 +317,35 @@ fn run_agent(
         println!("Auto mode activated on startup");
     }
 
+    // Block telemetry for all agents — only allow inference API calls
+    // Claude Code
+    if env::var("DISABLE_TELEMETRY").is_err() {
+        cmd.env("DISABLE_TELEMETRY", "1");
+    }
+    if env::var("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC").is_err() {
+        cmd.env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
+    }
+    // Gemini CLI (telemetry off by default, but be explicit)
+    if env::var("GEMINI_TELEMETRY_ENABLED").is_err() {
+        cmd.env("GEMINI_TELEMETRY_ENABLED", "false");
+    }
+    // OpenCode
+    if env::var("OPENCODE_DISABLE_SHARE").is_err() {
+        cmd.env("OPENCODE_DISABLE_SHARE", "1");
+    }
+    if env::var("OPENCODE_DISABLE_AUTOUPDATE").is_err() {
+        cmd.env("OPENCODE_DISABLE_AUTOUPDATE", "1");
+    }
+
+    // Clean up stale telemetry retry queue (Claude Code persists failed events here)
+    if let Some(home) = dirs::home_dir() {
+        let telemetry_dir = home.join(".claude/telemetry");
+        if telemetry_dir.exists() {
+            let _ = fs::remove_dir_all(&telemetry_dir);
+            let _ = fs::create_dir_all(&telemetry_dir);
+        }
+    }
+
     // Set timeout environment variables (extended timeouts)
     if env::var("BASH_DEFAULT_TIMEOUT_MS").is_err() {
         cmd.env("BASH_DEFAULT_TIMEOUT_MS", "999999999");

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -208,7 +208,7 @@ mod tests {
             ..default_flags()
         };
         let inv = resolve(&config, &flags, &[]);
-        assert!(inv.args.contains(&"-m".to_string()));
+        assert!(inv.args.contains(&"--model".to_string()));
         assert!(inv.args.contains(&"opus".to_string()));
     }
 
@@ -219,17 +219,17 @@ mod tests {
             model: Some("opus".to_string()),
             ..default_flags()
         };
-        let existing = vec!["-m".to_string()];
+        let existing = vec!["--model".to_string()];
         let inv = resolve(&config, &flags, &existing);
-        // Should not add -m again
-        assert!(!inv.args.contains(&"-m".to_string()));
+        // Should not add --model again
+        assert!(!inv.args.contains(&"--model".to_string()));
     }
 
     #[test]
     fn test_model_not_added_when_none() {
         let config = AgentDefinition::claude().polyfill;
         let inv = resolve(&config, &default_flags(), &[]);
-        assert!(!inv.args.contains(&"-m".to_string()));
+        assert!(!inv.args.contains(&"--model".to_string()));
     }
 
     // ── Continue / Resume ────────────────────────────────────
@@ -436,7 +436,7 @@ mod tests {
             ..default_flags()
         };
         let inv = resolve(&config, &flags, &[]);
-        assert!(inv.args.contains(&"-m".to_string()));
+        assert!(inv.args.contains(&"--model".to_string()));
         assert!(inv.args.contains(&"sonnet".to_string()));
         assert!(inv.args.contains(&"--effort".to_string()));
         assert!(inv.args.contains(&"low".to_string()));


### PR DESCRIPTION
## Summary

- 4 new internal reference docs for Claude Code internals
- Updated CLI_FORMAT.md with corrections and additions
- Telemetry blocking improvements across all 4 CLIs
- Bug fix in path encoding

## New Documents

- **HOOKS.md** — All hook events, 4 hook types, complete input/output schemas, asyncRewake and once flag details
- **TELEMETRY.md** — All telemetry systems, env vars to disable them
- **PLUGINS.md** — `--plugin-dir` internals: manifest schema, `hooks.json` format, `${CLAUDE_PLUGIN_ROOT}` mechanics
- **TOOLS.md** — All built-in tool names, input schemas, matcher patterns for hooks

## Changes

- `CLI_FORMAT.md`: corrections and additions to message types, path encoding rules, nesting details
- `docs/internal/README.md`: index updated with all new entries
- `launcher.rs`: telemetry blocking for Gemini CLI and OpenCode; auto-cleanup of `~/.claude/telemetry/`
- `inject.rs`: fix `encode_claude_project_path` — replace all non-alphanumeric chars, not just slashes

## Test Plan

- [ ] `cargo test` passes
- [ ] Spot-check hook event list against a running session
- [ ] Confirm PLUGINS.md hooks.json format matches bundled plugin files