### PR TITLE
refactor(supercompact): replace bash TOML parsing with config subcommand

### DIFF
--- a/plugins/bundled/supercompact/scripts/check-enabled.sh
+++ b/plugins/bundled/supercompact/scripts/check-enabled.sh
@@ -1,32 +1,19 @@
 #!/usr/bin/env bash
-# check-enabled.sh — exit 0 if supercompact is enabled in unleash config,
+# check-enabled.sh — exit 0 if the named plugin is enabled in the unleash config,
 # 1 otherwise. Used by hook scripts as a self-disable guard against stale
 # registrations in ~/.claude/settings.json that the wrapper failed to prune.
 #
-# Empty enabled_plugins list = "all enabled" (backwards-compat semantics).
+# Delegates to `unleash config is-plugin-enabled <name>` so the TOML parsing
+# lives in Rust (where it is type-checked) instead of fragile awk/grep.
 
 set -uo pipefail
 
 PLUGIN_NAME="${1:-supercompact}"
-UNLEASH_CONFIG="${HOME}/.config/unleash/config.toml"
 
-# No config = treat as all enabled (first run, before TUI written anything).
-[[ ! -f "${UNLEASH_CONFIG}" ]] && exit 0
-
-# Extract the enabled_plugins array body.
-enabled_block=$(awk '
-  /^[[:space:]]*enabled_plugins[[:space:]]*=[[:space:]]*\[/ { in_block=1 }
-  in_block { print }
-  in_block && /\]/ { exit }
-' "${UNLEASH_CONFIG}")
-
-# No enabled_plugins key at all = treat as all enabled.
-[[ -z "${enabled_block}" ]] && exit 0
-
-# Block exists but contains no quoted entries = empty list = all enabled.
-if ! grep -q '"' <<<"${enabled_block}"; then
+# If unleash is not on PATH (e.g. plugin running outside the wrapper), fail
+# safe: treat as enabled. The hook will run; worst case is a no-op.
+if ! command -v unleash >/dev/null 2>&1; then
   exit 0
 fi
 
-# Block has entries — must contain our plugin name explicitly.
-grep -q "\"${PLUGIN_NAME}\"" <<<"${enabled_block}"
+unleash config is-plugin-enabled "${PLUGIN_NAME}"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -663,9 +663,27 @@ pub enum Commands {
         tokenizer: Option<String>,
     },
 
+    /// Query unleash configuration state (used by hooks and scripts)
+    Config {
+        #[command(subcommand)]
+        action: ConfigAction,
+    },
+
     /// Run a profile by name (catches any unknown subcommand as a profile name)
     #[command(external_subcommand)]
     Profile(Vec<String>),
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ConfigAction {
+    /// Exit 0 if the named plugin is enabled (or enabled_plugins is empty), 1 otherwise.
+    ///
+    /// Empty `enabled_plugins` means "all enabled" for backwards compatibility.
+    /// Missing config file is treated the same way (first run before TUI write).
+    IsPluginEnabled {
+        /// Plugin name to check (e.g. "supercompact")
+        name: String,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ mod version;
 
 use crate::agents::AgentType;
 use clap::Parser;
-use cli::{Cli, Commands};
+use cli::{Cli, Commands, ConfigAction};
 use config::ProfileManager;
 use std::env;
 use std::io;
@@ -1146,6 +1146,7 @@ pub fn run() -> io::Result<()> {
         Some(Commands::TokenCount { file, tokenizer }) => {
             token_count::handle_token_count(&file, tokenizer.as_deref())
         }
+        Some(Commands::Config { action }) => handle_config(action),
         None => {
             #[cfg(feature = "tui")]
             return tui::run();
@@ -1289,6 +1290,26 @@ mod tests {
         assert!(!is_known_subcommand("invalid-subcommand"));
         assert!(!is_known_subcommand(""));
         assert!(!is_known_subcommand("VERSION")); // case sensitive
+    }
+}
+
+fn handle_config(action: ConfigAction) -> io::Result<()> {
+    match action {
+        ConfigAction::IsPluginEnabled { name } => {
+            let manager = ProfileManager::new()?;
+            let path = manager.config_dir().join("config.toml");
+            // No config file = first run before TUI write = treat as all enabled.
+            if !path.exists() {
+                return Ok(());
+            }
+            let cfg = manager.load_app_config()?;
+            // Empty enabled_plugins = "all enabled" (backwards compat).
+            if cfg.enabled_plugins.is_empty() || cfg.enabled_plugins.contains(&name) {
+                Ok(())
+            } else {
+                std::process::exit(1);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Move TOML parsing of `enabled_plugins` from awk/grep in bash into a new `unleash config is-plugin-enabled <name>` Rust subcommand
- Update `check-enabled.sh` to delegate to it (zero new external deps; parsing is now type-checked)
- Preserves the existing semantics: missing config or empty `enabled_plugins` array both mean "all enabled" (backwards compat)

This is PR 3 of 4 from the tech-debt cleanup discussion (Gemini review on `fix/crossload-pi-resume-and-empty-timestamp`):

1. ✅ `ResumeStrategy` enum + agents.rs drift fix — Gemini, separate PR
2. ✅ `run_agent_with_polyfill` refactor — Gemini, separate PR
3. **This PR** — config subcommand for plugin-enabled check
4. Pi parser unknown-record stashing — follow-up

## Test plan

- [x] `unleash config is-plugin-enabled X` returns exit 0 on missing config file
- [x] Returns exit 0 on empty `enabled_plugins`
- [x] Returns exit 0 on missing `enabled_plugins` key
- [x] Returns exit 0 when plugin is in the list
- [x] Returns exit 1 when plugin is not in the list
- [x] Returns non-zero on malformed TOML
- [x] `check-enabled.sh` delegates correctly through all the above paths
- [x] `check-enabled.sh` fails safe (exit 0) when `unleash` is not on PATH