### PR TITLE
fix(ucf): session discovery, UUID validation, and init message

### DIFF
--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -417,8 +417,29 @@ fn inject_into_gemini(
     source: &SessionInfo,
     hub_records: &[HubRecord],
 ) -> Result<InjectionResult, ConvertError> {
-    let gemini_val = gemini::from_hub(hub_records)?;
-    let session_id = extract_session_id(hub_records);
+    let mut session_id = extract_session_id(hub_records);
+
+    // Gemini CLI validates that --resume arguments are valid UUIDs.
+    // If the source session ID is not a UUID (e.g. native UCF named sessions),
+    // we must generate a fresh UUID for Gemini to accept it.
+    let is_uuid = session_id.len() == 36
+        && session_id.split('-').count() == 5
+        && session_id.split('-').all(|seg| seg.chars().all(|c| c.is_ascii_hexdigit()));
+
+    let final_records = if !is_uuid {
+        session_id = uuid_v4();
+        let mut patched = hub_records.to_vec();
+        for record in &mut patched {
+            if let HubRecord::Session(ref mut header) = record {
+                header.session_id = session_id.clone();
+            }
+        }
+        patched
+    } else {
+        hub_records.to_vec()
+    };
+
+    let gemini_val = gemini::from_hub(&final_records)?;
 
     // Gemini uses project slugs from ~/.gemini/projects.json for session dirs
     // Falls back to SHA-256 hash if not in projects.json
@@ -443,16 +464,17 @@ fn inject_into_gemini(
     let uuid_short = &session_id[..session_id.len().min(8)];
     let output_path = chats_dir.join(format!("session-{}-{}.json", date_part, uuid_short));
 
-    // Ensure projectHash is in the output
+    // Ensure projectHash and id are correct in the output
     let mut gemini_val = gemini_val;
     gemini_val["projectHash"] = serde_json::Value::String(project_hash);
+    gemini_val["id"] = serde_json::Value::String(session_id.clone());
 
     let json = serde_json::to_string_pretty(&gemini_val)?;
     std::fs::write(&output_path, &json)?;
 
     // Write/append logs.json entries for session discovery
     let logs_path = gemini_base.join("logs.json");
-    let log_entries = gemini::build_logs_entries(hub_records);
+    let log_entries = gemini::build_logs_entries(&final_records);
     if !log_entries.is_empty() {
         let mut existing_logs: Vec<serde_json::Value> = if logs_path.exists() {
             std::fs::read_to_string(&logs_path)
@@ -867,7 +889,7 @@ fn uuid_v4() -> String {
     let pid = std::process::id() as u64;
     let a = (lo >> 32) as u32;
     let b = (lo >> 16) as u16;
-    let c = (lo & 0xFFFF) as u16 | 0x4000; // version 4
+    let c = (lo & 0x0FFF) as u16 | 0x4000; // version 4
     let d = ((hi >> 48) as u16 & 0x3FFF) | 0x8000; // variant 1
     let e = hi ^ pid;
     format!("{a:08x}-{b:04x}-{c:04x}-{d:04x}-{e:012x}")

--- a/src/interchange/sessions.rs
+++ b/src/interchange/sessions.rs
@@ -522,15 +522,15 @@ fn discover_ucf() -> Vec<SessionInfo> {
 
         if let Some(Ok(first_line)) = lines.next() {
             if let Ok(val) = serde_json::from_str::<serde_json::Value>(&first_line) {
-                if let Some(session) = val.get("session") {
-                    let updated_at = session
+                if val.get("type").and_then(|t| t.as_str()) == Some("session") {
+                    let updated_at = val
                         .get("updated_at")
                         .and_then(|t| t.as_str())
                         .unwrap_or("1970-01-01T00:00:00.000Z")
                         .to_string();
-                    let title = session.get("title").and_then(|t| t.as_str()).map(|s| s.to_string());
-                    
-                    // message count = total lines - 1 (for the header)
+                    let title = val.get("title").and_then(|t| t.as_str()).map(|s| s.to_string());
+
+                    // remaining lines after header (messages + events)
                     let message_count = lines.filter(|l| l.is_ok()).count();
 
                     sessions.push(SessionInfo {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1254,8 +1254,9 @@ fn setup_ucf_session(ucf_name: &str, target_cli: &str) -> io::Result<(String, Ve
             ucf_version: interchange::hub::UCF_VERSION.to_string(),
             session_id: ucf_name.to_string(),
             created_at: now_iso.clone(),
-            updated_at: now_iso,
-            source_cli: "ucf".to_string(),            source_version: "1.0.0".to_string(),
+            updated_at: now_iso.clone(),
+            source_cli: "ucf".to_string(),
+            source_version: "1.0.0".to_string(),
             project: None,
             model: None,
             title: Some(ucf_name.to_string()),
@@ -1263,8 +1264,26 @@ fn setup_ucf_session(ucf_name: &str, target_cli: &str) -> io::Result<(String, Ve
             parent_session_id: None,
             extensions: serde_json::json!({}),
         };
-        let record = interchange::hub::HubRecord::Session(header);
-        let data = serde_json::to_string(&record).unwrap() + "\n";
+        let msg = interchange::hub::HubMessage {
+            id: format!("init-{ucf_name}"),
+            api_message_id: None,
+            parent_id: None,
+            timestamp: now_iso.clone(),
+            completed_at: Some(now_iso),
+            role: "user".to_string(),
+            content: vec![interchange::hub::ContentBlock::Text {
+                text: "[UCF Session Initialized]".to_string(),
+            }],
+            metadata: Default::default(),
+            extensions: serde_json::json!({}),
+        };
+
+        let record_session = interchange::hub::HubRecord::Session(header);
+        let record_msg = interchange::hub::HubRecord::Message(msg);
+        let data = serde_json::to_string(&record_session).unwrap()
+            + "\n"
+            + &serde_json::to_string(&record_msg).unwrap()
+            + "\n";
         std::fs::write(&ucf_path, data)?;
     } else {
         eprintln!("\x1b[34minfo:\x1b[0m Loading native UCF session: {ucf_name} into {target_cli}");

--- a/tests/test_ucf_live.sh
+++ b/tests/test_ucf_live.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# MANUAL INTEGRATION TEST — requires installed CLIs with API keys.
+# Not suitable for CI. Run locally to validate UCF crossload end-to-end.
+set -euo pipefail
+
+SESSION_NAME="ucf-live-test-$$"
+UCF_FILE="$HOME/.local/share/unleash/sessions/${SESSION_NAME}.ucf.jsonl"
+GEMINI_OUT=$(mktemp /tmp/gemini_out.XXXXXX)
+CODEX_OUT=$(mktemp /tmp/codex_out.XXXXXX)
+OPENCODE_OUT=$(mktemp /tmp/opencode_out.XXXXXX)
+
+echo "=== UCF Live Test ==="
+echo "Session Name: $SESSION_NAME"
+
+cleanup() {
+    rm -f "$GEMINI_OUT" "$CODEX_OUT" "$OPENCODE_OUT"
+    rm -f "$UCF_FILE"
+}
+trap cleanup EXIT
+
+# Use the debug binary if it exists
+BIN="./target/debug/unleash"
+if [[ ! -x "$BIN" ]]; then
+    echo "ERROR: Please run 'cargo build' first"
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# Step 1: Claude Code
+echo "[1] Claude Code: Creating native UCF session ($SESSION_NAME) and setting context"
+"$BIN" claude -u "$SESSION_NAME" -p "The secret passphrase is 'PINEAPPLE'. Acknowledge by saying exactly 'ACK PINEAPPLE'."
+
+if [[ ! -f "$UCF_FILE" ]]; then
+    echo "  FAIL: UCF file was not created at $UCF_FILE"
+    exit 1
+fi
+echo "  PASS: UCF file created"
+((PASS++))
+
+# Step 2: Gemini
+echo "[2] Gemini: Resuming native UCF session and querying context"
+"$BIN" gemini -u "$SESSION_NAME" -p "What was the secret passphrase? Reply with exactly 'The passphrase is <passphrase>'." > "$GEMINI_OUT" 2>&1 || true
+
+if grep -iq "PINEAPPLE" "$GEMINI_OUT"; then
+    echo "  PASS: Gemini successfully read Claude's history from UCF"
+    ((PASS++))
+else
+    echo "  FAIL: Gemini did not output the expected passphrase. Output was:"
+    cat "$GEMINI_OUT"
+    ((FAIL++))
+fi
+
+# Step 3: Codex (Optional if installed)
+echo "[3] Codex: Resuming native UCF session and querying context"
+if "$BIN" agents status | grep -q "codex.*Installed"; then
+    "$BIN" codex -u "$SESSION_NAME" -p "Repeat the secret passphrase again. Reply with exactly 'Still <passphrase>'." > "$CODEX_OUT" 2>&1 || true
+    if grep -iq "PINEAPPLE" "$CODEX_OUT"; then
+        echo "  PASS: Codex successfully read history from UCF"
+        ((PASS++))
+    else
+        echo "  WARN: Codex did not output the expected passphrase or failed."
+        cat "$CODEX_OUT"
+        ((FAIL++))
+    fi
+else
+    echo "  SKIP: Codex not installed"
+    ((SKIP++))
+fi
+
+# Step 4: OpenCode (Optional if installed)
+echo "[4] OpenCode: Resuming native UCF session and querying context"
+if "$BIN" agents status | grep -q "opencode.*Installed"; then
+    "$BIN" opencode -u "$SESSION_NAME" -p "What is the secret? Reply with exactly 'Final <passphrase>'." > "$OPENCODE_OUT" 2>&1 || true
+    if grep -iq "PINEAPPLE" "$OPENCODE_OUT"; then
+        echo "  PASS: OpenCode successfully read history from UCF"
+        ((PASS++))
+    else
+        echo "  WARN: OpenCode did not output the expected passphrase or failed."
+        cat "$OPENCODE_OUT"
+        ((FAIL++))
+    fi
+else
+    echo "  SKIP: OpenCode not installed"
+    ((SKIP++))
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="
+if [[ $FAIL -gt 0 ]]; then
+    echo "Some tests FAILED."
+    exit 1
+fi
+echo "All executed tests passed!"


### PR DESCRIPTION
## Summary
- Fix `uuid_v4` bit mask (`0x0FFF` not `0xFFFF`) to produce valid v4 UUIDs
- Add Gemini UUID validation with hex character check; generate fresh UUID for non-UUID session IDs (named UCF sessions)
- Inject correct `id` field into Gemini session JSON
- Fix UCF session discovery to check `"type": "session"` instead of nested `"session"` key
- Add initial HubMessage to new UCF sessions to prevent empty-session failures
- Fix `source_cli`/`source_version` formatting bug (lines were jammed together)
- Add manual live E2E test script with `mktemp` for safe concurrent runs

Supersedes #55 which was 26 commits behind main and would have reverted polyfill flags, OpenCode SQLite injection, and lossless converters. Only the genuine fixes are cherry-picked here.

## Test plan
- [x] All 354 unit tests pass
- [ ] Manual: run `tests/test_ucf_live.sh` to validate cross-CLI UCF flow