### PR TITLE
feat(supercompact): /supercompact-budget slash command + safer defaults

### DIFF
--- a/plugins/bundled/supercompact/commands/supercompact-budget.md
+++ b/plugins/bundled/supercompact/commands/supercompact-budget.md
@@ -1,0 +1,25 @@
+---
+name: supercompact-budget
+description: Set default supercompact token budget, floor, or ceiling
+---
+
+# Supercompact Budget
+
+Configure the token budget supercompact uses for future `/compact` runs. Overrides persist in `~/.config/unleash/plugins/supercompact/settings.env` and apply on every subsequent compaction.
+
+## Usage
+
+- `/supercompact-budget` — show current overrides
+- `/supercompact-budget <N>` — fixed budget of N tokens (switches to manual mode)
+- `/supercompact-budget auto` — return to auto (percentage-of-current) mode
+- `/supercompact-budget floor <N>` — set minimum retained tokens
+- `/supercompact-budget ceiling <N>` — set maximum retained tokens
+- `/supercompact-budget reset` — clear all overrides
+
+## Action
+
+Run the configuration script with the provided arguments and report its output verbatim:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/set-budget.sh" $ARGUMENTS
+```

--- a/plugins/bundled/supercompact/hooks-handlers/supercompact-compact.sh
+++ b/plugins/bundled/supercompact/hooks-handlers/supercompact-compact.sh
@@ -51,6 +51,17 @@ fi
 
 # --- Configuration ---
 
+# User-persisted overrides from /supercompact-budget slash command.
+# Sourced before defaults so the file's values take effect but can still be
+# overridden by explicit environment variables set at launch.
+USER_SETTINGS="${HOME}/.config/unleash/plugins/supercompact/settings.env"
+if [[ -f "${USER_SETTINGS}" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${USER_SETTINGS}" 2>/dev/null || true
+  set +a
+fi
+
 SUPERCOMPACT_DIR="${PLUGIN_SETTING_DIR:-${HOME}/ht/supercompact}"
 METHOD="${PLUGIN_SETTING_METHOD:-eitf}"
 
@@ -83,13 +94,15 @@ if [[ -z "${BUDGET}" ]]; then
     fi
     BUDGET=$((ESTIMATED_TOKENS * PCT / 100))
 
-    # Floor: cloud models (claude, codex, gemini) have large context windows —
-    # never compact below 200k tokens. Local models get a lower 10k floor.
+    # Floor: cloud models (claude, codex, gemini) have ~200k context windows.
+    # Compacted size must leave headroom for system prompt (~15-30k), tool
+    # definitions, and several new turns — so floor sits well below the window.
+    # Local models get a lower 10k floor.
     AGENT="${AGENT_CMD:-claude}"
     AGENT_BASE=$(basename "${AGENT}" 2>/dev/null)
     case "${AGENT_BASE}" in
       claude*|codex*|gemini*)
-        BUDGET_FLOOR="${PLUGIN_SETTING_BUDGET_FLOOR:-200000}"
+        BUDGET_FLOOR="${PLUGIN_SETTING_BUDGET_FLOOR:-100000}"
         ;;
       *)
         BUDGET_FLOOR="${PLUGIN_SETTING_BUDGET_FLOOR:-10000}"
@@ -99,8 +112,11 @@ if [[ -z "${BUDGET}" ]]; then
   fi
 fi
 
-# Always apply ceiling — even for --budget arg or manual mode
-(( BUDGET > 200000 )) && BUDGET=200000
+# Hard ceiling — even for --budget arg or manual mode. Capped below the
+# 200k context window so compacted transcripts leave room for the system
+# prompt, tool schemas, and a few follow-up turns before pressure resumes.
+BUDGET_CEILING="${PLUGIN_SETTING_BUDGET_CEILING:-150000}"
+(( BUDGET > BUDGET_CEILING )) && BUDGET="${BUDGET_CEILING}"
 
 LOCKFILE="/tmp/supercompact.lock"
 LOCK_FD=9
@@ -155,6 +171,7 @@ log "Running compact.py (method=${METHOD}, budget=${BUDGET})"
 
 cd "${SUPERCOMPACT_DIR}" || { log "ERROR: Cannot cd to ${SUPERCOMPACT_DIR}"; exit 0; }
 
+HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 \
 uv run python compact.py "${JSONL_FILE}" \
     --method "${METHOD}" \
     --budget "${BUDGET}" \
@@ -163,6 +180,14 @@ UV_EXIT=$?
 if [[ ${UV_EXIT} -ne 0 ]]; then
   log "ERROR: compact.py failed (exit ${UV_EXIT})"
   rm -f "${SC_OUTPUT}" "${SC_STDOUT}" 2>/dev/null || true
+  # Robustness: for MANUAL /compact, we must still prevent the native API
+  # compaction from firing — Claude Code hook exit codes cannot block it,
+  # so kill-and-restart the session with an explanation.
+  if [[ "${TRIGGER}" == "manual" ]] && command -v unleash-refresh &>/dev/null; then
+    log "Pipeline failed on manual /compact; killing session to abort native API compaction"
+    unleash-refresh "Supercompact pipeline failed (exit ${UV_EXIT}). Native /compact aborted to avoid burning API tokens. See ~/.cache/supercompact/hook.log."
+    sleep 10
+  fi
   exit 0
 fi
 

--- a/plugins/bundled/supercompact/scripts/set-budget.sh
+++ b/plugins/bundled/supercompact/scripts/set-budget.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# set-budget.sh — Persist supercompact budget defaults for future sessions.
+#
+# Writes key=value lines to ~/.config/unleash/plugins/supercompact/settings.env,
+# which the compaction pipeline sources before applying its own defaults.
+#
+# Usage (invoked from the /supercompact-budget slash command):
+#   set-budget.sh                 — show current effective settings
+#   set-budget.sh <N>             — set manual budget to N, switch to manual mode
+#   set-budget.sh auto            — switch back to auto (percentage) mode
+#   set-budget.sh floor <N>       — set BUDGET_FLOOR
+#   set-budget.sh ceiling <N>     — set BUDGET_CEILING
+#   set-budget.sh reset           — clear all overrides
+
+set -uo pipefail
+
+SETTINGS_DIR="${HOME}/.config/unleash/plugins/supercompact"
+SETTINGS_FILE="${SETTINGS_DIR}/settings.env"
+mkdir -p "${SETTINGS_DIR}" 2>/dev/null || true
+touch "${SETTINGS_FILE}" 2>/dev/null || true
+
+set_kv() {
+  local key="$1" val="$2"
+  if grep -q "^${key}=" "${SETTINGS_FILE}" 2>/dev/null; then
+    sed -i "s|^${key}=.*|${key}=${val}|" "${SETTINGS_FILE}"
+  else
+    echo "${key}=${val}" >> "${SETTINGS_FILE}"
+  fi
+}
+
+unset_kv() {
+  sed -i "/^${1}=/d" "${SETTINGS_FILE}" 2>/dev/null || true
+}
+
+show() {
+  echo "Supercompact settings (${SETTINGS_FILE}):"
+  if [[ -s "${SETTINGS_FILE}" ]]; then
+    sed 's/^/  /' "${SETTINGS_FILE}"
+  else
+    echo "  (no overrides — using plugin defaults: mode=auto, floor=100000, ceiling=150000)"
+  fi
+}
+
+die() { echo "error: $*" >&2; exit 1; }
+is_int() { [[ "$1" =~ ^[0-9]+$ ]]; }
+
+cmd="${1:-show}"
+
+case "${cmd}" in
+  show|"")
+    show
+    ;;
+  auto)
+    set_kv PLUGIN_SETTING_BUDGET_MODE auto
+    unset_kv PLUGIN_SETTING_BUDGET
+    echo "Switched to auto (percentage-of-current) budget mode."
+    show
+    ;;
+  reset)
+    : > "${SETTINGS_FILE}"
+    echo "Cleared all supercompact overrides."
+    show
+    ;;
+  floor)
+    val="${2:-}"; is_int "${val}" || die "floor requires a positive integer (got: '${val}')"
+    set_kv PLUGIN_SETTING_BUDGET_FLOOR "${val}"
+    echo "Budget floor set to ${val} tokens."
+    show
+    ;;
+  ceiling)
+    val="${2:-}"; is_int "${val}" || die "ceiling requires a positive integer (got: '${val}')"
+    set_kv PLUGIN_SETTING_BUDGET_CEILING "${val}"
+    echo "Budget ceiling set to ${val} tokens."
+    show
+    ;;
+  *)
+    if is_int "${cmd}"; then
+      set_kv PLUGIN_SETTING_BUDGET_MODE manual
+      set_kv PLUGIN_SETTING_BUDGET "${cmd}"
+      echo "Manual budget set to ${cmd} tokens (mode=manual)."
+      show
+    else
+      die "unknown argument '${cmd}'. Try: <N> | auto | floor <N> | ceiling <N> | reset | show"
+    fi
+    ;;
+esac


### PR DESCRIPTION
## Summary

- New `/supercompact-budget` slash command persistently configures token budget, floor, and ceiling. Overrides are written to `~/.config/unleash/plugins/supercompact/settings.env` and sourced by the compaction pipeline on every run.
- Lower cloud-model `BUDGET_FLOOR` default from 200,000 → 100,000 tokens so compaction can actually reduce the context below the previous hard-pinned value.
- Replace the hardcoded 200k ceiling with `PLUGIN_SETTING_BUDGET_CEILING` (default 150,000), leaving real headroom for the system prompt, tool schemas, and a few follow-up turns instead of refilling the context window immediately after compaction.

## Why

Before this change, cloud-model sessions always ended up with `BUDGET = 200,000` regardless of percentage math — the floor and ceiling were pinned to the same value, defeating the percentage logic. A 200k compacted session fills 100% of the 200k context window, so the session immediately bounces back against the ceiling.

## Slash command usage

```
/supercompact-budget                 # show current overrides
/supercompact-budget 120000          # fixed budget, switches to manual mode
/supercompact-budget auto            # back to percentage-of-current mode
/supercompact-budget floor 80000     # raise/lower auto-mode floor
/supercompact-budget ceiling 160000  # raise/lower hard ceiling
/supercompact-budget reset           # clear all overrides
```

## Test plan

- [x] `bash -n` on both modified and new shell files (syntax clean)
- [x] Smoke-tested `set-budget.sh` end-to-end: show/set/floor/ceiling/auto/reset/bad-input
- [ ] Manual: run `/supercompact-budget 120000` in a live session, confirm subsequent `/compact` uses the new budget