### PR TITLE
fix(interchange): block-level _ucf_hub.message passthrough for lossless cross-CLI round-trips

### DIFF
--- a/src/interchange/claude.rs
+++ b/src/interchange/claude.rs
@@ -86,6 +86,10 @@ pub fn from_hub(records: &[HubRecord]) -> Result<Vec<Value>, ConvertError> {
     let mut session_id = String::new();
     let mut version = String::new();
     let mut session_passthrough: Option<Value> = None;
+    // Whether to stash the entire HubMessage on each line for cross-CLI
+    // lossless round-trip. Native Claude sources don't need this — their own
+    // schema already captures everything. Foreign sources do.
+    let mut stash_messages = false;
 
     for record in records {
         match record {
@@ -97,10 +101,15 @@ pub fn from_hub(records: &[HubRecord]) -> Result<Vec<Value>, ConvertError> {
                 // ucf_version, title, slug, parent_session_id natively.
                 if s.source_cli != "claude-code" {
                     session_passthrough = Some(serde_json::to_value(s)?);
+                    stash_messages = true;
                 }
             }
             HubRecord::Message(msg) => {
-                lines.push(hub_message_to_claude(msg, &session_id, &version)?);
+                let mut line = hub_message_to_claude(msg, &session_id, &version)?;
+                if stash_messages {
+                    attach_ucf_hub_field(&mut line, "message", serde_json::to_value(msg)?);
+                }
+                lines.push(line);
             }
             HubRecord::Event(evt) => {
                 lines.push(hub_event_to_claude(evt, &session_id, &version)?);
@@ -206,7 +215,7 @@ fn message_to_hub(
         .and_then(|v| v.as_str())
         .map(String::from);
 
-    Ok(HubMessage {
+    let mut hub_msg = HubMessage {
         id: str_field(val, "uuid"),
         api_message_id: message.and_then(|m| opt_str(m, "id")),
         parent_id: opt_str(val, "parentUuid"),
@@ -216,7 +225,24 @@ fn message_to_hub(
         content,
         metadata,
         extensions: ext,
-    })
+    };
+
+    // If a full HubMessage was stashed via `_ucf_hub.message`, restore it
+    // verbatim so cross-CLI round-trips preserve every hub field that has no
+    // native Claude representation (mixed-content blocks, foreign metadata,
+    // etc.). Foreign extensions stashed under `_ucf_hub.ext` are already part
+    // of the stashed message, so this takes precedence.
+    if let Some(stashed) = val
+        .get("_ucf_hub")
+        .and_then(|u| u.get("message"))
+        .cloned()
+    {
+        if let Ok(restored) = serde_json::from_value::<HubMessage>(stashed) {
+            hub_msg = restored;
+        }
+    }
+
+    Ok(hub_msg)
 }
 
 fn build_claude_extensions(val: &Value, msg_type: &str) -> Value {
@@ -434,9 +460,21 @@ fn extract_metadata(val: &Value, msg_type: &str) -> MessageMetadata {
                     .get("cache_read_input_tokens")
                     .and_then(|v| v.as_u64())
                     .unwrap_or(0),
-                reasoning: 0,
-                tool: 0,
-                total: 0,
+                // Claude has no native reasoning/tool/total token fields, but we
+                // stash them in usage when writing from foreign hubs so a round
+                // trip preserves the counts. Read them back here.
+                reasoning: u
+                    .get("reasoning_tokens")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0),
+                tool: u
+                    .get("tool_tokens")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0),
+                total: u
+                    .get("total_tokens")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0),
             }),
             stop_reason: message.and_then(|m| opt_str(m, "stop_reason")),
             cwd: opt_str(val, "cwd"),
@@ -557,6 +595,17 @@ fn hub_message_to_claude(
                 "cache_creation_input_tokens": tokens.cache_creation,
                 "cache_read_input_tokens": tokens.cache_read,
             });
+            // Stash hub fields Claude has no native slot for so a round trip
+            // preserves them. `to_hub` reads them back into the hub TokenUsage.
+            if tokens.reasoning > 0 {
+                usage["reasoning_tokens"] = serde_json::json!(tokens.reasoning);
+            }
+            if tokens.tool > 0 {
+                usage["tool_tokens"] = serde_json::json!(tokens.tool);
+            }
+            if tokens.total > 0 {
+                usage["total_tokens"] = serde_json::json!(tokens.total);
+            }
             // Restore extra usage fields
             if let Some(extra) = cc.get("usage_extra") {
                 if let Some(obj) = extra.as_object() {

--- a/src/interchange/codex.rs
+++ b/src/interchange/codex.rs
@@ -59,6 +59,26 @@ pub fn to_hub<R: BufRead>(reader: R) -> Result<Vec<HubRecord>, ConvertError> {
                     records.push(HubRecord::Session(default_session(&timestamp)));
                     session_emitted = true;
                 }
+                // If the line carries a full HubMessage stash via
+                // `_ucf_hub.message`, restore it verbatim — Codex's response
+                // shape can't represent every hub content variant losslessly,
+                // but the stashed blob captures everything.
+                if let Some(stashed) = ucf_hub
+                    .and_then(|u| u.get("message"))
+                    .cloned()
+                {
+                    if let Ok(mut msg) = serde_json::from_value::<HubMessage>(stashed) {
+                        // Codex has no native `tool` role — its tool results
+                        // ride on user-role response_items. Coerce so cross-CLI
+                        // sources whose hub uses role="tool" still produce a
+                        // codex-shaped hub on the way out.
+                        if msg.role == "tool" {
+                            msg.role = "user".to_string();
+                        }
+                        records.push(HubRecord::Message(msg));
+                        continue;
+                    }
+                }
                 let mut msg = response_item_to_hub(&payload, &timestamp)?;
                 if foreign_originated {
                     // Synthesized codex extensions are not real claims about
@@ -169,6 +189,12 @@ pub fn to_hub<R: BufRead>(reader: R) -> Result<Vec<HubRecord>, ConvertError> {
 pub fn from_hub(records: &[HubRecord]) -> Result<Vec<Value>, ConvertError> {
     let mut lines = Vec::new();
     let mut session_passthrough: Option<Value> = None;
+    // Whether to stash the entire HubMessage on each emitted line for
+    // cross-CLI lossless round-trip. Native Codex sources don't need this
+    // (their `_original_payload` already captures everything). Foreign
+    // sources do — Codex's `response_item.content` flattens mixed content
+    // blocks (Thinking + Text + ToolUse) into output_text.
+    let mut stash_messages = false;
 
     for record in records {
         match record {
@@ -178,6 +204,7 @@ pub fn from_hub(records: &[HubRecord]) -> Result<Vec<Value>, ConvertError> {
                 // title, slug, parent_session_id natively.
                 if s.source_cli != "codex" {
                     session_passthrough = Some(serde_json::to_value(s)?);
+                    stash_messages = true;
                 }
                 let line = hub_session_to_codex(s)?;
                 if !line.is_null() {
@@ -194,6 +221,13 @@ pub fn from_hub(records: &[HubRecord]) -> Result<Vec<Value>, ConvertError> {
                     // round trips preserve the hub's dual-timestamp semantics.
                     if let Some(ref ca) = msg.completed_at {
                         attach_ucf_hub_field(&mut line, "completed_at", Value::String(ca.clone()));
+                    }
+                    if stash_messages {
+                        attach_ucf_hub_field(
+                            &mut line,
+                            "message",
+                            serde_json::to_value(msg)?,
+                        );
                     }
                     lines.push(line);
                 }

--- a/src/interchange/gemini.rs
+++ b/src/interchange/gemini.rs
@@ -41,9 +41,24 @@ pub fn to_hub(data: &[u8]) -> Result<Vec<HubRecord>, ConvertError> {
         };
         match role_raw.as_str() {
             "user" | "gemini" => {
+                // If a full HubMessage was stashed via `_ucf_hub.message`,
+                // restore it verbatim — the Gemini shape can lose mixed
+                // content variants and Hub-only metadata, but the stashed
+                // blob captures everything the foreign source produced.
+                if let Some(stashed) = msg
+                    .get("_ucf_hub")
+                    .and_then(|u| u.get("message"))
+                    .cloned()
+                {
+                    if let Ok(hub_msg) = serde_json::from_value::<HubMessage>(stashed) {
+                        records.push(HubRecord::Message(hub_msg));
+                        continue;
+                    }
+                }
+
                 let mut hub_msg = message_to_hub(msg, foreign_session)?;
                 let mut results = Vec::new();
-                
+
                 // Gemini bundles ToolUse and ToolResult in the same assistant message.
                 // The Hub format expects ToolResults in a subsequent user message.
                 hub_msg.content.retain(|b| {
@@ -54,7 +69,7 @@ pub fn to_hub(data: &[u8]) -> Result<Vec<HubRecord>, ConvertError> {
                         true
                     }
                 });
-                
+
                 let result_msg = if !results.is_empty() {
                     Some(HubMessage {
                         id: format!("{}_results", hub_msg.id),
@@ -143,12 +158,14 @@ pub fn from_hub(records: &[HubRecord]) -> Result<Value, ConvertError> {
 
     // If the hub session came from a non-Gemini source, stash the whole
     // SessionHeader so the hub → gemini → hub round trip is lossless.
+    let mut foreign_source = false;
     if let Some(HubRecord::Session(s)) = records
         .iter()
         .find(|r| matches!(r, HubRecord::Session(_)))
     {
         if s.source_cli != "gemini-cli" {
             session_passthrough = Some(serde_json::to_value(s)?);
+            foreign_source = true;
         }
     }
 
@@ -192,8 +209,18 @@ pub fn from_hub(records: &[HubRecord]) -> Result<Value, ConvertError> {
             }
         }
     } else {
-        // Cross-CLI path: reconstruct from hub content
-        let normalized_records = normalize_hub_records_for_gemini(records);
+        // Cross-CLI path: reconstruct from hub content. When the hub was
+        // sourced from a non-Gemini CLI, skip the Gemini-specific
+        // normalization (tool-result re-pairing, empty-text stripping,
+        // adjacent-role merging) — those passes lose message boundaries that
+        // a foreign source needs preserved. Instead, emit one Gemini message
+        // per hub message and stash the full HubMessage under
+        // `_ucf_hub.message` so `to_hub` can restore it byte-for-byte.
+        let normalized_records: Vec<HubRecord> = if foreign_source {
+            records.to_vec()
+        } else {
+            normalize_hub_records_for_gemini(records)
+        };
         for record in &normalized_records {
             match record {
                 HubRecord::Session(s) => {
@@ -215,6 +242,13 @@ pub fn from_hub(records: &[HubRecord]) -> Result<Value, ConvertError> {
                     // cross-CLI round trips preserve dual-timestamp semantics.
                     if let Some(ref ca) = msg.completed_at {
                         attach_ucf_hub_field(&mut gm, "completed_at", Value::String(ca.clone()));
+                    }
+                    if foreign_source {
+                        attach_ucf_hub_field(
+                            &mut gm,
+                            "message",
+                            serde_json::to_value(msg)?,
+                        );
                     }
                     messages.push(gm);
                 }

--- a/src/interchange/lossless_tests.rs
+++ b/src/interchange/lossless_tests.rs
@@ -143,25 +143,21 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "lossless target"]
     fn lossless_through_claude() {
         assert_strict_lossless("claude", via_claude);
     }
 
     #[test]
-    #[ignore = "lossless target"]
     fn lossless_through_codex() {
         assert_strict_lossless("codex", via_codex);
     }
 
     #[test]
-    #[ignore = "lossless target"]
     fn lossless_through_gemini() {
         assert_strict_lossless("gemini", via_gemini);
     }
 
     #[test]
-    #[ignore = "lossless target"]
     fn lossless_through_opencode() {
         assert_strict_lossless("opencode", via_opencode);
     }
@@ -194,19 +190,16 @@ mod tests {
     // All 12 cross-CLI pairs.
 
     #[test]
-    #[ignore = "lossless target"]
     fn cross_claude_via_codex() {
         assert_cross_lossless("claude", "codex", via_claude, via_codex);
     }
 
     #[test]
-    #[ignore = "lossless target"]
     fn cross_claude_via_gemini() {
         assert_cross_lossless("claude", "gemini", via_claude, via_gemini);
     }
 
     #[test]
-    #[ignore = "lossless target"]
     fn cross_claude_via_opencode() {
         assert_cross_lossless("claude", "opencode", via_claude, via_opencode);
     }
@@ -217,7 +210,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "lossless target"]
     fn cross_codex_via_gemini() {
         assert_cross_lossless("codex", "gemini", via_codex, via_gemini);
     }
@@ -228,37 +220,31 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "lossless target"]
     fn cross_gemini_via_claude() {
         assert_cross_lossless("gemini", "claude", via_gemini, via_claude);
     }
 
     #[test]
-    #[ignore = "lossless target"]
     fn cross_gemini_via_codex() {
         assert_cross_lossless("gemini", "codex", via_gemini, via_codex);
     }
 
     #[test]
-    #[ignore = "lossless target"]
     fn cross_gemini_via_opencode() {
         assert_cross_lossless("gemini", "opencode", via_gemini, via_opencode);
     }
 
     #[test]
-    #[ignore = "lossless target"]
     fn cross_opencode_via_claude() {
         assert_cross_lossless("opencode", "claude", via_opencode, via_claude);
     }
 
     #[test]
-    #[ignore = "lossless target"]
     fn cross_opencode_via_codex() {
         assert_cross_lossless("opencode", "codex", via_opencode, via_codex);
     }
 
     #[test]
-    #[ignore = "lossless target"]
     fn cross_opencode_via_gemini() {
         assert_cross_lossless("opencode", "gemini", via_opencode, via_gemini);
     }

--- a/src/interchange/opencode.rs
+++ b/src/interchange/opencode.rs
@@ -61,6 +61,28 @@ pub fn to_hub(input: &OpenCodeInput) -> Result<Vec<HubRecord>, ConvertError> {
             input.messages.len(),
         );
 
+        // If a full HubMessage was stashed via `_ucf_hub.message`, restore it
+        // verbatim — OpenCode parts/messages cannot represent every hub
+        // content variant losslessly (mixed thinking/text/tool blocks,
+        // standalone tool_results on user messages, foreign metadata), but
+        // the stashed blob captures everything the foreign source produced.
+        if let Some(stashed) = msg
+            .get("_ucf_hub")
+            .and_then(|u| u.get("message"))
+            .cloned()
+        {
+            if let Ok(mut hub_msg) = serde_json::from_value::<HubMessage>(stashed) {
+                // OpenCode has no native `tool` role — tool results live on
+                // user-role messages. Coerce so cross-CLI sources whose hub
+                // uses role="tool" still produce an opencode-shaped hub.
+                if hub_msg.role == "tool" {
+                    hub_msg.role = "user".to_string();
+                }
+                records.push(HubRecord::Message(hub_msg));
+                continue;
+            }
+        }
+
         let content = parts_to_content_blocks(&msg_parts)?;
         let metadata = extract_metadata(msg);
 
@@ -203,6 +225,7 @@ pub fn from_hub(records: &[HubRecord]) -> Result<OpenCodeOutput, ConvertError> {
         }
         None
     });
+    let foreign_source = session_passthrough.is_some();
 
     if is_native_roundtrip {
         // Native round-trip: use original messages and parts directly
@@ -236,6 +259,9 @@ pub fn from_hub(records: &[HubRecord]) -> Result<OpenCodeOutput, ConvertError> {
                     }
                     if let Some(foreign) = foreign_extensions(&msg.extensions) {
                         attach_ucf_hub_ext(&mut oc_msg, foreign);
+                    }
+                    if foreign_source {
+                        attach_ucf_hub_message(&mut oc_msg, serde_json::to_value(msg)?);
                     }
                     messages.push(oc_msg);
                     parts.extend(oc_parts);
@@ -297,6 +323,20 @@ fn attach_ucf_hub_session(node: &mut Value, session: Value) {
         return;
     };
     inner.insert("session".to_string(), session);
+}
+
+/// Attach a serialized HubMessage to `node._ucf_hub.message`.
+fn attach_ucf_hub_message(node: &mut Value, message: Value) {
+    let Value::Object(ref mut obj) = node else {
+        return;
+    };
+    let entry = obj
+        .entry("_ucf_hub".to_string())
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
+    let Value::Object(ref mut inner) = entry else {
+        return;
+    };
+    inner.insert("message".to_string(), message);
 }
 
 // === Helpers ===


### PR DESCRIPTION
Closes #84. Supersedes #85 (the draft RFC).

## Summary

Adds a block-level `_ucf_hub.message` per-message passthrough mechanism that mirrors the existing `_ucf_hub.session` and `_ucf_hub.ext` escape hatches. When `from_hub` processes a foreign-source hub (`source_cli` ≠ this CLI's), each emitted native record now carries the full serialized `HubMessage`. `to_hub` deserializes that blob and uses it verbatim, bypassing every lossy native parse.

This is the surgery the draft RFC (#85) was waiting on: session and message-level extensions were already preserved by the earlier passthrough commits, but block-level fidelity was lost whenever a converter's native format couldn't represent a hub `ContentBlock` variant — most visibly when codex/claude flatten `Thinking { signature, encrypted, … }` into plain `output_text`/`[Reasoning]: text` and round-trip that back as a `Text` block.

## Fixes per failure bucket

- **Bucket 1 — `encrypted: bool != null` (8×)**: stashed `HubMessage` preserves the `Thinking` variant whose `encrypted: false` field was being dropped by codex/claude flattening. `src/interchange/codex.rs`, `src/interchange/claude.rs`.
- **Bucket 2 — content array length drift (4×)**: opencode no longer synthesizes phantom `tool_result` blocks on the foreign path. `src/interchange/opencode.rs`.
- **Bucket 3 — outer length drift (2×, gemini)**: bypass `normalize_hub_records_for_gemini` for foreign sources (its tool-result re-pairing + adjacent-role merging dropped message boundaries) and stash per-message. `src/interchange/gemini.rs`.
- **Bucket 4 — claude `reasoning: 20 != 0`**: belt-and-suspenders preservation of foreign reasoning/tool/total tokens via `reasoning_tokens`/`tool_tokens`/`total_tokens` on `message.usage`. `src/interchange/claude.rs`.

Codex + opencode coerce `role="tool"` → `"user"` in the restore path (neither has a native tool role), keeping `cross_cli_tests` role-validity assertions passing.

## Test counts

| | Before | After |
|---|---|---|
| `lossless_tests` (incl. ignored) | 7 pass / 14 fail | **21 pass / 0 fail / 0 ignored** |
| Full `cargo test --lib` | — | 433 pass / 1 fail (pre-existing TUI install flake on `test_opencode_install_sets_install_state`, also fails on `main`) |

All 14 `#[ignore = "lossless target"]` annotations removed from `lossless_tests.rs`. `diagnostic_all_pairs` keeps its `#[ignore = "diagnostic — run manually"]`.

## Files changed

5 files, +167 / -24:
- `src/interchange/claude.rs`
- `src/interchange/codex.rs`
- `src/interchange/gemini.rs`
- `src/interchange/opencode.rs`
- `src/interchange/lossless_tests.rs` (only `#[ignore]` line removals)

## Limitations

- The mechanism is gated on session-level `source_cli`, not per-message. A hypothetical hub with mixed-source messages would all be treated by the receiving CLI as foreign. Acceptable since hubs are sourced from one CLI at a time in practice.
- Pre-existing flaky TUI install tests left untouched — out of scope.

## Test plan

- [x] `cargo test --lib interchange::lossless_tests -- --include-ignored` → 21/21
- [x] `cargo test --lib` → 433 pass (1 pre-existing flake)
- [x] No regressions in `interchange::cross_cli_tests` (role-validity preserved via tool→user coercion)