### PR TITLE
fix(supercompact): self-disable guard against stale hook registrations

### DIFF
--- a/plugins/bundled/supercompact/hooks-handlers/supercompact-precompact.sh
+++ b/plugins/bundled/supercompact/hooks-handlers/supercompact-precompact.sh
@@ -14,6 +14,14 @@
 
 set -uo pipefail
 
+# Self-disable guard: bail if supercompact is disabled in unleash config.
+# Robust against stale hook registrations the wrapper failed to prune.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_ENABLED="${SCRIPT_DIR}/../scripts/check-enabled.sh"
+if [[ -x "${CHECK_ENABLED}" ]] && ! "${CHECK_ENABLED}" supercompact; then
+  exit 0
+fi
+
 LOG_DIR="${HOME}/.cache/supercompact"
 mkdir -p "${LOG_DIR}" 2>/dev/null || true
 log() { echo "$(date -Iseconds) [precompact] $1" >> "${LOG_DIR}/hook.log" 2>/dev/null || true; }

--- a/plugins/bundled/supercompact/hooks-handlers/supercompact-userprompt.sh
+++ b/plugins/bundled/supercompact/hooks-handlers/supercompact-userprompt.sh
@@ -12,6 +12,14 @@
 
 set -uo pipefail
 
+# Self-disable guard: bail if supercompact is disabled in unleash config.
+# Robust against stale hook registrations the wrapper failed to prune.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_ENABLED="${SCRIPT_DIR}/../scripts/check-enabled.sh"
+if [[ -x "${CHECK_ENABLED}" ]] && ! "${CHECK_ENABLED}" supercompact; then
+  exit 0
+fi
+
 LOG_DIR="${HOME}/.cache/supercompact"
 mkdir -p "${LOG_DIR}" 2>/dev/null || true
 log() { echo "$(date -Iseconds) [userprompt] $1" >> "${LOG_DIR}/hook.log" 2>/dev/null || true; }

--- a/plugins/bundled/supercompact/scripts/check-enabled.sh
+++ b/plugins/bundled/supercompact/scripts/check-enabled.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# check-enabled.sh — exit 0 if supercompact is enabled in unleash config,
+# 1 otherwise. Used by hook scripts as a self-disable guard against stale
+# registrations in ~/.claude/settings.json that the wrapper failed to prune.
+#
+# Empty enabled_plugins list = "all enabled" (backwards-compat semantics).
+
+set -uo pipefail
+
+PLUGIN_NAME="${1:-supercompact}"
+UNLEASH_CONFIG="${HOME}/.config/unleash/config.toml"
+
+# No config = treat as all enabled (first run, before TUI written anything).
+[[ ! -f "${UNLEASH_CONFIG}" ]] && exit 0
+
+# Extract the enabled_plugins array body.
+enabled_block=$(awk '
+  /^[[:space:]]*enabled_plugins[[:space:]]*=[[:space:]]*\[/ { in_block=1 }
+  in_block { print }
+  in_block && /\]/ { exit }
+' "${UNLEASH_CONFIG}")
+
+# No enabled_plugins key at all = treat as all enabled.
+[[ -z "${enabled_block}" ]] && exit 0
+
+# Block exists but contains no quoted entries = empty list = all enabled.
+if ! grep -q '"' <<<"${enabled_block}"; then
+  exit 0
+fi
+
+# Block has entries — must contain our plugin name explicitly.
+grep -q "\"${PLUGIN_NAME}\"" <<<"${enabled_block}"


### PR DESCRIPTION
## Problem
Disabling supercompact in the TUI doesn't reliably stop its hooks from firing.

Root cause: hook entries in \`~/.claude/settings.json\` outlive the plugin's enabled/disabled state. The wrapper only prunes them at \`unleash\` startup or on TUI toggle — \`unleash-refresh\` restarts Claude inside the existing wrapper loop and never re-runs the prune. Once a stale entry lands in settings.json (because the wrapper was open before a toggle, or because the plugin name lookup misses for any reason), it keeps firing on every UserPromptSubmit/PreCompact.

## Fix
Add a tiny \`scripts/check-enabled.sh\` helper. Reads \`~/.config/unleash/config.toml\`, exits 0 if supercompact appears in \`enabled_plugins\` (or the list is empty = all-enabled back-compat), 1 otherwise.

Both hook scripts call it as their first action and exit 0 immediately when disabled. The wrapper-level prune logic still runs on its existing schedule; this is just a belt-and-braces guard at the hook itself, so the plugin can't fire even when its hook entries are stale.

Independent of the Rust code — works without a rebuild.

## Test plan
- [x] \`check-enabled.sh\` returns 0 for empty list, 0 when supercompact is listed, 1 when not listed
- [x] Live test: with supercompact NOT in enabled_plugins, invoking the hook script returns 0 immediately and writes nothing to the log
- [x] \`bash -n\` clean on all three modified/new shell scripts