### PR TITLE
fix(ci): self-dispatch release-please after auto-merge so release actually publishes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Needed so the auto-merge job can dispatch a follow-up run of this same
+  # workflow after merging the release PR (see "Re-trigger after auto-merge"
+  # step below). Without that follow-up, GHA suppresses the trigger that would
+  # normally fire from the merge push (loop prevention for GITHUB_TOKEN-driven
+  # pushes), and the build/upload-release jobs never run.
+  actions: write
 
 jobs:
   release-please:
@@ -89,6 +95,22 @@ jobs:
           PR_NUMBER=$(jq -r '.number' <<<"$PR_JSON")
           echo "Auto-merging PR #$PR_NUMBER (minor/patch release)"
           gh pr merge "$PR_NUMBER" --squash || echo "Auto-merge failed, PR may need manual merge"
+
+      # GHA suppresses workflow triggers from pushes made with the default
+      # GITHUB_TOKEN (loop prevention). The merge above therefore won't
+      # re-trigger this workflow on the new HEAD, which means release-please
+      # never runs the second pass that detects the merged PR and creates the
+      # release tag — leaving the release pipeline stuck without the actual
+      # release. workflow_dispatch is allowed even from GITHUB_TOKEN, so we
+      # explicitly kick the workflow off again here.
+      - name: Re-trigger workflow to publish release after auto-merge
+        if: steps.check-major.outputs.is_major == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Dispatching release-please.yml to publish the release"
+          gh workflow run release-please.yml --ref main \
+              || echo "Self-dispatch failed — run gh workflow run release-please.yml --ref main manually"
 
   # Build binaries for all platforms when a release is created
   build-release:


### PR DESCRIPTION
Follow-up to #119. Closes the gap that left v0.1.18 stuck as a merged release PR with no tag/release/binaries until I manually ran \`gh workflow run\`.

## The problem

GHA suppresses workflow triggers for pushes performed with the default \`GITHUB_TOKEN\` ([docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow), under \"loop prevention\"). With #119 merged, our \`auto-merge-release\` step finally **works** at squash-merging the release PR — but the resulting push doesn't re-trigger this workflow, so the second-pass release-please run that detects the merged PR and creates the release tag never happens.

That's exactly what happened today:

1. PR #119 merged → release-please run on \`ed1293c\` updated PR #104
2. auto-merge step now worked → squash-merged #104 as \`a5e0b32\`
3. **No new release-please run on \`a5e0b32\`** (suppressed)
4. Result: PR #104 \"merged\", but no v0.1.18 tag, no release, no binaries
5. I manually ran \`gh workflow run release-please.yml --ref main\` → second-pass runs and produces the v0.1.18 release with all 9 assets

## Fix

After the \`Auto-merge release PR\` step, explicitly dispatch the workflow via \`gh workflow run release-please.yml --ref main\`. \`workflow_dispatch\` is allowed even from \`GITHUB_TOKEN\`, so this works without a PAT.

Required permission: \`actions: write\` added to the top-level \`permissions:\` block — needed to call \`gh workflow run\`.

## End-to-end flow after this lands

1. push to main → workflow run #1 → release-please-action creates release PR
2. auto-merge step squash-merges the release PR
3. **NEW:** re-trigger step dispatches workflow run #2 against main
4. workflow run #2 → release-please-action sees the merged PR, creates the tag and GitHub release (\`release_created=true\`)
5. \`build-release\` matrix builds binaries for 4 platforms
6. \`upload-release\` attaches them to the v0.X.Y release

No more manual \`gh workflow run\` to unstick releases.

## Test plan

- [x] YAML valid
- [x] Today's manual self-dispatch did exactly what step 3-6 above describe — produced v0.1.18 with all 9 binaries — proving the second pass works correctly when triggered
- [ ] CI confirmation on the next release cycle