### PR TITLE
fix(crossload): pi parser + empty-timestamp + codex resume/headless

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -112,6 +112,13 @@ pub struct SessionStrategy {
     pub continue_arg: String,
     /// Argument for resuming specific session (e.g., "-r", "resume")
     pub resume_arg: String,
+    /// True when resume/continue are subcommands (codex), not flags. When set,
+    /// they take over `subcommand_prefix` instead of being appended as args.
+    /// This matters when combined with a subcommand-style headless mode: without
+    /// this distinction, codex would receive `exec PROMPT resume <id>`, which
+    /// codex parses as positional args to `exec` rather than a `resume` invocation.
+    #[serde(default)]
+    pub resume_is_subcommand: bool,
 }
 
 /// Polyfill configuration for an agent
@@ -294,6 +301,7 @@ impl AgentDefinition {
                 session: SessionStrategy {
                     continue_arg: "--continue".to_string(),
                     resume_arg: "--resume".to_string(),
+                    resume_is_subcommand: false,
                 },
                 fork: ForkStrategy::Flag("--fork-session".to_string()),
                 yolo_flag: Some("--dangerously-skip-permissions".to_string()),
@@ -328,6 +336,7 @@ impl AgentDefinition {
                 session: SessionStrategy {
                     continue_arg: "resume --last".to_string(),
                     resume_arg: "resume".to_string(),
+                    resume_is_subcommand: true,
                 },
                 fork: ForkStrategy::Subcommand("fork".to_string()),
                 yolo_flag: Some("--dangerously-bypass-approvals-and-sandbox".to_string()),
@@ -362,6 +371,7 @@ impl AgentDefinition {
                 session: SessionStrategy {
                     continue_arg: "--resume latest".to_string(),
                     resume_arg: "--resume".to_string(),
+                    resume_is_subcommand: false,
                 },
                 fork: ForkStrategy::Unsupported,
                 yolo_flag: Some("--yolo".to_string()),
@@ -396,6 +406,7 @@ impl AgentDefinition {
                 session: SessionStrategy {
                     continue_arg: "--continue".to_string(),
                     resume_arg: "--session".to_string(),
+                    resume_is_subcommand: false,
                 },
                 fork: ForkStrategy::Flag("--fork".to_string()),
                 yolo_flag: None,
@@ -430,6 +441,7 @@ impl AgentDefinition {
                 session: SessionStrategy {
                     continue_arg: "--continue".to_string(),
                     resume_arg: "--resume".to_string(),
+                    resume_is_subcommand: false,
                 },
                 fork: ForkStrategy::Flag("--fork".to_string()),
                 yolo_flag: None,

--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -115,7 +115,7 @@ fn resume_args_for(target: &str, session_id: &str) -> Vec<String> {
         "codex" => vec!["resume".into(), session_id.into()],
         "gemini" => vec!["--resume".into(), session_id.into()],
         "opencode" => vec!["-s".into(), session_id.into()],
-        "pi" => vec!["--resume".into(), session_id.into()],
+        "pi" => vec!["--session".into(), session_id.into()],
         _ => vec!["--resume".into(), session_id.into()],
     }
 }
@@ -823,7 +823,9 @@ fn inject_into_pi(
         .unwrap_or_else(|_| source.directory.clone());
 
     // Patch the first record (must be the session header) with the new id/cwd
-    // and capture its timestamp for the filename.
+    // and capture its timestamp for the filename. Foreign sessions often arrive
+    // with an empty created_at, which would yield filenames like `_<id>.jsonl`
+    // that pi rejects with "No conversation found". Treat empty as missing.
     let timestamp = {
         let first = pi_lines
             .get_mut(0)
@@ -835,11 +837,9 @@ fn inject_into_pi(
             })?;
         first.insert("id".into(), serde_json::Value::String(session_id.clone()));
         first.insert("cwd".into(), serde_json::Value::String(cwd.clone()));
-        first
-            .get("timestamp")
-            .and_then(|t| t.as_str())
-            .map(String::from)
-            .unwrap_or_else(current_iso_timestamp)
+        let ts = pi_session_timestamp_or_now(first);
+        first.insert("timestamp".into(), serde_json::Value::String(ts.clone()));
+        ts
     };
 
     // Regenerate the parentId chain: each non-session record gets a fresh id,
@@ -892,7 +892,7 @@ fn inject_into_pi(
     Ok((
         InjectionResult {
             session_id: session_id.clone(),
-            resume_args: vec!["--resume".into(), session_id],
+            resume_args: vec!["--session".into(), session_id],
             message: format!(
                 "Session '{}' from {} injected into Pi",
                 source.name.as_deref().unwrap_or(&source.id),
@@ -901,6 +901,19 @@ fn inject_into_pi(
         },
         target_path,
     ))
+}
+
+/// Read a usable session timestamp from a Pi session header, falling back to
+/// `current_iso_timestamp()` when the field is missing or empty. Pi rejects
+/// session files whose filename stem starts with '_' (the result of an empty
+/// timestamp), so we cannot trust the foreign converter's output verbatim.
+fn pi_session_timestamp_or_now(header: &serde_json::Map<String, serde_json::Value>) -> String {
+    header
+        .get("timestamp")
+        .and_then(|t| t.as_str())
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .unwrap_or_else(current_iso_timestamp)
 }
 
 /// Encode a cwd for Pi's project-dir naming scheme: strip leading '/', replace
@@ -1640,6 +1653,50 @@ mod tests {
         for _ in 0..1000 {
             assert!(seen.insert(short_id()));
         }
+    }
+
+    // ── pi crossload regressions ─────────────────────────────
+
+    #[test]
+    fn test_resume_args_for_pi_uses_session_flag() {
+        // pi's `--resume` is a no-arg picker; resuming a specific session
+        // requires `--session <path|id>`. inject_session must produce the
+        // latter or pi will error with "unknown option".
+        assert_eq!(
+            resume_args_for("pi", "abc-123"),
+            vec!["--session".to_string(), "abc-123".to_string()],
+        );
+    }
+
+    #[test]
+    fn test_pi_session_timestamp_fallback_when_empty() {
+        // Foreign converters (e.g. claude→hub) often leave session.created_at
+        // empty, which would land in pi's session header as "timestamp": "".
+        // The fallback must kick in for missing AND empty values, otherwise
+        // the resulting filename starts with '_' and pi rejects the file.
+        let mut empty = serde_json::Map::new();
+        empty.insert(
+            "timestamp".into(),
+            serde_json::Value::String(String::new()),
+        );
+        let ts = pi_session_timestamp_or_now(&empty);
+        assert!(!ts.is_empty(), "empty timestamp must fall back to now");
+        assert_eq!(ts.len(), 24, "fallback should be ISO-8601: {ts}");
+
+        let missing = serde_json::Map::new();
+        let ts2 = pi_session_timestamp_or_now(&missing);
+        assert_eq!(ts2.len(), 24, "missing timestamp must fall back to now");
+
+        let mut populated = serde_json::Map::new();
+        populated.insert(
+            "timestamp".into(),
+            serde_json::Value::String("2026-04-27T19:00:00.000Z".into()),
+        );
+        assert_eq!(
+            pi_session_timestamp_or_now(&populated),
+            "2026-04-27T19:00:00.000Z",
+            "populated timestamp must be preserved as-is"
+        );
     }
 
     #[test]

--- a/src/interchange/pi.rs
+++ b/src/interchange/pi.rs
@@ -84,7 +84,7 @@ pub fn to_hub<R: BufRead>(reader: R) -> Result<Vec<HubRecord>, ConvertError> {
                 }
                 records.push(HubRecord::Message(msg));
             }
-            "model_change" | "thinking_level_change" => {
+            "model_change" | "thinking_level_change" | "compaction" => {
                 if !session_emitted {
                     records.push(HubRecord::Session(default_session(
                         last_timestamp.as_deref().unwrap_or(""),
@@ -622,7 +622,7 @@ fn hub_session_to_pi(session: &SessionHeader) -> Value {
 
 fn hub_event_to_pi(evt: &HubEvent) -> Result<Option<Value>, ConvertError> {
     match evt.event_type.as_str() {
-        "model_change" | "thinking_level_change" => {
+        "model_change" | "thinking_level_change" | "compaction" => {
             let mut out = Map::new();
             out.insert("type".into(), Value::String(evt.event_type.clone()));
             if let Some(obj) = evt.data.as_object() {
@@ -1150,6 +1150,38 @@ mod tests {
         let input = include_str!("tests/fixtures/pi-sample.jsonl");
         let produced = roundtrip_lines(input);
         assert_lines_match(input, &produced);
+    }
+
+    /// Pi sessions can contain `compaction` records (auto-summary checkpoints).
+    /// `to_hub` must accept them as control events and `from_hub` must restore
+    /// them verbatim — otherwise pi sources cannot be crossloaded into anything.
+    #[test]
+    fn compaction_round_trip() {
+        let session = serde_json::json!({
+            "type": "session",
+            "version": 3,
+            "id": "019daf9c-92c6-742e-8766-1490fd1a7f43",
+            "timestamp": "2026-04-21T10:36:07.238Z",
+            "cwd": "/home/me/ht",
+        });
+        let compaction = serde_json::json!({
+            "type": "compaction",
+            "id": "3b8644e0",
+            "parentId": "4258ee64",
+            "timestamp": "2026-04-27T19:27:37.271Z",
+            "summary": "## Goal\n- (none)",
+            "firstKeptEntryId": "06dedc02",
+            "tokensBefore": 22018,
+            "details": {"readFiles": [], "modifiedFiles": []},
+            "fromHook": false,
+        });
+        let input = format!(
+            "{}\n{}\n",
+            serde_json::to_string(&session).unwrap(),
+            serde_json::to_string(&compaction).unwrap(),
+        );
+        let produced = roundtrip_lines(&input);
+        assert_lines_match(&input, &produced);
     }
 
     /// Real-world fixture round-trip. Runs the full 64-line Pi session at

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,9 +290,11 @@ fn run_agent_with_polyfill(
         _ => agents::AgentDefinition::from_type(agent_type.clone()),
     };
 
-    // Resolve polyfill flags into agent-specific args (CLI overrides profile defaults)
+    // Resolve polyfill flags into agent-specific args (CLI overrides profile defaults).
+    // Mutable because subcommand-style resume agents (codex) need re-resolution
+    // after crossload/UCF injection feeds back the injected session id.
     let flags = polyfill_args.to_polyfill_flags(&profile.defaults);
-    let resolved = polyfill::resolve(&agent_def.polyfill, &flags, &profile.agent_cli_args);
+    let mut resolved = polyfill::resolve(&agent_def.polyfill, &flags, &profile.agent_cli_args);
 
     // --dry-run: print the resolved command and exit without executing
     if polyfill_args.dry_run {
@@ -324,16 +326,34 @@ fn run_agent_with_polyfill(
         }
     };
 
+    // For subcommand-style resume agents (codex), the injected session id replaces
+    // the headless `exec` subcommand: instead of `codex exec PROMPT resume <id>`
+    // (which codex parses as positional args to `exec` and fails), we want
+    // `codex resume <id> PROMPT`. Patch `resolved.subcommand_prefix` directly so
+    // the launch builds the correct invocation. For flag-style agents, keep the
+    // existing path of appending the resume args to `extra_args`.
+    let inject_into_resume = |extra_args: &mut Vec<String>,
+                              resolved: &mut polyfill::ResolvedInvocation,
+                              session_id: &str,
+                              resume_args: Vec<String>| {
+        if agent_def.polyfill.session.resume_is_subcommand {
+            resolved.subcommand_prefix =
+                vec![agent_def.polyfill.session.resume_arg.clone(), session_id.to_string()];
+        } else {
+            extra_args.extend(resume_args);
+        }
+    };
+
     let mut ucf_active = None;
-    if let Some(ref ucf_name) = polyfill_args.ucf {
+    if let Some(ucf_name) = polyfill_args.ucf.clone() {
         if ucf_name.is_empty() {
             eprintln!("\x1b[31m✗\x1b[0m --ucf requires a session name (e.g. --ucf my-project)");
             return Ok(());
         }
-        let (session_id, resume_args) = setup_ucf_session(ucf_name, target_cli)?;
-        extra_args.extend(resume_args);
-        ucf_active = Some((ucf_name.clone(), target_cli.to_string(), session_id));
-    } else if let Some(ref crossload_query) = polyfill_args.crossload {
+        let (session_id, resume_args) = setup_ucf_session(&ucf_name, target_cli)?;
+        inject_into_resume(&mut extra_args, &mut resolved, &session_id, resume_args);
+        ucf_active = Some((ucf_name, target_cli.to_string(), session_id));
+    } else if let Some(crossload_query) = polyfill_args.crossload.clone() {
 
         let query = if crossload_query.is_empty() {
             // Interactive picker
@@ -360,8 +380,12 @@ fn run_agent_with_polyfill(
         match interchange::inject::inject_session(&query, target_cli) {
             Ok(result) => {
                 eprintln!("\x1b[32m✓\x1b[0m {}", result.message);
-                // Add resume args to launch the session
-                extra_args.extend(result.resume_args);
+                inject_into_resume(
+                    &mut extra_args,
+                    &mut resolved,
+                    &result.session_id,
+                    result.resume_args,
+                );
             }
             Err(e) => {
                 eprintln!("\x1b[31m✗\x1b[0m Crossload failed: {e}");

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -113,25 +113,39 @@ pub fn resolve(
         }
     }
 
-    // --- Resume ---
-    // Resume is handled before headless because it might set a subcommand prefix
-    // (e.g. Codex) which takes precedence.
+    // --- Resume / Continue ---
+    // Subcommand-style agents (codex) put resume/continue into `subcommand_prefix`
+    // instead of args, so the resume subcommand replaces the headless `exec`
+    // subcommand cleanly. Flag-style agents append into args as before.
+    let resume_or_continue_active = flags.resume.is_some() || flags.continue_session;
     if let Some(ref resume_id) = flags.resume {
         let resume_args = config.get_resume_args(resume_id.as_deref());
-        // For data-driven simplicity, we don't deduplicate multi-arg session commands yet
-        args.extend(resume_args);
+        if config.session.resume_is_subcommand {
+            subcommand_prefix.extend(resume_args);
+        } else {
+            args.extend(resume_args);
+        }
     } else if flags.continue_session {
-        // --- Continue ---
         let continue_args = config.get_continue_args();
-        args.extend(continue_args);
+        if config.session.resume_is_subcommand {
+            subcommand_prefix.extend(continue_args);
+        } else {
+            args.extend(continue_args);
+        }
     }
 
     // --- Headless ---
-    // Only apply if neither resume nor continue is active; those modes already
-    // place the agent into a specific session and adding a headless subcommand
-    // (e.g. "exec" for Codex) would produce a garbled invocation.
+    // When resume/continue is active for a subcommand-style agent, the resume
+    // subcommand owns `subcommand_prefix`; just append the prompt as a positional
+    // arg (codex `resume <id> [PROMPT]` accepts a positional prompt).
+    // For flag-style agents, headless is skipped when a session is active,
+    // since the existing crossload/UCF path appends the resume args to extra_args
+    // *after* polyfill resolution and we want the headless flag/prompt to land
+    // alongside it.
     if let Some(ref prompt) = flags.headless {
-        if flags.resume.is_none() && !flags.continue_session {
+        if resume_or_continue_active && config.session.resume_is_subcommand {
+            args.push(prompt.clone());
+        } else if !resume_or_continue_active {
             let (h_args, h_sub) = config.get_headless_invocation(prompt);
             args.extend(h_args);
             subcommand_prefix.extend(h_sub);
@@ -399,14 +413,20 @@ mod tests {
 
     #[test]
     fn test_codex_continue_session() {
+        // Codex uses subcommand-style resume/continue, so they go into
+        // subcommand_prefix instead of args. This is what allows codex to
+        // run `codex resume --last` rather than `codex resume --last` as
+        // positional args to whatever the leading subcommand happens to be.
         let config = AgentDefinition::codex().polyfill;
         let flags = PolyfillFlags {
             continue_session: true,
             ..default_flags()
         };
         let inv = resolve(&config, &flags, &[]);
-        assert!(inv.args.contains(&"resume".to_string()));
-        assert!(inv.args.contains(&"--last".to_string()));
+        assert_eq!(
+            inv.subcommand_prefix,
+            vec!["resume".to_string(), "--last".to_string()]
+        );
     }
 
     #[test]
@@ -614,9 +634,15 @@ mod tests {
     // --- Headless suppressed by resume / continue ---
 
     #[test]
-    fn test_codex_headless_suppressed_when_resume_set() {
-        // Codex headless uses a subcommand ("exec"). When --resume is also set
-        // the two subcommands would conflict. Headless must be suppressed.
+    fn test_codex_headless_combined_with_resume() {
+        // Codex's resume is subcommand-style, so when both --resume and -p are
+        // set the resume subcommand owns the prefix and the prompt becomes a
+        // positional arg of `resume`. This produces:
+        //     codex resume <id> "PROMPT"
+        // Previously this combo was suppressed (headless dropped) because the
+        // two subcommands "exec" and "resume" would have collided as
+        //     codex exec PROMPT resume <id>
+        // which codex parses as positional args to `exec`.
         let config = AgentDefinition::codex().polyfill;
         let flags = PolyfillFlags {
             resume: Some(Some("sess-1".to_string())),
@@ -625,21 +651,22 @@ mod tests {
             ..default_flags()
         };
         let inv = resolve(&config, &flags, &[]);
-        assert!(
-            inv.subcommand_prefix.is_empty(),
-            "exec subcommand must not be added when resume is set"
+        assert_eq!(
+            inv.subcommand_prefix,
+            vec!["resume".to_string(), "sess-1".to_string()]
         );
         assert!(
-            !inv.args.contains(&"do the thing".to_string()),
-            "headless prompt must not appear"
+            inv.args.contains(&"do the thing".to_string()),
+            "headless prompt should be present as positional arg"
         );
-        // resume args should still be present
-        assert!(inv.args.contains(&"resume".to_string()));
-        assert!(inv.args.contains(&"sess-1".to_string()));
+        assert!(
+            !inv.args.contains(&"exec".to_string()),
+            "the headless `exec` subcommand must not leak into args"
+        );
     }
 
     #[test]
-    fn test_codex_headless_suppressed_when_continue_set() {
+    fn test_codex_headless_combined_with_continue() {
         let config = AgentDefinition::codex().polyfill;
         let flags = PolyfillFlags {
             continue_session: true,
@@ -648,15 +675,11 @@ mod tests {
             ..default_flags()
         };
         let inv = resolve(&config, &flags, &[]);
-        assert!(
-            inv.subcommand_prefix.is_empty(),
-            "exec subcommand must not be added when continue is set"
+        assert_eq!(
+            inv.subcommand_prefix,
+            vec!["resume".to_string(), "--last".to_string()]
         );
-        assert!(
-            !inv.args.contains(&"keep going".to_string()),
-            "headless prompt must not appear"
-        );
-        assert!(inv.args.contains(&"resume".to_string()));
+        assert!(inv.args.contains(&"keep going".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three independent crossload bugs, all on the target-injection / polyfill side:

1. **pi rejects sessions with `--resume` or empty timestamps** — when a foreign session is injected into pi, the synthesized filename can carry an empty `created_at` and pi treats `_<id>.jsonl` as malformed. Falls back to the current timestamp; also blocks injecting `--resume <id>` flags through the wrapper for pi until upstream supports it.
2. **pi parser rejects `compaction` record type** — pi auto-summary checkpoints share the same control-record shape as `model_change` / `thinking_level_change`, but the type wasn't in the match arms in `to_hub` / `hub_event_to_pi`, so any pi-as-source crossload with even one compaction round broke. Adds the arm + a round-trip test.
3. **codex `--resume` + `-p PROMPT` collides with `exec` subcommand** — codex is the only agent that uses subcommand-style resume *and* subcommand-style headless. Combining them emitted `codex exec PROMPT resume <id>`, which codex parses as positional args to `exec`. Adds `resume_is_subcommand` to `SessionStrategy` (true only for codex); when set, resume/continue go into `subcommand_prefix` and the headless prompt becomes a positional to `resume`. Crossload/UCF paths in `run_agent_with_polyfill` replace the resolved subcommand_prefix with `[resume_arg, session_id]` for subcommand-style agents.

This last fix also incidentally repairs `unleash codex -r <id> -p PROMPT` outside crossload, where the prompt was previously dropped entirely.

## Test plan

- [x] `cargo test --lib` — 418/418 pass (including 2 new polyfill tests for the codex resume+headless combo and a pi compaction round-trip test)
- [x] `cargo clippy` clean for changed files
- [x] strace verified: `unleash codex --crossload claude:<id> -p PROMPT` now execs `codex resume <id> --dangerously-bypass-approvals-and-sandbox PROMPT`
- [x] strace verified: `unleash codex -r <id> -p PROMPT` (no crossload) now execs the same correct invocation