### PR TITLE
fix(supercompact): separate THRESHOLD from BUDGET

### DIFF
--- a/plugins/bundled/supercompact/commands/supercompact-budget.md
+++ b/plugins/bundled/supercompact/commands/supercompact-budget.md
@@ -1,19 +1,33 @@
 ---
 name: supercompact-budget
-description: Set default supercompact token budget, floor, or ceiling
+description: Configure supercompact threshold (when to auto-compact) and budget (compression target)
 ---
 
-# Supercompact Budget
+# Supercompact Configuration
 
-Configure the token budget supercompact uses for future `/compact` runs. Overrides persist in `~/.config/unleash/plugins/supercompact/settings.env` and apply on every subsequent compaction.
+Two distinct knobs:
+
+- **THRESHOLD** — token count at which preemptive auto-compaction TRIGGERS.
+  Should sit just below the model's context window. Default: 180000.
+- **BUDGET** — target token count compaction COMPRESSES TO.
+  Should be much smaller than THRESHOLD. Default: auto (percentage of current).
+
+These MUST be different. THRESHOLD must be substantially higher than BUDGET
+(at least +30000 headroom) or compaction will re-trigger immediately after running.
+
+Overrides persist in `~/.config/unleash/plugins/supercompact/settings.env`
+and apply on every subsequent compaction.
 
 ## Usage
 
 - `/supercompact-budget` — show current overrides
-- `/supercompact-budget <N>` — fixed budget of N tokens (switches to manual mode)
-- `/supercompact-budget auto` — return to auto (percentage-of-current) mode
-- `/supercompact-budget floor <N>` — set minimum retained tokens
-- `/supercompact-budget ceiling <N>` — set maximum retained tokens
+- `/supercompact-budget <N>` — set BUDGET to N tokens (switches to manual mode)
+- `/supercompact-budget budget <N>` — set BUDGET (alias)
+- `/supercompact-budget budget auto` — switch BUDGET to auto (percentage-of-current) mode
+- `/supercompact-budget threshold <N>` — set THRESHOLD (auto-compact trigger)
+- `/supercompact-budget threshold default` — restore default THRESHOLD (180000)
+- `/supercompact-budget floor <N>` — set BUDGET floor (auto-mode min)
+- `/supercompact-budget ceiling <N>` — set BUDGET ceiling (auto-mode max)
 - `/supercompact-budget reset` — clear all overrides
 
 ## Action

--- a/plugins/bundled/supercompact/hooks-handlers/supercompact-userprompt.sh
+++ b/plugins/bundled/supercompact/hooks-handlers/supercompact-userprompt.sh
@@ -26,8 +26,21 @@ if [[ -z "${JSONL_FILE}" || ! -f "${JSONL_FILE}" ]]; then
   exit 0
 fi
 
-# Token count check — use real tokenizer if available, fall back to byte estimate
-THRESHOLD_TOKENS=${PLUGIN_SETTING_THRESHOLD_TOKENS:-${SUPERCOMPACT_THRESHOLD_TOKENS:-200000}}
+# Source user settings so /supercompact-budget threshold <N> takes effect
+USER_SETTINGS="${HOME}/.config/unleash/plugins/supercompact/settings.env"
+if [[ -f "${USER_SETTINGS}" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${USER_SETTINGS}" 2>/dev/null || true
+  set +a
+fi
+
+# THRESHOLD: when to TRIGGER preemptive auto-compaction. Should sit just below
+# the model context window (200k for cloud models) so we compact before the
+# native API auto-compact would. NOT the same as BUDGET (compression target).
+# Default 180k = 90% of 200k context window — leaves room for one or two
+# more turns to land before compaction kicks in.
+THRESHOLD_TOKENS=${PLUGIN_SETTING_THRESHOLD_TOKENS:-${SUPERCOMPACT_THRESHOLD_TOKENS:-180000}}
 THRESHOLD_BYTES=${PLUGIN_SETTING_THRESHOLD_BYTES:-${SUPERCOMPACT_THRESHOLD_BYTES:-2700000}}
 
 # Fast path: skip tokenizer if file is clearly under threshold (bytes / 16 is a safe lower bound)
@@ -55,7 +68,7 @@ else
 fi
 
 if (( OVER_THRESHOLD )); then
-  log "Threshold exceeded (file=${FILE_BYTES} bytes, threshold=${THRESHOLD_TOKENS} tokens) — triggering preemptive compaction"
+  log "THRESHOLD exceeded (file=${FILE_BYTES} bytes, tokens~=${TOKEN_COUNT:-?}, threshold=${THRESHOLD_TOKENS}) — triggering preemptive compaction (will compress to BUDGET)"
 
   # Resolve plugin root (CLAUDE_PLUGIN_ROOT is set by Claude Code for plugin hooks)
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/plugins/bundled/supercompact/scripts/set-budget.sh
+++ b/plugins/bundled/supercompact/scripts/set-budget.sh
@@ -1,18 +1,35 @@
 #!/usr/bin/env bash
-# set-budget.sh — Persist supercompact budget defaults for future sessions.
+# set-budget.sh — Persist supercompact configuration for future sessions.
+#
+# Two distinct knobs:
+#   - THRESHOLD: token count at which preemptive auto-compaction TRIGGERS.
+#     Should be near the model's context window so it fires just before
+#     the native API auto-compact would. Default: 180000 (90% of 200k).
+#   - BUDGET: target token count compaction COMPRESSES TO.
+#     Should be much smaller than THRESHOLD to leave headroom for new work.
+#     Default: 50000 (or auto = percentage of current size).
+#
+# These MUST be different — THRESHOLD > BUDGET, with healthy headroom
+# (we enforce THRESHOLD >= BUDGET + 30000).
 #
 # Writes key=value lines to ~/.config/unleash/plugins/supercompact/settings.env,
 # which the compaction pipeline sources before applying its own defaults.
 #
 # Usage (invoked from the /supercompact-budget slash command):
-#   set-budget.sh                 — show current effective settings
-#   set-budget.sh <N>             — set manual budget to N, switch to manual mode
-#   set-budget.sh auto            — switch back to auto (percentage) mode
-#   set-budget.sh floor <N>       — set BUDGET_FLOOR
-#   set-budget.sh ceiling <N>     — set BUDGET_CEILING
-#   set-budget.sh reset           — clear all overrides
+#   set-budget.sh                       — show current effective settings
+#   set-budget.sh <N>                   — set BUDGET (compression target)
+#   set-budget.sh budget <N>            — set BUDGET (alias)
+#   set-budget.sh auto                  — switch BUDGET to auto (% of current)
+#   set-budget.sh threshold <N>         — set THRESHOLD (auto-compact trigger)
+#   set-budget.sh threshold default     — restore default THRESHOLD (180000)
+#   set-budget.sh floor <N>             — set BUDGET_FLOOR
+#   set-budget.sh ceiling <N>           — set BUDGET_CEILING
+#   set-budget.sh reset                 — clear all overrides
 
 set -uo pipefail
+
+DEFAULT_THRESHOLD=180000
+MIN_HEADROOM=30000
 
 SETTINGS_DIR="${HOME}/.config/unleash/plugins/supercompact"
 SETTINGS_FILE="${SETTINGS_DIR}/settings.env"
@@ -32,12 +49,37 @@ unset_kv() {
   sed -i "/^${1}=/d" "${SETTINGS_FILE}" 2>/dev/null || true
 }
 
+read_kv() {
+  grep "^${1}=" "${SETTINGS_FILE}" 2>/dev/null | tail -1 | cut -d= -f2-
+}
+
 show() {
   echo "Supercompact settings (${SETTINGS_FILE}):"
   if [[ -s "${SETTINGS_FILE}" ]]; then
     sed 's/^/  /' "${SETTINGS_FILE}"
   else
-    echo "  (no overrides — using plugin defaults: mode=auto, floor=100000, ceiling=150000)"
+    echo "  (no overrides — using plugin defaults)"
+  fi
+  echo
+  echo "Effective:"
+  local mode budget threshold
+  mode=$(read_kv PLUGIN_SETTING_BUDGET_MODE)
+  budget=$(read_kv PLUGIN_SETTING_BUDGET)
+  threshold=$(read_kv PLUGIN_SETTING_THRESHOLD_TOKENS)
+  echo "  THRESHOLD (auto-compact trigger) : ${threshold:-${DEFAULT_THRESHOLD} (default)}"
+  echo "  BUDGET    (compression target)   : ${budget:-auto} (mode=${mode:-auto})"
+}
+
+# Warn (don't fail) when threshold and budget have insufficient headroom.
+check_headroom() {
+  local threshold budget
+  threshold=$(read_kv PLUGIN_SETTING_THRESHOLD_TOKENS)
+  threshold="${threshold:-${DEFAULT_THRESHOLD}}"
+  budget=$(read_kv PLUGIN_SETTING_BUDGET)
+  [[ -z "${budget}" ]] && return 0
+  if (( threshold < budget + MIN_HEADROOM )); then
+    echo "warning: THRESHOLD (${threshold}) should be at least ${MIN_HEADROOM} above BUDGET (${budget})." >&2
+    echo "         Otherwise compaction will re-trigger immediately after running." >&2
   fi
 }
 
@@ -53,7 +95,7 @@ case "${cmd}" in
   auto)
     set_kv PLUGIN_SETTING_BUDGET_MODE auto
     unset_kv PLUGIN_SETTING_BUDGET
-    echo "Switched to auto (percentage-of-current) budget mode."
+    echo "Switched BUDGET to auto (percentage-of-current) mode."
     show
     ;;
   reset)
@@ -73,14 +115,45 @@ case "${cmd}" in
     echo "Budget ceiling set to ${val} tokens."
     show
     ;;
+  threshold)
+    val="${2:-}"
+    if [[ "${val}" == "default" || -z "${val}" && "${cmd}" == "threshold" ]]; then
+      unset_kv PLUGIN_SETTING_THRESHOLD_TOKENS
+      echo "THRESHOLD reset to default (${DEFAULT_THRESHOLD} tokens)."
+    elif is_int "${val}"; then
+      set_kv PLUGIN_SETTING_THRESHOLD_TOKENS "${val}"
+      echo "THRESHOLD set to ${val} tokens (auto-compaction triggers above this)."
+      check_headroom
+    else
+      die "threshold requires a positive integer or 'default' (got: '${val}')"
+    fi
+    show
+    ;;
+  budget)
+    val="${2:-}"
+    if [[ "${val}" == "auto" ]]; then
+      set_kv PLUGIN_SETTING_BUDGET_MODE auto
+      unset_kv PLUGIN_SETTING_BUDGET
+      echo "Switched BUDGET to auto (percentage-of-current) mode."
+    elif is_int "${val}"; then
+      set_kv PLUGIN_SETTING_BUDGET_MODE manual
+      set_kv PLUGIN_SETTING_BUDGET "${val}"
+      echo "Manual BUDGET set to ${val} tokens (compression target, mode=manual)."
+      check_headroom
+    else
+      die "budget requires a positive integer or 'auto' (got: '${val}')"
+    fi
+    show
+    ;;
   *)
     if is_int "${cmd}"; then
       set_kv PLUGIN_SETTING_BUDGET_MODE manual
       set_kv PLUGIN_SETTING_BUDGET "${cmd}"
-      echo "Manual budget set to ${cmd} tokens (mode=manual)."
+      echo "Manual BUDGET set to ${cmd} tokens (compression target, mode=manual)."
+      check_headroom
       show
     else
-      die "unknown argument '${cmd}'. Try: <N> | auto | floor <N> | ceiling <N> | reset | show"
+      die "unknown argument '${cmd}'. Try: <N> | budget <N> | budget auto | threshold <N> | threshold default | floor <N> | ceiling <N> | reset | show"
     fi
     ;;
 esac


### PR DESCRIPTION
## Summary
Supercompact had two distinct knobs that were easy to conflate, causing the auto-compaction trigger to fire at the same level as the compression target — making compaction re-trigger immediately after running.

- **THRESHOLD**: token count at which preemptive auto-compaction TRIGGERS. Should sit just below the model context window. Default lowered from 200000 → 180000 (90% of 200k cloud window).
- **BUDGET**: target token count compaction COMPRESSES TO. Stays user-controlled, should be much smaller than THRESHOLD.

## Changes
- `set-budget.sh`: adds `threshold <N>` and `budget <N>` subcommands. Warns when `THRESHOLD < BUDGET + 30000` (insufficient headroom).
- `supercompact-userprompt.sh`: now sources `~/.config/unleash/plugins/supercompact/settings.env` so the new threshold setting takes effect across runs. Default 180000.
- `/supercompact-budget` slash command doc: documents both knobs and the headroom invariant.

## Test plan
- [x] `set-budget.sh show` reports both THRESHOLD and BUDGET clearly
- [x] `set-budget.sh threshold 60000` with `BUDGET=50000` warns about insufficient headroom
- [x] `set-budget.sh threshold default` clears the override and falls back to 180000
- [x] `bash -n` clean on both modified shell scripts
- [ ] In practice: confirm auto-compaction no longer re-fires on the post-compact prompt