### PR TITLE
fix: sync plugin hooks into settings.json on every launch

### DIFF
--- a/plugins/bundled/supercompact/hooks-handlers/supercompact-compact.sh
+++ b/plugins/bundled/supercompact/hooks-handlers/supercompact-compact.sh
@@ -135,11 +135,13 @@ log "Running compact.py (method=${METHOD}, budget=${BUDGET})"
 
 cd "${SUPERCOMPACT_DIR}" || { log "ERROR: Cannot cd to ${SUPERCOMPACT_DIR}"; exit 0; }
 
-if ! uv run python compact.py "${JSONL_FILE}" \
+uv run python compact.py "${JSONL_FILE}" \
     --method "${METHOD}" \
     --budget "${BUDGET}" \
-    --output "${SC_OUTPUT}" 2>> "${LOG_FILE}"; then
-  log "ERROR: compact.py failed (exit $?)"
+    --output "${SC_OUTPUT}" 2>> "${LOG_FILE}"
+UV_EXIT=$?
+if [[ ${UV_EXIT} -ne 0 ]]; then
+  log "ERROR: compact.py failed (exit ${UV_EXIT})"
   rm -f "${SC_OUTPUT}" 2>/dev/null || true
   exit 0
 fi

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -45,7 +45,9 @@ fn detect_agent_type(cmd: &Path) -> Option<AgentType> {
 
 /// Run an agent with wrapper features
 pub fn run(auto_mode: bool, prompt: Option<String>, extra_args: Vec<String>) -> io::Result<()> {
-    // Install default hooks (NOT plugin hooks - those are loaded by Claude Code via --plugin-dir)
+    // Sync hooks: install defaults + merge plugin hooks into settings.json
+    // Plugin hooks must be in settings.json because Claude Code may not reliably
+    // load hooks from --plugin-dir when settings.json already has the event key.
     match HookManager::new() {
         Ok(manager) => {
             // Install default hooks if not already installed
@@ -56,7 +58,11 @@ pub fn run(auto_mode: bool, prompt: Option<String>, extra_args: Vec<String>) -> 
                     }
                 }
             }
-            // Note: Plugin hooks are loaded by Claude Code from --plugin-dir, not from settings.json
+            // Always sync plugin hooks into settings.json on launch
+            let plugin_dirs = find_plugin_dirs();
+            if let Err(e) = manager.sync_plugin_hooks(&plugin_dirs) {
+                eprintln!("Warning: Failed to sync plugin hooks: {}", e);
+            }
         }
         Err(e) => {
             eprintln!("Warning: Failed to initialize hook manager: {}", e);


### PR DESCRIPTION
## Summary
- Plugin hooks (like supercompact's PreCompact) were silently not firing because `settings.json` had an empty `"PreCompact": []` array, which prevented Claude Code from loading the plugin's hook via `--plugin-dir`
- Launcher now calls `sync_plugin_hooks()` on every startup, ensuring plugin hooks are always registered in `settings.json`
- Fixed exit code logging in compact pipeline (`$?` inside `if` body is always 0)

## Test plan
- [ ] Launch unleash, verify `settings.json` has PreCompact hook registered
- [ ] Run `/compact 50000` and verify supercompact fires (check `~/.cache/supercompact/hook.log`)
- [ ] Verify preemptive compaction still works via UserPromptSubmit

🤖 Generated with [Claude Code](https://claude.com/claude-code)