### PR TITLE
fix(docker): treat flag-first CMD override as unleash args

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,6 +19,15 @@ nameserver 8.8.4.4
 EOF
 fi
 
+# If the image is invoked with a flag as the first argument (e.g. `docker run
+# image --version`), docker replaces the default CMD and hands us just the flag.
+# Bash's `exec` builtin then tries to parse it as its own option and dies with
+# "exec: --: invalid option". Treat flag-first invocations as arguments to the
+# default `unleash` binary, matching the intent of `CMD ["unleash"]`.
+if [[ "${1:-}" == -* ]]; then
+    set -- unleash "$@"
+fi
+
 # Determine if we should drop privileges
 cmd="$(basename "${1:-}" 2>/dev/null)"
 case "$cmd" in


### PR DESCRIPTION
## Summary

Fixes the long-running **Build Docker Image** failure (pre-existing on `main`) where `docker run unleash:ci-test --version` dies with `exec: --: invalid option`. When docker's positional args start with a flag, they replace `CMD ["unleash"]` entirely — entrypoint.sh then runs `exec "$@"` where `$@ = --version`, and bash's `exec` builtin mis-parses the leading `--` as its own option.

The fix prepends `unleash` when `$1` starts with `-`, matching the intent of `CMD ["unleash"]` and the comment in the CI workflow ("Entrypoint is already 'unleash', so just pass --version directly").

## Why now

Was blocking green CI on every PR (including the recently-merged #87). Root cause isn't related to that PR — it has been red on `main` since 2026-04-13.

## Test plan

Smoke-tested the guarded case statement locally:

| Invocation | Before | After |
|---|---|---|
| `docker run image --version` | `exec: --: invalid option` ❌ | `runuser -u unleash -- unleash --version` ✓ |
| `docker run image claude --version` | `runuser -u unleash -- claude --version` | unchanged ✓ |
| `docker run image codex version` | `runuser -u unleash -- codex version` | unchanged ✓ |
| `docker run image bash -c ls` | `exec bash -c ls` | unchanged ✓ |
| `docker run image` (no args, uses CMD) | `runuser -u unleash -- unleash` | unchanged ✓ |

- [x] `shellcheck docker/entrypoint.sh` clean
- [ ] CI **Build Docker Image** passes on this PR