### PR TITLE
fix(supercompact): correct bytes/token ratio from 4 to 12

### DIFF
--- a/plugins/bundled/supercompact/hooks-handlers/supercompact-compact.sh
+++ b/plugins/bundled/supercompact/hooks-handlers/supercompact-compact.sh
@@ -68,8 +68,9 @@ if [[ -z "${BUDGET}" ]]; then
     BUDGET="${PLUGIN_SETTING_BUDGET}"
   else
     FILE_BYTES=$(stat -c %s "${JSONL_FILE}" 2>/dev/null || echo 0)
-    # ~4 bytes per token is a reasonable estimate for JSONL with tool output
-    ESTIMATED_TOKENS=$((FILE_BYTES / 4))
+    # ~12 bytes per token for JSONL (JSON structure, keys, escaping inflate
+    # byte count vs actual tokens — measured at ~16 b/t, using 12 to be conservative)
+    ESTIMATED_TOKENS=$((FILE_BYTES / 12))
 
     if [[ "${TRIGGER}" == "preemptive" ]]; then
       PCT="${PLUGIN_SETTING_BUDGET_PCT_PREEMPTIVE:-50}"
@@ -80,6 +81,10 @@ if [[ -z "${BUDGET}" ]]; then
 
     # Floor: never set budget below 10k tokens (would lose too much)
     (( BUDGET < 10000 )) && BUDGET=10000
+
+    # Ceiling: cap at 200k tokens — even with corrected ratio, very large
+    # files shouldn't produce budgets exceeding the context window
+    (( BUDGET > 200000 )) && BUDGET=200000
   fi
 fi
 

--- a/plugins/bundled/supercompact/hooks-handlers/supercompact-userprompt.sh
+++ b/plugins/bundled/supercompact/hooks-handlers/supercompact-userprompt.sh
@@ -29,10 +29,10 @@ fi
 # Fast file-size check
 FILE_BYTES=$(stat -c %s "${JSONL_FILE}" 2>/dev/null || echo 0)
 
-# Threshold: 60% of effective context window × ~4 bytes/token
-# For 200K model: (200000 - 20000) × 0.60 × 4 = 432,000 bytes
+# Threshold: 60% of effective context window × ~12 bytes/token
+# For 200K model: (200000 - 20000) × 0.60 × 12 = 1,296,000 bytes
 # Configurable via env var for different model windows
-THRESHOLD=${PLUGIN_SETTING_THRESHOLD_BYTES:-${SUPERCOMPACT_THRESHOLD_BYTES:-432000}}
+THRESHOLD=${PLUGIN_SETTING_THRESHOLD_BYTES:-${SUPERCOMPACT_THRESHOLD_BYTES:-1296000}}
 
 if (( FILE_BYTES > THRESHOLD )); then
   log "Threshold exceeded (${FILE_BYTES} > ${THRESHOLD} bytes) — triggering preemptive compaction"


### PR DESCRIPTION
## Summary
- Fix bytes/token estimate from 4 to 12 (measured ~16 in practice) — the old ratio inflated budgets 3-4x, causing compact.py to skip compaction
- Add 200k token ceiling on auto-calculated budgets
- Update preemptive trigger threshold from 432KB to 1.3MB to match corrected ratio

## Root cause
The `4 bytes/token` estimate massively overestimated token counts for JSONL (JSON structure overhead inflates bytes). A 1.8MB file was estimated at 460K tokens when the real count was ~115K. The resulting budget exceeded actual tokens, so compact.py correctly said "already within budget" and skipped — letting Claude's native compaction kick in instead.