### PR TITLE
fix(supercompact): sync plugin.json threshold + audit fixes

### DIFF
--- a/plugins/bundled/supercompact/.claude-plugin/plugin.json
+++ b/plugins/bundled/supercompact/.claude-plugin/plugin.json
@@ -51,11 +51,11 @@
     "threshold_bytes": {
       "type": "integer",
       "min": 100000,
-      "max": 2000000,
+      "max": 5000000,
       "step": 50000,
-      "default": 432000,
+      "default": 1296000,
       "label": "Trigger Threshold",
-      "description": "File size in bytes that triggers preemptive compaction"
+      "description": "File size in bytes that triggers preemptive compaction (~12 bytes/token)"
     }
   }
 }

--- a/plugins/bundled/supercompact/hooks-handlers/supercompact-compact.sh
+++ b/plugins/bundled/supercompact/hooks-handlers/supercompact-compact.sh
@@ -81,12 +81,11 @@ if [[ -z "${BUDGET}" ]]; then
 
     # Floor: never set budget below 10k tokens (would lose too much)
     (( BUDGET < 10000 )) && BUDGET=10000
-
-    # Ceiling: cap at 200k tokens — even with corrected ratio, very large
-    # files shouldn't produce budgets exceeding the context window
-    (( BUDGET > 200000 )) && BUDGET=200000
   fi
 fi
+
+# Always apply ceiling — even for --budget arg or manual mode
+(( BUDGET > 200000 )) && BUDGET=200000
 
 LOCKFILE="/tmp/supercompact.lock"
 LOCK_FD=9
@@ -127,7 +126,7 @@ if ! cp "${JSONL_FILE}" "${BACKUP_FILE}"; then
   exit 0
 fi
 
-JSONL_LINES=$(wc -l < "${JSONL_FILE}" 2>/dev/null || echo 0)
+JSONL_LINES=$(grep -c "" "${JSONL_FILE}" 2>/dev/null || echo 0)
 JSONL_BYTES=$(stat -c %s "${JSONL_FILE}" 2>/dev/null || echo 0)
 log "Backup saved (${JSONL_LINES} lines, ${JSONL_BYTES} bytes)"
 
@@ -184,7 +183,7 @@ if ! echo "${LAST_LINE}" | jq empty 2>/dev/null; then
   exit 0
 fi
 
-SC_LINES=$(wc -l < "${SC_OUTPUT}" 2>/dev/null || echo 0)
+SC_LINES=$(grep -c "" "${SC_OUTPUT}" 2>/dev/null || echo 0)
 SC_BYTES=$(stat -c %s "${SC_OUTPUT}" 2>/dev/null || echo 0)
 log "Compaction complete: ${JSONL_LINES} -> ${SC_LINES} lines, ${JSONL_BYTES} -> ${SC_BYTES} bytes"
 
@@ -224,7 +223,7 @@ log "JSONL replaced successfully"
 
 # Clean up old backups (keep last 3 of each type)
 for pattern in ".pre-compact-full" ".pre-supercompact"; do
-  ls -t "${JSONL_FILE}${pattern}"* 2>/dev/null | tail -n +4 | xargs rm -f 2>/dev/null || true
+  ls -t "${JSONL_FILE}${pattern}"* 2>/dev/null | tail -n +4 | tr '\n' '\0' | xargs -0 rm -f 2>/dev/null || true
 done
 
 # --- 7. Restart via unleash-refresh ---


### PR DESCRIPTION
## Summary
- Sync `plugin.json` threshold_bytes default (432000 → 1296000) with corrected 12 b/t ratio from #78
- Move 200k budget ceiling outside auto-calc block so `--budget` arg is also validated
- Fix `wc -l` off-by-one (→ `grep -c ""`) that silently rejected valid compactions
- Fix `xargs` backup cleanup for paths with spaces

## Why
PR #78 fixed the ratio in the shell scripts but missed `plugin.json`. Since `PLUGIN_SETTING_THRESHOLD_BYTES` is populated from plugin.json defaults, the old 432KB threshold was still being used, triggering compaction too early and then skipping it because the budget was still reasonable. The other fixes are from a broader audit.