### PR TITLE
feat: unleash sandbox subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,13 +249,23 @@ For non-interactive installs (CI, scripts):
 curl -fsSL unleash.software/install | bash -s -- --boring
 ```
 
-### Docker
+### Docker (Sandboxed)
+
+```bash
+# One-time setup (installs gVisor, network isolation, pulls image)
+sudo unleash sandbox setup
+
+# Run an agent
+unleash sandbox run claude
+```
+
+Or run the image directly:
 
 ```bash
 docker run -it --rm -e ANTHROPIC_API_KEY marksverdhei/unleash
 ```
 
-All 4 agent CLIs are pre-installed. Pass API keys as environment variables. See the [Docker + gVisor sandbox guide](docs/docker.md) for hardened setups with LAN isolation.
+All 4 agent CLIs are pre-installed. See the [Docker + gVisor sandbox guide](docs/docker.md) for hardened setups with LAN isolation and named sandboxes.
 
 ### Build from source
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -128,6 +128,16 @@ ENV AGENT_UNLEASH=1
 ENV HOME=/home/unleash
 ENV PATH="/home/unleash/.local/bin:/home/unleash/.npm-global/bin:${PATH}"
 ENV NPM_CONFIG_PREFIX=/home/unleash/.npm-global
+ENV SANDBOX_NAME=sandbox
+ENV STARSHIP_CONFIG=/home/unleash/.config/starship.toml
+
+# -- Install starship prompt --
+RUN curl -fsSL https://starship.rs/install.sh | sh -s -- --yes
+
+# -- Configure starship for sandbox shell --
+COPY docker/starship.toml /home/unleash/.config/starship.toml
+RUN chown unleash:unleash /home/unleash/.config/starship.toml \
+    && echo 'eval "$(starship init bash)"' >> /home/unleash/.bashrc
 
 # Switch to non-root user
 USER unleash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,11 +75,24 @@ RUN apt-get update \
        openssh-client \
        tmux \
        jq \
+       sudo \
+       iproute2 \
+       iputils-ping \
+       dnsutils \
+       net-tools \
+       wget \
+       vim-tiny \
+       less \
+       htop \
+       procps \
+       file \
+       unzip \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user for sandboxing
+# Create non-root user for sandboxing (with passwordless sudo)
 RUN useradd -m -s /bin/bash unleash \
-    && mkdir -p /home/unleash/.local/bin /home/unleash/.npm-global
+    && mkdir -p /home/unleash/.local/bin /home/unleash/.npm-global \
+    && echo 'unleash ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/unleash
 
 # -- Install unleash binary from builder stage --
 COPY --from=rust-builder /build/target/release/unleash /usr/local/bin/unleash

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,18 +14,28 @@ One image, all agents ready to go.
 The recommended setup uses [gVisor](https://gvisor.dev/) for syscall-level isolation and a firewall that blocks LAN access while allowing internet.
 
 ```bash
-# 1. Build the image
-docker build -f docker/Dockerfile -t unleash .
+# 1. One-time setup: installs gVisor, creates network, pulls image, sets up .env
+sudo unleash sandbox setup
 
-# 2. One-time: install gVisor and create sandbox network
-sudo runsc install && sudo systemctl restart docker
-sudo ./docker/sandbox-network.sh setup
+# 2. Run Claude Code (sandboxed, internet-only, no LAN access)
+unleash sandbox run claude
 
-# 3. Run Claude Code (sandboxed, internet-only, no LAN access)
-docker compose -f docker/docker-compose.yml run --rm claude
+# Or open a bash shell
+unleash sandbox run
 ```
 
 That's it. The container has full internet access (API calls, npm, git) but cannot reach your local network.
+
+### Named Sandboxes
+
+Run multiple independent sandboxes with `--name`:
+
+```bash
+unleash sandbox run --name research claude
+unleash sandbox run --name testing bash
+```
+
+Each named sandbox gets its own hostname and starship prompt showing the sandbox name.
 
 ### Without gVisor
 
@@ -124,11 +134,14 @@ If you run a local inference server (vLLM, Ollama, llama.cpp, TGI, etc.) and wan
 ### Step 1: Open the IP (port-restricted)
 
 ```bash
-# Allow containers to reach your local API server on a specific port only (recommended)
-sudo ./docker/sandbox-network.sh allow-ip 192.168.1.100:8080
+# Via unleash sandbox subcommand (recommended)
+sudo unleash sandbox allow-ip 192.168.1.100:8080
 
 # Or open all ports on that IP (less secure)
-sudo ./docker/sandbox-network.sh allow-ip 192.168.1.100
+sudo unleash sandbox allow-ip 192.168.1.100
+
+# Or directly via the script
+sudo ./docker/sandbox-network.sh allow-ip 192.168.1.100:8080
 ```
 
 This inserts an ACCEPT rule *before* the DROP rules. When a port is specified, only TCP traffic to that port is allowed. All other LAN addresses remain blocked.
@@ -152,7 +165,7 @@ docker compose -f docker/docker-compose.yml \
 ### Step 4: Revoke when done
 
 ```bash
-sudo ./docker/sandbox-network.sh revoke-ip 192.168.1.100:8080
+sudo unleash sandbox revoke-ip 192.168.1.100:8080
 ```
 
 > **Security warning:** Opening a LAN IP increases the attack surface. A compromised agent could send arbitrary requests to that endpoint or probe other services on the same host. Mitigations:

--- a/docker/README.md
+++ b/docker/README.md
@@ -121,14 +121,17 @@ The `.env` file is gitignored — never commit real credentials.
 
 If you run a local inference server (vLLM, Ollama, llama.cpp, TGI, etc.) and want the sandboxed container to reach it, you need to open a single IP through the firewall.
 
-### Step 1: Open the IP
+### Step 1: Open the IP (port-restricted)
 
 ```bash
-# Allow containers to reach your local API server (e.g., on 192.168.1.100)
+# Allow containers to reach your local API server on a specific port only (recommended)
+sudo ./docker/sandbox-network.sh allow-ip 192.168.1.100:8080
+
+# Or open all ports on that IP (less secure)
 sudo ./docker/sandbox-network.sh allow-ip 192.168.1.100
 ```
 
-This inserts an ACCEPT rule *before* the DROP rules, so only that specific IP is reachable. All other LAN addresses remain blocked.
+This inserts an ACCEPT rule *before* the DROP rules. When a port is specified, only TCP traffic to that port is allowed. All other LAN addresses remain blocked.
 
 ### Step 2: Set the endpoint
 
@@ -149,7 +152,7 @@ docker compose -f docker/docker-compose.yml \
 ### Step 4: Revoke when done
 
 ```bash
-sudo ./docker/sandbox-network.sh revoke-ip 192.168.1.100
+sudo ./docker/sandbox-network.sh revoke-ip 192.168.1.100:8080
 ```
 
 > **Security warning:** Opening a LAN IP increases the attack surface. A compromised agent could send arbitrary requests to that endpoint or probe other services on the same host. Mitigations:

--- a/docker/sandbox-network.sh
+++ b/docker/sandbox-network.sh
@@ -117,18 +117,29 @@ status() {
 }
 
 allow_ip() {
-    local ip="${1:-}"
-    if [[ -z "$ip" ]]; then
-        echo "Usage: $0 allow-ip <IP_ADDRESS>"
+    local input="${1:-}"
+    if [[ -z "$input" ]]; then
+        echo "Usage: $0 allow-ip <IP_ADDRESS>[:<PORT>]"
         echo ""
-        echo "Opens a single LAN IP through the sandbox firewall so containers"
-        echo "can reach a local service (e.g., a local OpenAI-compatible API)."
+        echo "Opens a single LAN IP (optionally restricted to a specific port)"
+        echo "through the sandbox firewall so containers can reach a local service."
         echo ""
-        echo "Example: $0 allow-ip 192.168.1.100"
+        echo "Examples:"
+        echo "  $0 allow-ip 192.168.1.100        # open all ports on that IP"
+        echo "  $0 allow-ip 192.168.1.100:8080   # open only port 8080"
         echo ""
         echo "WARNING: This increases the attack surface. See docker/README.md"
-        echo "for security guidance."
+        echo "for security guidance. Using a port restriction is strongly recommended."
         exit 1
+    fi
+
+    # Parse IP and optional port
+    local ip port=""
+    if [[ "$input" == *:* ]]; then
+        ip="${input%%:*}"
+        port="${input##*:}"
+    else
+        ip="$input"
     fi
 
     # Validate it's actually a private IP
@@ -138,31 +149,64 @@ allow_ip() {
         exit 1
     fi
 
+    # Validate port if specified
+    if [[ -n "$port" ]] && ! [[ "$port" =~ ^[0-9]+$ && "$port" -ge 1 && "$port" -le 65535 ]]; then
+        echo "ERROR: Invalid port '$port'. Must be 1-65535."
+        exit 1
+    fi
+
+    # Build iptables rule args
+    local rule_args=(-s "${SUBNET}" -d "${ip}/32")
+    if [[ -n "$port" ]]; then
+        rule_args+=(-p tcp --dport "$port")
+    fi
+    rule_args+=(-j ACCEPT)
+
     # Insert ACCEPT rule BEFORE the DROP rules in DOCKER-USER
-    if iptables -C DOCKER-USER -s "${SUBNET}" -d "${ip}/32" -j ACCEPT 2>/dev/null; then
-        echo "Rule already exists: ACCEPT ${SUBNET} -> ${ip}"
+    if iptables -C DOCKER-USER "${rule_args[@]}" 2>/dev/null; then
+        echo "Rule already exists: ACCEPT ${SUBNET} -> ${input}"
     else
-        iptables -I DOCKER-USER -s "${SUBNET}" -d "${ip}/32" -j ACCEPT
-        echo "Added firewall exception: containers can now reach ${ip}"
+        iptables -I DOCKER-USER "${rule_args[@]}"
+        if [[ -n "$port" ]]; then
+            echo "Added firewall exception: containers can reach ${ip} on port ${port} only"
+        else
+            echo "Added firewall exception: containers can reach ${ip} on ALL ports"
+            echo "  (consider restricting to a specific port: $0 allow-ip ${ip}:<PORT>)"
+        fi
         echo ""
-        echo "To revoke: sudo $0 revoke-ip ${ip}"
+        echo "To revoke: sudo $0 revoke-ip ${input}"
         echo ""
         echo "NOTE: This rule does NOT survive reboots. Re-run after restart."
     fi
 }
 
 revoke_ip() {
-    local ip="${1:-}"
-    if [[ -z "$ip" ]]; then
-        echo "Usage: $0 revoke-ip <IP_ADDRESS>"
+    local input="${1:-}"
+    if [[ -z "$input" ]]; then
+        echo "Usage: $0 revoke-ip <IP_ADDRESS>[:<PORT>]"
         exit 1
     fi
 
-    if iptables -C DOCKER-USER -s "${SUBNET}" -d "${ip}/32" -j ACCEPT 2>/dev/null; then
-        iptables -D DOCKER-USER -s "${SUBNET}" -d "${ip}/32" -j ACCEPT
-        echo "Revoked firewall exception for ${ip}"
+    # Parse IP and optional port
+    local ip port=""
+    if [[ "$input" == *:* ]]; then
+        ip="${input%%:*}"
+        port="${input##*:}"
     else
-        echo "No exception found for ${ip}"
+        ip="$input"
+    fi
+
+    local rule_args=(-s "${SUBNET}" -d "${ip}/32")
+    if [[ -n "$port" ]]; then
+        rule_args+=(-p tcp --dport "$port")
+    fi
+    rule_args+=(-j ACCEPT)
+
+    if iptables -C DOCKER-USER "${rule_args[@]}" 2>/dev/null; then
+        iptables -D DOCKER-USER "${rule_args[@]}"
+        echo "Revoked firewall exception for ${input}"
+    else
+        echo "No exception found for ${input}"
     fi
 }
 

--- a/docker/starship.toml
+++ b/docker/starship.toml
@@ -1,0 +1,42 @@
+# Starship prompt for unleash sandbox containers
+# Shows sandbox name, directory, git info, and common language versions
+
+format = """[sandbox:${env_var.SANDBOX_NAME}](bold cyan) $directory$git_branch$git_status$nodejs$python$rust$golang
+$character"""
+
+[env_var.SANDBOX_NAME]
+format = "$env_value"
+default = "sandbox"
+
+[directory]
+truncation_length = 3
+style = "bold yellow"
+read_only = " ro"
+
+[character]
+success_symbol = "[>](bold green)"
+error_symbol = "[>](bold red)"
+
+[git_branch]
+format = "on [$symbol$branch]($style) "
+symbol = ""
+
+[git_status]
+format = '([$all_status$ahead_behind]($style) )'
+
+[nodejs]
+format = "[$symbol($version)]($style) "
+symbol = "node "
+detect_files = ["package.json"]
+
+[python]
+format = "[$symbol($version)]($style) "
+symbol = "py "
+
+[rust]
+format = "[$symbol($version)]($style) "
+symbol = "rs "
+
+[golang]
+format = "[$symbol($version)]($style) "
+symbol = "go "

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,23 +1,50 @@
 # Docker Setup
 
-Run agents in sandboxed containers with network isolation. Three tiers
-depending on your needs.
+Run agents in sandboxed containers with network isolation.
 
-## Quick Start
+## Quick Start (via `unleash sandbox`)
+
+The `unleash sandbox` subcommand wraps Docker + gVisor + network isolation into one workflow:
 
 ```bash
-# Build the image
-docker build -f docker/Dockerfile -t unleash .
+# One-time setup: installs gVisor, creates network, pulls image, sets up .env
+sudo unleash sandbox setup
 
-# Run a single sandboxed agent
-docker compose -f docker/docker-compose.yml run --rm claude
+# Run Claude Code in the sandbox
+unleash sandbox run claude
+
+# Open a bash shell in the sandbox
+unleash sandbox run
+
+# Check sandbox health
+unleash sandbox status
 ```
 
-## Tiers
+### Named Sandboxes
 
-### 1. Single Agent (Sandboxed)
+Run multiple independent sandboxes with `--name`:
 
-One agent in an isolated container with network filtering.
+```bash
+unleash sandbox run --name research claude
+unleash sandbox run --name testing bash
+```
+
+Each named sandbox gets its own hostname and can run any agent.
+
+### Local API Access
+
+To reach a local inference server (vLLM, Ollama, llama.cpp) from the sandbox:
+
+```bash
+sudo unleash sandbox allow-ip 192.168.1.100:8080   # port-restricted (recommended)
+sudo unleash sandbox revoke-ip 192.168.1.100:8080   # close when done
+```
+
+## Advanced: Direct Docker Compose
+
+For more control, use Docker Compose directly:
+
+### Single Agent
 
 ```bash
 docker compose -f docker/docker-compose.yml run --rm claude

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -635,6 +635,18 @@ pub enum Commands {
         verify: bool,
     },
 
+    /// Run agents in a sandboxed Docker container with gVisor + LAN isolation
+    ///
+    /// Examples:
+    ///   unleash sandbox setup          # One-time: install gVisor, create network, build image
+    ///   unleash sandbox claude          # Run Claude Code in the sandbox
+    ///   unleash sandbox status          # Check sandbox health
+    ///   unleash sandbox allow-ip X      # Open a LAN IP for local API access
+    Sandbox {
+        #[command(subcommand)]
+        action: crate::sandbox::SandboxAction,
+    },
+
     /// Run a profile by name (catches any unknown subcommand as a profile name)
     #[command(external_subcommand)]
     Profile(Vec<String>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod json_output;
 mod launcher;
 pub mod pixel_art;
 mod polyfill;
+mod sandbox;
 mod progress;
 #[cfg(feature = "tui")]
 mod text_input;
@@ -412,6 +413,7 @@ pub(crate) fn is_known_subcommand(first_arg: &str) -> bool {
             | "uninstall"
             | "sessions"
             | "convert"
+            | "sandbox"
             | "help"
     )
 }
@@ -1087,6 +1089,9 @@ pub fn run() -> io::Result<()> {
                 .map_err(|e| io::Error::other(e.to_string()))?;
             Ok(())
         }
+        Some(Commands::Sandbox { action }) => {
+            sandbox::handle_sandbox(&action)
+        }
         None => {
             #[cfg(feature = "tui")]
             return tui::run();
@@ -1202,6 +1207,7 @@ mod tests {
             "uninstall",
             "sessions",
             "convert",
+            "sandbox",
             "help",
         ] {
             assert!(

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -413,7 +413,7 @@ pub fn run_status(docker_dir: &Path) -> io::Result<()> {
     Ok(())
 }
 
-pub fn run_agent(docker_dir: &Path, agent: &str, extra_args: &[String]) -> io::Result<()> {
+pub fn run_agent(docker_dir: &Path, agent: &str, name: &str, extra_args: &[String]) -> io::Result<()> {
     // Validate agent name
     let valid_agents = ["claude", "codex", "gemini", "opencode", "bash", "unleash"];
     if !valid_agents.contains(&agent) {
@@ -468,13 +468,15 @@ pub fn run_agent(docker_dir: &Path, agent: &str, extra_args: &[String]) -> io::R
             cmd.args(["-f", local_api_compose.to_str().unwrap()]);
         }
 
-        cmd.args(["run", "--rm", agent]);
+        cmd.args(["run", "--rm", "-e", &format!("SANDBOX_NAME={}", name), "--hostname", name, agent]);
     } else {
         // Direct docker run (no compose files available — e.g., installed via binary only)
         cmd.args([
             "run", "--rm", "-it",
             "--runtime", "runsc",
             "--network", "unleash-sandbox",
+            "--hostname", name,
+            "-e", &format!("SANDBOX_NAME={}", name),
             "-v", &format!("{}:/workspace", std::env::current_dir()
                 .map(|p| p.to_string_lossy().to_string())
                 .unwrap_or_else(|_| ".".to_string())),
@@ -581,11 +583,8 @@ pub fn handle_sandbox(action: &SandboxAction) -> io::Result<()> {
         SandboxAction::Teardown => run_teardown(&docker_dir),
         SandboxAction::AllowIp { ip } => run_allow_ip(&docker_dir, ip),
         SandboxAction::RevokeIp { ip } => run_revoke_ip(&docker_dir, ip),
-        SandboxAction::Run(args) => {
-            let agent = args.first().ok_or_else(|| {
-                io::Error::other("Usage: unleash sandbox <agent> [args...]\n  Agents: claude, codex, gemini, opencode, bash")
-            })?;
-            run_agent(&docker_dir, agent, &args[1..])
+        SandboxAction::Run { name, agent, args } => {
+            run_agent(&docker_dir, agent, name, args.as_slice())
         }
     }
 }
@@ -620,7 +619,21 @@ pub enum SandboxAction {
         ip: String,
     },
 
-    /// Run an agent in the sandbox (e.g., `unleash sandbox claude`)
-    #[command(external_subcommand)]
-    Run(Vec<String>),
+    /// Run an agent in the sandbox (e.g., `unleash sandbox run claude`)
+    ///
+    /// Without an agent argument, opens a bash shell.
+    Run {
+        /// Sandbox name (used as hostname; allows multiple sandboxes)
+        #[arg(long, default_value = "sandbox")]
+        name: String,
+
+        /// Agent to run: claude, codex, gemini, opencode, bash, unleash
+        /// Defaults to bash if omitted.
+        #[arg(default_value = "bash")]
+        agent: String,
+
+        /// Extra arguments passed to the agent
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -2,7 +2,7 @@
 //!
 //! Wraps Docker + gVisor + LAN isolation into a seamless experience:
 //!   - `unleash sandbox setup`     — install gVisor, create network, set iptables
-//!   - `unleash sandbox <agent>`   — run an agent in the sandbox
+//!   - `unleash sandbox run [agent]` — run an agent (or bash shell) in the sandbox
 //!   - `unleash sandbox status`    — health check
 //!   - `unleash sandbox teardown`  — clean up
 //!   - `unleash sandbox allow-ip`  — open a LAN IP for local API access
@@ -45,6 +45,11 @@ fn find_docker_dir() -> Option<PathBuf> {
 
 fn sandbox_network_script(docker_dir: &Path) -> PathBuf {
     docker_dir.join("sandbox-network.sh")
+}
+
+/// Convert a Path to a string, lossy but safe (no panics on non-UTF8).
+fn path_str(p: &Path) -> String {
+    p.to_string_lossy().into_owned()
 }
 
 fn check_command_exists(cmd: &str) -> bool {
@@ -237,7 +242,7 @@ pub fn run_setup(docker_dir: &Path) -> io::Result<()> {
     print!("  Sandbox network... ");
     let script = sandbox_network_script(docker_dir);
     if script.exists() {
-        let ok = run_command("bash", &[script.to_str().unwrap(), "setup"])?;
+        let ok = run_command("bash", &[&path_str(&script), "setup"])?;
         if ok {
             println!("\x1b[32m✓\x1b[0m");
         } else {
@@ -273,7 +278,7 @@ pub fn run_setup(docker_dir: &Path) -> io::Result<()> {
                 let ok = run_command("docker", &[
                     "build",
                     "-f",
-                    dockerfile.to_str().unwrap(),
+                    &path_str(&dockerfile),
                     "-t",
                     &full_image,
                     &context,
@@ -309,7 +314,8 @@ pub fn run_setup(docker_dir: &Path) -> io::Result<()> {
     }
 
     println!("\n\x1b[32m=== Sandbox ready! ===\x1b[0m");
-    println!("  Run an agent:  unleash sandbox claude");
+    println!("  Run an agent:  unleash sandbox run claude");
+    println!("  Open a shell:  unleash sandbox run");
     println!("  Check status:  unleash sandbox status");
     Ok(())
 }
@@ -413,7 +419,24 @@ pub fn run_status(docker_dir: &Path) -> io::Result<()> {
     Ok(())
 }
 
+fn validate_sandbox_name(name: &str) -> io::Result<()> {
+    // RFC 1123 hostname: alphanumeric + hyphens, max 63 chars, no leading/trailing hyphen
+    if name.is_empty() || name.len() > 63 {
+        return Err(io::Error::other("sandbox name must be 1-63 characters"));
+    }
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+        return Err(io::Error::other("sandbox name must contain only alphanumeric characters and hyphens"));
+    }
+    if name.starts_with('-') || name.ends_with('-') {
+        return Err(io::Error::other("sandbox name must not start or end with a hyphen"));
+    }
+    Ok(())
+}
+
 pub fn run_agent(docker_dir: &Path, agent: &str, name: &str, extra_args: &[String]) -> io::Result<()> {
+    // Validate sandbox name (used as Docker hostname, must be RFC 1123 compliant)
+    validate_sandbox_name(name)?;
+
     // Validate agent name
     let valid_agents = ["claude", "codex", "gemini", "opencode", "bash", "unleash"];
     if !valid_agents.contains(&agent) {
@@ -460,12 +483,12 @@ pub fn run_agent(docker_dir: &Path, agent: &str, name: &str, extra_args: &[Strin
     let mut cmd = Command::new("docker");
 
     if use_compose {
-        cmd.args(["compose", "-f", compose_file.to_str().unwrap()]);
+        cmd.args(["compose", "-f", &path_str(&compose_file)]);
 
         // Check for local-api overlay
         let local_api_compose = docker_dir.join("docker-compose.local-api.yml");
         if std::env::var("LOCAL_API_BASE").is_ok() && local_api_compose.exists() {
-            cmd.args(["-f", local_api_compose.to_str().unwrap()]);
+            cmd.args(["-f", &path_str(&local_api_compose)]);
         }
 
         cmd.args(["run", "--rm", "-e", &format!("SANDBOX_NAME={}", name), "--hostname", name, agent]);
@@ -497,7 +520,7 @@ pub fn run_agent(docker_dir: &Path, agent: &str, name: &str, extra_args: &[Strin
         // Pass through .env file if present
         let dotenv = docker_dir.join(".env");
         if dotenv.exists() {
-            cmd.args(["--env-file", dotenv.to_str().unwrap()]);
+            cmd.args(["--env-file", &path_str(&dotenv)]);
         }
 
         cmd.args([&img, agent]);
@@ -529,7 +552,7 @@ pub fn run_teardown(docker_dir: &Path) -> io::Result<()> {
 
     let script = sandbox_network_script(docker_dir);
     if script.exists() {
-        run_command("bash", &[script.to_str().unwrap(), "teardown"])?;
+        run_command("bash", &[&path_str(&script), "teardown"])?;
     }
 
     println!("\n\x1b[32mTeardown complete.\x1b[0m");
@@ -545,7 +568,7 @@ pub fn run_allow_ip(docker_dir: &Path, ip: &str) -> io::Result<()> {
         return Err(io::Error::other("script not found"));
     }
 
-    let ok = run_command("bash", &[script.to_str().unwrap(), "allow-ip", ip])?;
+    let ok = run_command("bash", &[&path_str(&script), "allow-ip", ip])?;
     if !ok {
         return Err(io::Error::other("allow-ip failed"));
     }
@@ -561,7 +584,7 @@ pub fn run_revoke_ip(docker_dir: &Path, ip: &str) -> io::Result<()> {
         return Err(io::Error::other("script not found"));
     }
 
-    let ok = run_command("bash", &[script.to_str().unwrap(), "revoke-ip", ip])?;
+    let ok = run_command("bash", &[&path_str(&script), "revoke-ip", ip])?;
     if !ok {
         return Err(io::Error::other("revoke-ip failed"));
     }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -12,6 +12,9 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+const DOCKER_IMAGE: &str = "marksverdhei/unleash";
+const DOCKER_TAG: &str = "latest";
+
 /// Find the docker/ directory relative to the unleash binary or repo root.
 fn find_docker_dir() -> Option<PathBuf> {
     // Try relative to current exe
@@ -137,15 +140,40 @@ fn iptables_rules_active() -> bool {
     }
 }
 
-/// Check if the unleash Docker image exists
+/// Check if the unleash Docker image exists (either local or pulled)
 fn image_exists() -> bool {
-    Command::new("docker")
-        .args(["image", "inspect", "unleash:latest"])
+    let full_image = format!("{}:{}", DOCKER_IMAGE, DOCKER_TAG);
+    // Check for both the pulled name and a local "unleash:latest" alias
+    for name in &[full_image.as_str(), "unleash:latest"] {
+        if Command::new("docker")
+            .args(["image", "inspect", name])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Get the image name to use (prefer pulled image, fall back to local)
+fn image_name() -> String {
+    let full_image = format!("{}:{}", DOCKER_IMAGE, DOCKER_TAG);
+    if Command::new("docker")
+        .args(["image", "inspect", &full_image])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
+    {
+        full_image
+    } else {
+        "unleash:latest".to_string()
+    }
 }
 
 /// Check if the .env file exists in the docker directory
@@ -221,34 +249,45 @@ pub fn run_setup(docker_dir: &Path) -> io::Result<()> {
         return Err(io::Error::other("script not found"));
     }
 
-    // Step 4: Build Docker image
+    // Step 4: Pull Docker image (or build if --build flag)
     print!("  Docker image... ");
     if image_exists() {
-        println!("\x1b[32m✓\x1b[0m unleash:latest exists");
-        println!("    (to rebuild: docker build -f {}/Dockerfile -t unleash {})",
-            docker_dir.display(),
-            docker_dir.parent().map(|p| p.display().to_string()).unwrap_or_else(|| ".".to_string()),
-        );
+        let name = image_name();
+        println!("\x1b[32m✓\x1b[0m {} exists", name);
+        println!("    (to update: docker pull {}:{})", DOCKER_IMAGE, DOCKER_TAG);
     } else {
-        println!("\x1b[33m!\x1b[0m not found — building...");
-        let context = docker_dir
-            .parent()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|| ".".to_string());
-        let dockerfile = docker_dir.join("Dockerfile");
-        let ok = run_command("docker", &[
-            "build",
-            "-f",
-            dockerfile.to_str().unwrap(),
-            "-t",
-            "unleash:latest",
-            &context,
-        ])?;
+        let full_image = format!("{}:{}", DOCKER_IMAGE, DOCKER_TAG);
+        println!("\x1b[33m!\x1b[0m not found — pulling from Docker Hub...");
+        let ok = run_command("docker", &["pull", &full_image])?;
         if ok {
-            println!("  \x1b[32m✓\x1b[0m Image built");
+            println!("  \x1b[32m✓\x1b[0m Image pulled");
         } else {
-            eprintln!("  \x1b[31m✗\x1b[0m Image build failed");
-            return Err(io::Error::other("docker build failed"));
+            // Fall back to local build if pull fails and we have the Dockerfile
+            let dockerfile = docker_dir.join("Dockerfile");
+            if dockerfile.exists() {
+                println!("  \x1b[33m!\x1b[0m Pull failed — building locally...");
+                let context = docker_dir
+                    .parent()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_else(|| ".".to_string());
+                let ok = run_command("docker", &[
+                    "build",
+                    "-f",
+                    dockerfile.to_str().unwrap(),
+                    "-t",
+                    &full_image,
+                    &context,
+                ])?;
+                if ok {
+                    println!("  \x1b[32m✓\x1b[0m Image built locally");
+                } else {
+                    eprintln!("  \x1b[31m✗\x1b[0m Image build failed");
+                    return Err(io::Error::other("docker build failed"));
+                }
+            } else {
+                eprintln!("  \x1b[31m✗\x1b[0m Pull failed and no Dockerfile found for local build");
+                return Err(io::Error::other("image pull failed"));
+            }
         }
     }
 
@@ -317,16 +356,17 @@ pub fn run_status(docker_dir: &Path) -> io::Result<()> {
     // Image
     print!("  Container image:  ");
     if image_exists() {
+        let name = image_name();
         let age = run_command_output("docker", &[
-            "image", "inspect", "unleash:latest",
+            "image", "inspect", &name,
             "--format", "{{.Created}}",
         ])
         .ok()
         .map(|s| s.trim().to_string())
         .unwrap_or_default();
-        println!("\x1b[32m✓\x1b[0m unleash:latest ({})", if age.is_empty() { "unknown age" } else { &age });
+        println!("\x1b[32m✓\x1b[0m {} ({})", name, if age.is_empty() { "unknown age" } else { &age });
     } else {
-        println!("\x1b[31m✗\x1b[0m not built");
+        println!("\x1b[31m✗\x1b[0m not found (run: unleash sandbox setup)");
     }
 
     // .env
@@ -411,24 +451,55 @@ pub fn run_agent(docker_dir: &Path, agent: &str, extra_args: &[String]) -> io::R
         eprintln!("  Fix: cp docker/example.env docker/.env && edit docker/.env");
     }
 
-    // Build the docker compose command
+    let img = image_name();
+
+    // Try compose first (has env_file, service definitions, etc.)
     let compose_file = docker_dir.join("docker-compose.yml");
+    let use_compose = compose_file.exists();
 
     let mut cmd = Command::new("docker");
-    cmd.args(["compose", "-f", compose_file.to_str().unwrap()]);
 
-    // Check for local-api overlay
-    let local_api_compose = docker_dir.join("docker-compose.local-api.yml");
-    if std::env::var("LOCAL_API_BASE").is_ok() && local_api_compose.exists() {
-        cmd.args(["-f", local_api_compose.to_str().unwrap()]);
+    if use_compose {
+        cmd.args(["compose", "-f", compose_file.to_str().unwrap()]);
+
+        // Check for local-api overlay
+        let local_api_compose = docker_dir.join("docker-compose.local-api.yml");
+        if std::env::var("LOCAL_API_BASE").is_ok() && local_api_compose.exists() {
+            cmd.args(["-f", local_api_compose.to_str().unwrap()]);
+        }
+
+        cmd.args(["run", "--rm", agent]);
+    } else {
+        // Direct docker run (no compose files available — e.g., installed via binary only)
+        cmd.args([
+            "run", "--rm", "-it",
+            "--runtime", "runsc",
+            "--network", "unleash-sandbox",
+            "-v", &format!("{}:/workspace", std::env::current_dir()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|_| ".".to_string())),
+            "-w", "/workspace",
+        ]);
+
+        // Pass through API keys from environment
+        for key in &[
+            "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN",
+            "OPENAI_API_KEY", "GEMINI_API_KEY", "LOCAL_API_BASE",
+            "OPENAI_BASE_URL",
+        ] {
+            if std::env::var(key).is_ok() {
+                cmd.args(["-e", key]);
+            }
+        }
+
+        // Pass through .env file if present
+        let dotenv = docker_dir.join(".env");
+        if dotenv.exists() {
+            cmd.args(["--env-file", dotenv.to_str().unwrap()]);
+        }
+
+        cmd.args([&img, agent]);
     }
-
-    cmd.args(["run", "--rm"]);
-
-    // Pass through extra args (e.g., -p "prompt")
-    // These go BEFORE the service name for docker compose run
-    // Actually, agent-specific args should go after the service name
-    cmd.arg(agent);
 
     // Pass extra args to the container entrypoint
     for arg in extra_args {

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -602,17 +602,21 @@ pub enum SandboxAction {
     /// Remove sandbox network and firewall rules
     Teardown,
 
-    /// Open a single LAN IP through the sandbox firewall (for local API servers)
+    /// Open a single LAN IP (optionally port-restricted) through the sandbox firewall
+    ///
+    /// Examples:
+    ///   unleash sandbox allow-ip 192.168.1.100        # all ports
+    ///   unleash sandbox allow-ip 192.168.1.100:8080   # port 8080 only (recommended)
     #[command(name = "allow-ip")]
     AllowIp {
-        /// The private IP address to allow (e.g., 192.168.1.100)
+        /// The private IP address to allow, optionally with port (e.g., 192.168.1.100:8080)
         ip: String,
     },
 
     /// Close a previously opened LAN IP
     #[command(name = "revoke-ip")]
     RevokeIp {
-        /// The private IP address to revoke
+        /// The private IP address to revoke (must match the format used in allow-ip)
         ip: String,
     },
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,0 +1,551 @@
+//! Sandbox subcommand: one-command secure container setup and execution.
+//!
+//! Wraps Docker + gVisor + LAN isolation into a seamless experience:
+//!   - `unleash sandbox setup`     — install gVisor, create network, set iptables
+//!   - `unleash sandbox <agent>`   — run an agent in the sandbox
+//!   - `unleash sandbox status`    — health check
+//!   - `unleash sandbox teardown`  — clean up
+//!   - `unleash sandbox allow-ip`  — open a LAN IP for local API access
+//!   - `unleash sandbox revoke-ip` — close it
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// Find the docker/ directory relative to the unleash binary or repo root.
+fn find_docker_dir() -> Option<PathBuf> {
+    // Try relative to current exe
+    if let Ok(exe) = std::env::current_exe() {
+        // Installed: /usr/local/bin/unleash -> look for /usr/local/share/unleash/docker/
+        if let Some(prefix) = exe.parent().and_then(|p| p.parent()) {
+            let share_path = prefix.join("share").join("unleash").join("docker");
+            if share_path.join("Dockerfile").exists() {
+                return Some(share_path);
+            }
+        }
+    }
+
+    // Try repo layout: cwd or parent has docker/
+    let cwd = std::env::current_dir().ok()?;
+    for dir in [&cwd, &cwd.join(".."), &cwd.join("../..")]
+        .iter()
+        .filter_map(|p| p.canonicalize().ok())
+    {
+        let docker_dir = dir.join("docker");
+        if docker_dir.join("Dockerfile").exists() {
+            return Some(docker_dir);
+        }
+    }
+
+    None
+}
+
+fn sandbox_network_script(docker_dir: &Path) -> PathBuf {
+    docker_dir.join("sandbox-network.sh")
+}
+
+fn check_command_exists(cmd: &str) -> bool {
+    Command::new("which")
+        .arg(cmd)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn run_command(cmd: &str, args: &[&str]) -> io::Result<bool> {
+    let status = Command::new(cmd)
+        .args(args)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()?;
+    Ok(status.success())
+}
+
+fn run_command_output(cmd: &str, args: &[&str]) -> io::Result<String> {
+    let output = Command::new(cmd).args(args).output()?;
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn is_root() -> bool {
+    // Check UID via /proc or id command
+    std::fs::read_to_string("/proc/self/status")
+        .ok()
+        .and_then(|s| {
+            s.lines()
+                .find(|l| l.starts_with("Uid:"))
+                .and_then(|l| l.split_whitespace().nth(1))
+                .and_then(|uid| uid.parse::<u32>().ok())
+                .map(|uid| uid == 0)
+        })
+        .unwrap_or(false)
+}
+
+fn needs_sudo(action: &str) -> io::Result<()> {
+    if !is_root() {
+        eprintln!(
+            "\x1b[33mwarning:\x1b[0m '{}' requires root privileges. Re-run with sudo:",
+            action
+        );
+        eprintln!("  sudo unleash sandbox {}", action);
+        return Err(io::Error::other("requires root"));
+    }
+    Ok(())
+}
+
+/// Check if gVisor (runsc) is installed
+fn gvisor_installed() -> bool {
+    check_command_exists("runsc")
+}
+
+/// Check if Docker is running
+fn docker_running() -> bool {
+    Command::new("docker")
+        .args(["info"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Check if the sandbox network exists
+fn network_exists() -> bool {
+    Command::new("docker")
+        .args(["network", "inspect", "unleash-sandbox"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Check if iptables LAN-blocking rules are in place
+fn iptables_rules_active() -> bool {
+    let output = Command::new("iptables")
+        .args(["-L", "DOCKER-USER", "-n"])
+        .output();
+
+    match output {
+        Ok(out) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            stdout.contains("172.30.0.0/16")
+        }
+        Err(_) => false,
+    }
+}
+
+/// Check if the unleash Docker image exists
+fn image_exists() -> bool {
+    Command::new("docker")
+        .args(["image", "inspect", "unleash:latest"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Check if the .env file exists in the docker directory
+fn env_file_exists(docker_dir: &Path) -> bool {
+    docker_dir.join(".env").exists()
+}
+
+// ─── Subcommands ────────────────────────────────────────────
+
+pub fn run_setup(docker_dir: &Path) -> io::Result<()> {
+    needs_sudo("setup")?;
+
+    println!("\x1b[1m=== Sandbox Setup ===\x1b[0m\n");
+
+    // Step 1: Check Docker
+    print!("  Docker daemon... ");
+    if docker_running() {
+        println!("\x1b[32m✓\x1b[0m running");
+    } else {
+        println!("\x1b[31m✗\x1b[0m not running");
+        eprintln!("\nPlease start Docker first: sudo systemctl start docker");
+        return Err(io::Error::other("Docker not running"));
+    }
+
+    // Step 2: Check/install gVisor
+    print!("  gVisor (runsc)... ");
+    if gvisor_installed() {
+        println!("\x1b[32m✓\x1b[0m installed");
+    } else {
+        println!("\x1b[33m!\x1b[0m not found — installing...");
+        let arch = if cfg!(target_arch = "x86_64") {
+            "amd64"
+        } else if cfg!(target_arch = "aarch64") {
+            "arm64"
+        } else {
+            return Err(io::Error::other("Unsupported architecture for gVisor"));
+        };
+
+        // Download and install gVisor
+        let url = format!(
+            "https://storage.googleapis.com/gvisor/releases/release/latest/{}/runsc",
+            arch
+        );
+        let ok = run_command("bash", &[
+            "-c",
+            &format!(
+                "curl -fsSL -o /tmp/runsc '{}' && chmod +x /tmp/runsc && mv /tmp/runsc /usr/local/bin/runsc && runsc install && systemctl restart docker",
+                url
+            ),
+        ])?;
+        if ok {
+            println!("  \x1b[32m✓\x1b[0m gVisor installed and Docker restarted");
+        } else {
+            eprintln!("  \x1b[31m✗\x1b[0m gVisor installation failed");
+            eprintln!("    See https://gvisor.dev/docs/user_guide/install/");
+            return Err(io::Error::other("gVisor install failed"));
+        }
+    }
+
+    // Step 3: Create sandbox network + iptables rules
+    print!("  Sandbox network... ");
+    let script = sandbox_network_script(docker_dir);
+    if script.exists() {
+        let ok = run_command("bash", &[script.to_str().unwrap(), "setup"])?;
+        if ok {
+            println!("\x1b[32m✓\x1b[0m");
+        } else {
+            println!("\x1b[31m✗\x1b[0m sandbox-network.sh setup failed");
+            return Err(io::Error::other("network setup failed"));
+        }
+    } else {
+        println!("\x1b[31m✗\x1b[0m sandbox-network.sh not found at {}", script.display());
+        return Err(io::Error::other("script not found"));
+    }
+
+    // Step 4: Build Docker image
+    print!("  Docker image... ");
+    if image_exists() {
+        println!("\x1b[32m✓\x1b[0m unleash:latest exists");
+        println!("    (to rebuild: docker build -f {}/Dockerfile -t unleash {})",
+            docker_dir.display(),
+            docker_dir.parent().map(|p| p.display().to_string()).unwrap_or_else(|| ".".to_string()),
+        );
+    } else {
+        println!("\x1b[33m!\x1b[0m not found — building...");
+        let context = docker_dir
+            .parent()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|| ".".to_string());
+        let dockerfile = docker_dir.join("Dockerfile");
+        let ok = run_command("docker", &[
+            "build",
+            "-f",
+            dockerfile.to_str().unwrap(),
+            "-t",
+            "unleash:latest",
+            &context,
+        ])?;
+        if ok {
+            println!("  \x1b[32m✓\x1b[0m Image built");
+        } else {
+            eprintln!("  \x1b[31m✗\x1b[0m Image build failed");
+            return Err(io::Error::other("docker build failed"));
+        }
+    }
+
+    // Step 5: Check .env
+    print!("  API keys (.env)... ");
+    if env_file_exists(docker_dir) {
+        println!("\x1b[32m✓\x1b[0m found");
+    } else {
+        println!("\x1b[33m!\x1b[0m not found");
+        let example = docker_dir.join("example.env");
+        let dotenv = docker_dir.join(".env");
+        if example.exists() {
+            std::fs::copy(&example, &dotenv)?;
+            println!("    Created {} from example.env", dotenv.display());
+            println!("    \x1b[33mEdit it with your API keys before running agents.\x1b[0m");
+        } else {
+            println!("    Create docker/.env with your API keys (see docker/example.env)");
+        }
+    }
+
+    println!("\n\x1b[32m=== Sandbox ready! ===\x1b[0m");
+    println!("  Run an agent:  unleash sandbox claude");
+    println!("  Check status:  unleash sandbox status");
+    Ok(())
+}
+
+pub fn run_status(docker_dir: &Path) -> io::Result<()> {
+    println!("\x1b[1mSandbox Status\x1b[0m\n");
+
+    // Docker
+    print!("  Docker daemon:    ");
+    if docker_running() {
+        println!("\x1b[32m✓\x1b[0m running");
+    } else {
+        println!("\x1b[31m✗\x1b[0m not running");
+    }
+
+    // gVisor
+    print!("  gVisor (runsc):   ");
+    if gvisor_installed() {
+        let ver = run_command_output("runsc", &["--version"])
+            .ok()
+            .and_then(|s| s.lines().next().map(|l| l.trim().to_string()))
+            .unwrap_or_else(|| "installed".to_string());
+        println!("\x1b[32m✓\x1b[0m {}", ver);
+    } else {
+        println!("\x1b[31m✗\x1b[0m not installed");
+    }
+
+    // Network
+    print!("  Docker network:   ");
+    if network_exists() {
+        println!("\x1b[32m✓\x1b[0m unleash-sandbox (172.30.0.0/16)");
+    } else {
+        println!("\x1b[31m✗\x1b[0m not created");
+    }
+
+    // iptables
+    print!("  iptables rules:   ");
+    if iptables_rules_active() {
+        println!("\x1b[32m✓\x1b[0m LAN-blocking rules active");
+    } else {
+        println!("\x1b[33m?\x1b[0m cannot verify (need root, or rules missing)");
+    }
+
+    // Image
+    print!("  Container image:  ");
+    if image_exists() {
+        let age = run_command_output("docker", &[
+            "image", "inspect", "unleash:latest",
+            "--format", "{{.Created}}",
+        ])
+        .ok()
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default();
+        println!("\x1b[32m✓\x1b[0m unleash:latest ({})", if age.is_empty() { "unknown age" } else { &age });
+    } else {
+        println!("\x1b[31m✗\x1b[0m not built");
+    }
+
+    // .env
+    print!("  API keys (.env):  ");
+    if env_file_exists(docker_dir) {
+        // Count non-empty, non-comment lines
+        let count = std::fs::read_to_string(docker_dir.join(".env"))
+            .ok()
+            .map(|content| {
+                content
+                    .lines()
+                    .filter(|l| {
+                        let l = l.trim();
+                        !l.is_empty() && !l.starts_with('#') && l.contains('=')
+                            && l.split('=').nth(1).map(|v| !v.is_empty()).unwrap_or(false)
+                    })
+                    .count()
+            })
+            .unwrap_or(0);
+        if count > 0 {
+            println!("\x1b[32m✓\x1b[0m {} key(s) configured", count);
+        } else {
+            println!("\x1b[33m!\x1b[0m file exists but no keys set");
+        }
+    } else {
+        println!("\x1b[31m✗\x1b[0m not found (cp docker/example.env docker/.env)");
+    }
+
+    // LAN exceptions
+    let exceptions = run_command_output("iptables", &["-L", "DOCKER-USER", "-n"])
+        .ok()
+        .map(|output| {
+            output
+                .lines()
+                .filter(|l| l.contains("ACCEPT") && l.contains("172.30.0.0/16"))
+                .count()
+        })
+        .unwrap_or(0);
+    if exceptions > 0 {
+        println!("  LAN exceptions:   {} active", exceptions);
+    }
+
+    println!();
+    Ok(())
+}
+
+pub fn run_agent(docker_dir: &Path, agent: &str, extra_args: &[String]) -> io::Result<()> {
+    // Validate agent name
+    let valid_agents = ["claude", "codex", "gemini", "opencode", "bash", "unleash"];
+    if !valid_agents.contains(&agent) {
+        eprintln!(
+            "\x1b[31merror:\x1b[0m Unknown agent '{}'. Valid agents: {}",
+            agent,
+            valid_agents.join(", ")
+        );
+        return Err(io::Error::other("unknown agent"));
+    }
+
+    // Preflight checks
+    if !docker_running() {
+        eprintln!("\x1b[31merror:\x1b[0m Docker is not running. Start it first.");
+        return Err(io::Error::other("Docker not running"));
+    }
+
+    if !image_exists() {
+        eprintln!("\x1b[31merror:\x1b[0m Docker image not built. Run: unleash sandbox setup");
+        return Err(io::Error::other("image not built"));
+    }
+
+    if !network_exists() {
+        eprintln!("\x1b[33mwarning:\x1b[0m Sandbox network not found. LAN isolation may not be active.");
+        eprintln!("  Fix: sudo unleash sandbox setup");
+    }
+
+    if !iptables_rules_active() {
+        eprintln!("\x1b[33mwarning:\x1b[0m Cannot verify iptables rules (need root, or rules missing after reboot).");
+        eprintln!("  Fix: sudo ./docker/sandbox-network.sh setup");
+    }
+
+    if !env_file_exists(docker_dir) {
+        eprintln!("\x1b[33mwarning:\x1b[0m No .env file found. API keys may not be set.");
+        eprintln!("  Fix: cp docker/example.env docker/.env && edit docker/.env");
+    }
+
+    // Build the docker compose command
+    let compose_file = docker_dir.join("docker-compose.yml");
+
+    let mut cmd = Command::new("docker");
+    cmd.args(["compose", "-f", compose_file.to_str().unwrap()]);
+
+    // Check for local-api overlay
+    let local_api_compose = docker_dir.join("docker-compose.local-api.yml");
+    if std::env::var("LOCAL_API_BASE").is_ok() && local_api_compose.exists() {
+        cmd.args(["-f", local_api_compose.to_str().unwrap()]);
+    }
+
+    cmd.args(["run", "--rm"]);
+
+    // Pass through extra args (e.g., -p "prompt")
+    // These go BEFORE the service name for docker compose run
+    // Actually, agent-specific args should go after the service name
+    cmd.arg(agent);
+
+    // Pass extra args to the container entrypoint
+    for arg in extra_args {
+        cmd.arg(arg);
+    }
+
+    cmd.stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    let status = cmd.status()?;
+    if !status.success() {
+        return Err(io::Error::other(format!(
+            "Container exited with code {}",
+            status.code().unwrap_or(-1)
+        )));
+    }
+    Ok(())
+}
+
+pub fn run_teardown(docker_dir: &Path) -> io::Result<()> {
+    needs_sudo("teardown")?;
+
+    println!("\x1b[1m=== Sandbox Teardown ===\x1b[0m\n");
+
+    let script = sandbox_network_script(docker_dir);
+    if script.exists() {
+        run_command("bash", &[script.to_str().unwrap(), "teardown"])?;
+    }
+
+    println!("\n\x1b[32mTeardown complete.\x1b[0m");
+    Ok(())
+}
+
+pub fn run_allow_ip(docker_dir: &Path, ip: &str) -> io::Result<()> {
+    needs_sudo("allow-ip")?;
+
+    let script = sandbox_network_script(docker_dir);
+    if !script.exists() {
+        eprintln!("\x1b[31merror:\x1b[0m sandbox-network.sh not found");
+        return Err(io::Error::other("script not found"));
+    }
+
+    let ok = run_command("bash", &[script.to_str().unwrap(), "allow-ip", ip])?;
+    if !ok {
+        return Err(io::Error::other("allow-ip failed"));
+    }
+    Ok(())
+}
+
+pub fn run_revoke_ip(docker_dir: &Path, ip: &str) -> io::Result<()> {
+    needs_sudo("revoke-ip")?;
+
+    let script = sandbox_network_script(docker_dir);
+    if !script.exists() {
+        eprintln!("\x1b[31merror:\x1b[0m sandbox-network.sh not found");
+        return Err(io::Error::other("script not found"));
+    }
+
+    let ok = run_command("bash", &[script.to_str().unwrap(), "revoke-ip", ip])?;
+    if !ok {
+        return Err(io::Error::other("revoke-ip failed"));
+    }
+    Ok(())
+}
+
+/// Main dispatch for `unleash sandbox <action>`
+pub fn handle_sandbox(action: &SandboxAction) -> io::Result<()> {
+    let docker_dir = find_docker_dir().ok_or_else(|| {
+        io::Error::other(
+            "Cannot find docker/ directory. Run from the unleash repo root, \
+             or ensure docker files are installed at /usr/local/share/unleash/docker/",
+        )
+    })?;
+
+    match action {
+        SandboxAction::Setup => run_setup(&docker_dir),
+        SandboxAction::Status => run_status(&docker_dir),
+        SandboxAction::Teardown => run_teardown(&docker_dir),
+        SandboxAction::AllowIp { ip } => run_allow_ip(&docker_dir, ip),
+        SandboxAction::RevokeIp { ip } => run_revoke_ip(&docker_dir, ip),
+        SandboxAction::Run(args) => {
+            let agent = args.first().ok_or_else(|| {
+                io::Error::other("Usage: unleash sandbox <agent> [args...]\n  Agents: claude, codex, gemini, opencode, bash")
+            })?;
+            run_agent(&docker_dir, agent, &args[1..])
+        }
+    }
+}
+
+/// Sandbox subcommand actions (parsed by clap in cli.rs)
+#[derive(clap::Subcommand, Debug)]
+pub enum SandboxAction {
+    /// Set up the sandbox: install gVisor, create network, apply firewall rules, build image
+    Setup,
+
+    /// Show sandbox health status
+    Status,
+
+    /// Remove sandbox network and firewall rules
+    Teardown,
+
+    /// Open a single LAN IP through the sandbox firewall (for local API servers)
+    #[command(name = "allow-ip")]
+    AllowIp {
+        /// The private IP address to allow (e.g., 192.168.1.100)
+        ip: String,
+    },
+
+    /// Close a previously opened LAN IP
+    #[command(name = "revoke-ip")]
+    RevokeIp {
+        /// The private IP address to revoke
+        ip: String,
+    },
+
+    /// Run an agent in the sandbox (e.g., `unleash sandbox claude`)
+    #[command(external_subcommand)]
+    Run(Vec<String>),
+}


### PR DESCRIPTION
## Summary
Adds `unleash sandbox` subcommand that wraps Docker + gVisor + LAN isolation into a one-command experience:

- `unleash sandbox setup` — installs gVisor, creates network, applies iptables rules, builds image, sets up .env
- `unleash sandbox claude` (or codex/gemini/opencode) — runs agent in full sandbox with preflight checks
- `unleash sandbox status` — health dashboard showing all component states
- `unleash sandbox teardown` — clean removal of network and firewall rules
- `unleash sandbox allow-ip <IP>` / `revoke-ip <IP>` — manage LAN exceptions for local API servers

### Before (6 manual steps)
```bash
sudo runsc install && sudo systemctl restart docker
sudo ./docker/sandbox-network.sh setup
docker build -f docker/Dockerfile -t unleash .
cp docker/example.env docker/.env
# edit .env
docker compose -f docker/docker-compose.yml run --rm claude
```

### After (2 steps)
```bash
sudo unleash sandbox setup
unleash sandbox claude
```

## Test plan
- [x] All 355 tests pass (354 + 1 ignored)
- [x] `unleash sandbox --help` shows all subcommands
- [x] `unleash sandbox status` works without root (gracefully degrades for iptables check)
- [ ] `sudo unleash sandbox setup` on a clean machine
- [ ] `unleash sandbox claude` end-to-end

Addresses #68