### PR TITLE
fix(agents): use musl asset name for Codex Linux installs (unblocks Docker CI)

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -885,13 +885,16 @@ impl AgentManager {
 
     /// Detect the platform triple for prebuilt binary downloads
     fn detect_platform_triple() -> Option<&'static str> {
+        // Codex's Linux releases are statically-linked musl builds; the gnu
+        // targets were dropped upstream around rust-v0.118. The musl binaries
+        // run fine on glibc systems thanks to static linking.
         #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
         {
-            return Some("x86_64-unknown-linux-gnu");
+            return Some("x86_64-unknown-linux-musl");
         }
         #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
         {
-            return Some("aarch64-unknown-linux-gnu");
+            return Some("aarch64-unknown-linux-musl");
         }
         #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
         {


### PR DESCRIPTION
Unblocks the Docker Image build on main (failing since `d449a64`, May 1).

## Root cause

Codex dropped the `*-unknown-linux-gnu` release artifacts upstream around `rust-v0.118` in favor of statically-linked musl builds. \`detect_platform_triple()\` in \`src/agents.rs\` still asked for \`x86_64-unknown-linux-gnu\` / \`aarch64-unknown-linux-gnu\` — those assets do not exist anymore. Every Linux Codex install therefore reported:

\`\`\`
✗ Codex  No prebuilt Codex binary for this platform and cargo is not installed.
\`\`\`

Verified against today's release — the latest \`rust-v0.128.0\` ships only \`musl\` for Linux:

\`\`\`
codex-aarch64-unknown-linux-musl.tar.gz
codex-x86_64-unknown-linux-musl.tar.gz
\`\`\`

## Why CI was breaking

\`unleash agents install claude codex gemini pi\` reports per-agent failures but exits 0 (\"3 updated, 1 failed\"). The Docker build then runs \`RUN claude --version && codex --version && ...\` which trips on \`codex: not found\` with exit code 127. The Docker CI job has been red on main since May 1; this restores it.

## Why musl is fine on glibc systems

Codex's musl binaries are statically linked. They run unchanged on Debian / Ubuntu / Arch / RHEL etc. — no glibc dependency.

## Test plan

- [x] \`cargo build --release\` clean
- [x] Verified asset names against \`gh api repos/openai/codex/releases/latest\` — only musl ships for Linux
- [ ] Docker CI to confirm green on this PR (the actual integration test)

## Follow-up worth considering

\`unleash agents install\` should probably exit non-zero when any requested agent fails, instead of swallowing per-agent failures. That would have caught this bug at its source rather than hours downstream in the Docker step. Out of scope for this fix.