### PR TITLE
ci: add actionlint to catch GHA script-injection at PR time

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,46 @@
+name: Lint workflows
+
+# Run actionlint on every change to .github/workflows/ to catch:
+#  - YAML / GHA expression syntax errors
+#  - Script-injection patterns (${{ }} interpolated into `run:` blocks where
+#    the value is user-controlled — see PR #119 for a real example where
+#    `${{ needs.release-please.outputs.pr }}` going into bash via inline
+#    substitution let an apostrophe in a commit message break the parser
+#    and would have allowed RCE on the runner from a malicious commit body)
+#  - Wrong action `uses:` versions, missing inputs, and other static checks
+#
+# Background: https://github.com/rhysd/actionlint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1
+        with:
+          # Fail the check on `error`-severity findings (e.g. real GHA syntax
+          # errors and the `expression`-injection lint that flags
+          # `${{ github.event.* }}` going into a `run:` block — the exact
+          # class of bug #119 fixed). `info`/`warning` shellcheck noise like
+          # SC2086/SC2155 is left to land as PR comments without blocking.
+          fail_level: error
+          # Annotate problems on the PR diff via reviewdog rather than only
+          # in the run log; makes the failures discoverable inline.
+          reporter: github-pr-check


### PR DESCRIPTION
Direct ROI from this session: PRs **#119** and **#120** both fixed bugs that actionlint would have caught at PR time, before merge.

## Why

**#119** — \`\${{ needs.release-please.outputs.pr }}\` interpolated directly into a \`run:\` block let an apostrophe in a commit body break bash, and was a script-injection vector to RCE on the runner. actionlint flags this exact pattern as an \`expression\`-rule error:

\`\`\`
"github.event.pull_request.body" is potentially untrusted. avoid using it directly
in inline scripts. instead, pass it through an environment variable.
\`\`\`

**#120** — wouldn't have been needed in the same form if #119 had been caught earlier, since the underlying release pipeline would never have shipped the broken auto-merge.

## Setup

- Triggers on push/pr touching \`.github/workflows/**\`
- Uses \`reviewdog/action-actionlint@v1\` so findings surface as inline PR annotations, not just in the run log
- \`fail_level: error\` keeps the bar at real bugs / injection patterns. The 148 lines of pre-existing shellcheck \`info:\` / \`warning:\` quoting nits across our other workflows are not addressed here — actionlint will surface them but not block.

## Verified

\`\`\`bash
$ cat <<'YML' > /tmp/test-injection.yml
name: Test
on: { push: { branches: [main] } }
permissions: { contents: read }
jobs:
  bad:
    runs-on: ubuntu-latest
    steps:
      - run: echo '\${{ github.event.pull_request.body }}'
YML
$ actionlint /tmp/test-injection.yml
... "github.event.pull_request.body" is potentially untrusted ... [expression]
$ echo \$?
1

$ actionlint .github/workflows/*.yml | grep -vE 'info:|warning:' | wc -l
0   # zero error-level findings on the current tree
\`\`\`

## Test plan

- [x] YAML valid
- [x] Local actionlint flags the #119 buggy pattern as error
- [x] Current workflow tree has zero error-level findings (so this lands non-disruptively)
- [ ] CI confirmation