### PR TITLE
feat(docker): sandbox tests, local API access, and env file

### DIFF
--- a/docker/NETWORKING.md
+++ b/docker/NETWORKING.md
@@ -145,6 +145,24 @@ Safe configurations:
 
 The runc + multi-agent combination uses the default Docker bridge for internet (no LAN blocking, no gVisor) and the mesh network for inter-agent communication. This is a lower-security mode suitable for development.
 
+## Opening a Single LAN IP (Local API Access)
+
+If you need the container to reach a specific LAN host (e.g., a local OpenAI-compatible API server), use `allow-ip` to punch a single-host exception through the firewall:
+
+```bash
+sudo ./docker/sandbox-network.sh allow-ip 192.168.1.100   # open
+sudo ./docker/sandbox-network.sh revoke-ip 192.168.1.100  # close
+```
+
+This inserts an ACCEPT rule for that `/32` address *before* the DROP rules. All other private ranges remain blocked. The rule does not survive reboots.
+
+See [README.md](README.md#using-a-local-openai-compatible-api) for full setup instructions including the compose overlay and security guidance.
+
+| What's Opened | What's Still Blocked |
+|---------------|---------------------|
+| Only the specified IP (`/32`) | All other RFC 1918, link-local |
+| Only from sandbox containers | Host iptables unaffected |
+
 ## Troubleshooting
 
 ### Agent cannot reach another agent

--- a/docker/README.md
+++ b/docker/README.md
@@ -99,19 +99,84 @@ sudo ./docker/sandbox-network.sh status    # Check current state
 
 ## Authentication
 
-Generate a token on your host machine, then pass it to the container:
+Copy the example env file, fill in your keys, and docker compose will pick them up automatically:
 
 ```bash
-claude setup-token
-export CLAUDE_CODE_OAUTH_TOKEN=<your-token>
+cp docker/example.env docker/.env
+# Edit docker/.env with your keys
 ```
 
-| Agent | Environment Variable |
-|-------|---------------------|
-| Claude Code | `CLAUDE_CODE_OAUTH_TOKEN` |
-| Codex | `OPENAI_API_KEY` |
-| Gemini CLI | `GEMINI_API_KEY` |
-| OpenCode | *(uses configured provider)* |
+The `.env` file is gitignored — never commit real credentials.
+
+| Agent | Environment Variable | How to Get |
+|-------|---------------------|------------|
+| Claude Code | `CLAUDE_CODE_OAUTH_TOKEN` | `claude setup-token` |
+| Codex | `OPENAI_API_KEY` | platform.openai.com |
+| Gemini CLI | `GEMINI_API_KEY` | aistudio.google.com |
+| OpenCode | *(uses configured provider)* | Depends on backend |
+
+**Security note:** These keys are passed into a container where AI agents run with full code execution. Use scoped, rotatable keys with spending limits — not your personal all-access keys. See `docker/example.env` for detailed guidance.
+
+## Using a Local OpenAI-Compatible API
+
+If you run a local inference server (vLLM, Ollama, llama.cpp, TGI, etc.) and want the sandboxed container to reach it, you need to open a single IP through the firewall.
+
+### Step 1: Open the IP
+
+```bash
+# Allow containers to reach your local API server (e.g., on 192.168.1.100)
+sudo ./docker/sandbox-network.sh allow-ip 192.168.1.100
+```
+
+This inserts an ACCEPT rule *before* the DROP rules, so only that specific IP is reachable. All other LAN addresses remain blocked.
+
+### Step 2: Set the endpoint
+
+Add to your `docker/.env`:
+
+```bash
+LOCAL_API_BASE=http://192.168.1.100:8080/v1
+```
+
+### Step 3: Run with the local-api overlay
+
+```bash
+docker compose -f docker/docker-compose.yml \
+  -f docker/docker-compose.local-api.yml \
+  run --rm opencode
+```
+
+### Step 4: Revoke when done
+
+```bash
+sudo ./docker/sandbox-network.sh revoke-ip 192.168.1.100
+```
+
+> **Security warning:** Opening a LAN IP increases the attack surface. A compromised agent could send arbitrary requests to that endpoint or probe other services on the same host. Mitigations:
+>
+> - Run the local API in its own container or VM — not bare-metal alongside sensitive services
+> - Bind the API server to a single interface/port, not `0.0.0.0`
+> - Use API-key authentication even for local endpoints
+> - Monitor API logs for unexpected requests
+>
+> The firewall exception does **not** survive reboots. Re-run `allow-ip` after restart.
+
+## Verifying the Sandbox
+
+Run the integration tests to confirm gVisor and LAN isolation are working:
+
+```bash
+# Build the image first
+docker build -f docker/Dockerfile -t unleash .
+
+# Full test suite (requires sudo for iptables checks + container spawning)
+sudo ./tests/test_sandbox_network.sh
+
+# Quick mode (internet + DNS only, skips LAN probe)
+sudo ./tests/test_sandbox_network.sh quick
+```
+
+The tests verify: internet connectivity, DNS resolution, LAN blocking for all RFC 1918 ranges, gVisor syscall filtering, and that all 5 CLIs are installed.
 
 ## Docker Compose
 

--- a/docker/docker-compose.local-api.yml
+++ b/docker/docker-compose.local-api.yml
@@ -1,0 +1,34 @@
+# docker-compose.local-api.yml — Allow container access to a single local API endpoint
+#
+# Use case: Running a local OpenAI-compatible API (vLLM, Ollama, llama.cpp server,
+# text-generation-inference, etc.) and want the sandboxed container to reach it.
+#
+# Usage:
+#   1. Open the specific IP in the sandbox firewall:
+#      sudo ./docker/sandbox-network.sh allow-ip 192.168.1.100
+#
+#   2. Start with this overlay:
+#      docker compose -f docker/docker-compose.yml \
+#        -f docker/docker-compose.local-api.yml \
+#        run --rm opencode
+#
+# The container can now reach ONLY that IP on your LAN. All other private
+# ranges remain blocked.
+#
+# SECURITY WARNING:
+#   Opening a LAN IP increases the attack surface. A compromised agent could:
+#     - Send arbitrary requests to that API (prompt injection, data exfiltration)
+#     - Probe other services on that host (if the API host runs other things)
+#
+#   Mitigations:
+#     - Run the local API in its own container or VM (not bare-metal alongside
+#       sensitive services)
+#     - Bind the API to a single interface/port, not 0.0.0.0
+#     - Use API-key auth even for local endpoints
+#     - Monitor API logs for unexpected requests
+
+services:
+  unleash:
+    environment:
+      - LOCAL_API_BASE=${LOCAL_API_BASE:-}
+      - OPENAI_BASE_URL=${LOCAL_API_BASE:-}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -46,6 +46,9 @@ services:
     working_dir: /workspace
     volumes:
       - ${WORKSPACE_DIR:-.}:/workspace
+    env_file:
+      - path: .env
+        required: false
     environment:
       - ANTHROPIC_API_KEY
       - OPENAI_API_KEY

--- a/docker/example.env
+++ b/docker/example.env
@@ -1,0 +1,41 @@
+# unleash Docker — API Keys and Configuration
+#
+# Copy this file to .env and fill in your keys:
+#   cp docker/example.env docker/.env
+#
+# The .env file is gitignored. NEVER commit real credentials.
+#
+# SECURITY NOTE:
+#   These credentials are passed into a sandboxed container where AI agents
+#   run with full code execution permissions. Use keys that:
+#     - Have the minimum required permissions (read-only where possible)
+#     - Are scoped to a specific project or organization
+#     - You are prepared to rotate if compromised
+#     - Have spending limits / rate limits configured
+#
+#   Do NOT use your personal all-access API keys here.
+
+# ─── Claude Code (Anthropic) ────────────────────────────────
+# Option A: OAuth token (recommended — scoped, revocable)
+#   Generate with: claude setup-token
+CLAUDE_CODE_OAUTH_TOKEN=
+
+# Option B: API key (from console.anthropic.com)
+# ANTHROPIC_API_KEY=sk-ant-...
+
+# ─── Codex (OpenAI) ─────────────────────────────────────────
+OPENAI_API_KEY=
+
+# ─── Gemini CLI (Google) ────────────────────────────────────
+GEMINI_API_KEY=
+
+# ─── OpenCode ────────────────────────────────────────────────
+# OpenCode uses its own config file for provider settings.
+# If using a local OpenAI-compatible API, see docker/README.md
+# for instructions on opening a LAN IP through the firewall.
+
+# ─── Optional: Local API Endpoint ────────────────────────────
+# If you run a local OpenAI-compatible API (vLLM, Ollama, etc.),
+# set the endpoint URL here. You will also need to open the
+# specific IP:port in the sandbox firewall — see README.md.
+# LOCAL_API_BASE=http://192.168.1.100:8080/v1

--- a/docker/sandbox-network.sh
+++ b/docker/sandbox-network.sh
@@ -116,12 +116,64 @@ status() {
     fi
 }
 
+allow_ip() {
+    local ip="${1:-}"
+    if [[ -z "$ip" ]]; then
+        echo "Usage: $0 allow-ip <IP_ADDRESS>"
+        echo ""
+        echo "Opens a single LAN IP through the sandbox firewall so containers"
+        echo "can reach a local service (e.g., a local OpenAI-compatible API)."
+        echo ""
+        echo "Example: $0 allow-ip 192.168.1.100"
+        echo ""
+        echo "WARNING: This increases the attack surface. See docker/README.md"
+        echo "for security guidance."
+        exit 1
+    fi
+
+    # Validate it's actually a private IP
+    if ! echo "$ip" | grep -qE '^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.)'; then
+        echo "ERROR: $ip does not look like a private (RFC 1918) address."
+        echo "Only private IPs need firewall exceptions — public IPs are already reachable."
+        exit 1
+    fi
+
+    # Insert ACCEPT rule BEFORE the DROP rules in DOCKER-USER
+    if iptables -C DOCKER-USER -s "${SUBNET}" -d "${ip}/32" -j ACCEPT 2>/dev/null; then
+        echo "Rule already exists: ACCEPT ${SUBNET} -> ${ip}"
+    else
+        iptables -I DOCKER-USER -s "${SUBNET}" -d "${ip}/32" -j ACCEPT
+        echo "Added firewall exception: containers can now reach ${ip}"
+        echo ""
+        echo "To revoke: sudo $0 revoke-ip ${ip}"
+        echo ""
+        echo "NOTE: This rule does NOT survive reboots. Re-run after restart."
+    fi
+}
+
+revoke_ip() {
+    local ip="${1:-}"
+    if [[ -z "$ip" ]]; then
+        echo "Usage: $0 revoke-ip <IP_ADDRESS>"
+        exit 1
+    fi
+
+    if iptables -C DOCKER-USER -s "${SUBNET}" -d "${ip}/32" -j ACCEPT 2>/dev/null; then
+        iptables -D DOCKER-USER -s "${SUBNET}" -d "${ip}/32" -j ACCEPT
+        echo "Revoked firewall exception for ${ip}"
+    else
+        echo "No exception found for ${ip}"
+    fi
+}
+
 case "${1:-status}" in
-    setup)    setup ;;
-    teardown) teardown ;;
-    status)   status ;;
+    setup)      setup ;;
+    teardown)   teardown ;;
+    status)     status ;;
+    allow-ip)   allow_ip "${2:-}" ;;
+    revoke-ip)  revoke_ip "${2:-}" ;;
     *)
-        echo "Usage: $0 {setup|teardown|status}"
+        echo "Usage: $0 {setup|teardown|status|allow-ip <IP>|revoke-ip <IP>}"
         exit 1
         ;;
 esac

--- a/tests/test_sandbox_network.sh
+++ b/tests/test_sandbox_network.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Sandbox Network Integration Tests
+#
+# Verifies that gVisor + LAN isolation is working correctly:
+#   1. Internet connectivity (can reach external APIs)
+#   2. LAN blocking (cannot reach private RFC 1918 ranges)
+#   3. DNS resolution works inside the container
+#   4. Inter-container communication is blocked (icc=false)
+#
+# Prerequisites:
+#   - Docker with gVisor (runsc) installed
+#   - sandbox-network.sh setup has been run
+#   - unleash image built: docker build -f docker/Dockerfile -t unleash .
+#
+# Usage:
+#   sudo ./tests/test_sandbox_network.sh          # full suite
+#   sudo ./tests/test_sandbox_network.sh quick     # internet + DNS only (no LAN probe)
+
+set -euo pipefail
+
+IMAGE="unleash:latest"
+NETWORK="unleash-sandbox"
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { echo "  PASS: $1"; ((PASS++)); }
+fail() { echo "  FAIL: $1"; ((FAIL++)); }
+skip() { echo "  SKIP: $1"; ((SKIP++)); }
+
+# Helper: run a command inside a fresh sandbox container, return exit code
+sandbox_run() {
+    docker run --rm --network "${NETWORK}" --runtime runsc \
+        --entrypoint /bin/bash "${IMAGE}" -c "$1" 2>&1
+}
+
+sandbox_run_rc() {
+    docker run --rm --network "${NETWORK}" --runtime runsc \
+        --entrypoint /bin/bash "${IMAGE}" -c "$1" >/dev/null 2>&1
+    return $?
+}
+
+echo "=== Sandbox Network Integration Tests ==="
+echo ""
+
+# ─── Preflight ───────────────────────────────────────────────
+echo "[0] Preflight checks"
+
+if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+    echo "  ERROR: Image '${IMAGE}' not found. Build it first:"
+    echo "    docker build -f docker/Dockerfile -t unleash ."
+    exit 1
+fi
+pass "Image exists"
+
+if ! docker network inspect "${NETWORK}" >/dev/null 2>&1; then
+    echo "  ERROR: Network '${NETWORK}' not found. Run:"
+    echo "    sudo ./docker/sandbox-network.sh setup"
+    exit 1
+fi
+pass "Sandbox network exists"
+
+if ! command -v runsc >/dev/null 2>&1; then
+    echo "  WARNING: gVisor (runsc) not found on host. Tests will use it inside Docker."
+fi
+
+# Check iptables rules are in place
+if iptables -L DOCKER-USER -n 2>/dev/null | grep -q "172.30.0.0/16"; then
+    pass "iptables LAN-blocking rules present"
+else
+    echo "  WARNING: iptables rules may be missing (need sudo or rules not set up)"
+    echo "  Run: sudo ./docker/sandbox-network.sh setup"
+    skip "iptables rules check (insufficient privileges or not set up)"
+fi
+
+echo ""
+
+# ─── Test 1: Internet Connectivity ──────────────────────────
+echo "[1] Internet connectivity"
+
+# Test HTTPS to a reliable endpoint
+INTERNET_OUT=$(sandbox_run "curl -sf --max-time 10 -o /dev/null -w '%{http_code}' https://api.anthropic.com/ 2>/dev/null || echo 'FAILED'")
+if [[ "$INTERNET_OUT" == *"FAILED"* ]]; then
+    fail "Cannot reach api.anthropic.com (HTTPS)"
+else
+    pass "HTTPS to api.anthropic.com (HTTP $INTERNET_OUT)"
+fi
+
+# Test DNS resolution
+DNS_OUT=$(sandbox_run "nslookup api.openai.com 2>/dev/null | grep -c 'Address' || echo 0")
+if [[ "$DNS_OUT" -ge 2 ]]; then
+    pass "DNS resolution works (api.openai.com)"
+else
+    # nslookup might not be installed; try getent
+    DNS_OUT2=$(sandbox_run "getent hosts api.openai.com 2>/dev/null | head -1 || echo ''")
+    if [[ -n "$DNS_OUT2" ]]; then
+        pass "DNS resolution works (api.openai.com via getent)"
+    else
+        fail "DNS resolution failed for api.openai.com"
+    fi
+fi
+
+# Test npm registry (package installs need this)
+NPM_OUT=$(sandbox_run "curl -sf --max-time 10 -o /dev/null -w '%{http_code}' https://registry.npmjs.org/ 2>/dev/null || echo 'FAILED'")
+if [[ "$NPM_OUT" == *"FAILED"* ]]; then
+    fail "Cannot reach registry.npmjs.org"
+else
+    pass "npm registry reachable (HTTP $NPM_OUT)"
+fi
+
+echo ""
+
+# ─── Test 2: LAN Blocking ───────────────────────────────────
+echo "[2] LAN isolation (RFC 1918 ranges blocked)"
+
+if [[ "${1:-full}" == "quick" ]]; then
+    skip "LAN tests (quick mode)"
+    echo ""
+else
+    # These should all time out / be unreachable.
+    # We use short timeouts since they should fail fast.
+
+    # 192.168.x.x (most common home LAN)
+    if sandbox_run_rc "curl -sf --max-time 3 http://192.168.1.1/ >/dev/null 2>&1"; then
+        fail "192.168.1.1 is REACHABLE (should be blocked!)"
+    else
+        pass "192.168.1.1 blocked"
+    fi
+
+    # 10.x.x.x
+    if sandbox_run_rc "curl -sf --max-time 3 http://10.0.0.1/ >/dev/null 2>&1"; then
+        fail "10.0.0.1 is REACHABLE (should be blocked!)"
+    else
+        pass "10.0.0.1 blocked"
+    fi
+
+    # 172.16.x.x
+    if sandbox_run_rc "curl -sf --max-time 3 http://172.16.0.1/ >/dev/null 2>&1"; then
+        fail "172.16.0.1 is REACHABLE (should be blocked!)"
+    else
+        pass "172.16.0.1 blocked"
+    fi
+
+    # Link-local
+    if sandbox_run_rc "curl -sf --max-time 3 http://169.254.169.254/ >/dev/null 2>&1"; then
+        fail "169.254.169.254 (link-local/metadata) is REACHABLE (should be blocked!)"
+    else
+        pass "169.254.169.254 (link-local) blocked"
+    fi
+
+    # Docker host gateway (common at 172.30.0.1 on our subnet)
+    if sandbox_run_rc "curl -sf --max-time 3 http://172.30.0.1/ >/dev/null 2>&1"; then
+        fail "172.30.0.1 (gateway) is REACHABLE (should be blocked by icc rules!)"
+    else
+        pass "172.30.0.1 (gateway) blocked"
+    fi
+
+    echo ""
+fi
+
+# ─── Test 3: gVisor Runtime ─────────────────────────────────
+echo "[3] gVisor runtime verification"
+
+DMESG_OUT=$(sandbox_run "dmesg 2>&1 || echo 'BLOCKED'")
+if [[ "$DMESG_OUT" == *"BLOCKED"* ]] || [[ "$DMESG_OUT" == *"Operation not permitted"* ]] || [[ "$DMESG_OUT" == *"gvisor"* ]]; then
+    pass "gVisor syscall filtering active (dmesg restricted)"
+else
+    fail "dmesg accessible — may not be running under gVisor"
+fi
+
+# gVisor blocks /proc/kcore access
+KCORE_OUT=$(sandbox_run "cat /proc/kcore 2>&1 || echo 'BLOCKED'")
+if [[ "$KCORE_OUT" == *"BLOCKED"* ]] || [[ "$KCORE_OUT" == *"Permission denied"* ]] || [[ "$KCORE_OUT" == *"No such file"* ]]; then
+    pass "/proc/kcore inaccessible (gVisor kernel isolation)"
+else
+    fail "/proc/kcore accessible — gVisor may not be active"
+fi
+
+echo ""
+
+# ─── Test 4: Agent CLIs Available ────────────────────────────
+echo "[4] Agent CLIs installed and accessible"
+
+for cli in claude codex gemini opencode unleash; do
+    VER=$(sandbox_run "command -v ${cli} >/dev/null 2>&1 && ${cli} --version 2>&1 | head -1 || echo 'NOT FOUND'")
+    if [[ "$VER" == *"NOT FOUND"* ]]; then
+        fail "${cli} not found in container"
+    else
+        pass "${cli} installed (${VER})"
+    fi
+done
+
+echo ""
+
+# ─── Results ─────────────────────────────────────────────────
+echo "=== Results: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped ==="
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo "FAILURES DETECTED. Review the output above."
+    exit 1
+fi
+echo "All sandbox tests passed!"


### PR DESCRIPTION
## Summary
- Add `tests/test_sandbox_network.sh` — integration tests verifying gVisor runtime, internet connectivity, DNS resolution, LAN blocking (all RFC 1918 ranges), and CLI availability
- Add `allow-ip` / `revoke-ip` commands to `sandbox-network.sh` for opening a single LAN IP (e.g., local vLLM/Ollama endpoint) through the firewall
- Add `docker-compose.local-api.yml` overlay for local OpenAI-compatible API access
- Add `docker/example.env` with security guidance — replaces bare env var passing
- Update README with local API setup instructions + security warnings
- Update NETWORKING.md with allow-ip docs

## Test plan
- [ ] Build image: `docker build -f docker/Dockerfile -t unleash .`
- [ ] Run sandbox tests: `sudo ./tests/test_sandbox_network.sh`
- [ ] Verify `allow-ip` / `revoke-ip` work: `sudo ./docker/sandbox-network.sh allow-ip 192.168.1.1` then check `iptables -L DOCKER-USER -n`
- [ ] Verify `docker compose` picks up `docker/.env` when present
- [ ] ShellCheck passes on all scripts

Addresses #50