### PR TITLE
ci: fix SC2129 in integration-tests step-summary (unblocks actionlint on main)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -252,17 +252,27 @@ jobs:
 
     steps:
       - name: Generate test report
+        env:
+          SHELLCHECK_RESULT: ${{ needs.shellcheck.result }}
+          HEADLESS_RESULT: ${{ needs.test-headless.result }}
+          PLUGINS_RESULT: ${{ needs.test-plugins.result }}
+          AUTOMODE_RESULT: ${{ needs.test-auto-mode.result }}
+          INSTALL_RESULT: ${{ needs.test-install-script.result }}
+          AUTH_RESULT: ${{ needs.test-auth-comprehensive.result }}
         run: |
-          echo "# Test Results Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Job | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|-----|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| ShellCheck Linting | ${{ needs.shellcheck.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Headless Commands | ${{ needs.test-headless.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Plugin Tests | ${{ needs.test-plugins.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Auto Mode Hook | ${{ needs.test-auto-mode.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Install Script | ${{ needs.test-install-script.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Auth Comprehensive | ${{ needs.test-auth-comprehensive.result == 'success' && '✅ Passed' || '❌ Failed' }} |" >> $GITHUB_STEP_SUMMARY
+          status() { [[ "$1" == "success" ]] && echo "✅ Passed" || echo "❌ Failed"; }
+          {
+            echo "# Test Results Summary"
+            echo ""
+            echo "| Job | Status |"
+            echo "|-----|--------|"
+            echo "| ShellCheck Linting | $(status "$SHELLCHECK_RESULT") |"
+            echo "| Headless Commands | $(status "$HEADLESS_RESULT") |"
+            echo "| Plugin Tests | $(status "$PLUGINS_RESULT") |"
+            echo "| Auto Mode Hook | $(status "$AUTOMODE_RESULT") |"
+            echo "| Install Script | $(status "$INSTALL_RESULT") |"
+            echo "| Auth Comprehensive | $(status "$AUTH_RESULT") |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check test results
         run: |


### PR DESCRIPTION
Unblocks the actionlint workflow that PR #128 added — currently failing on main because reviewdog elevates shellcheck \`style:\` findings to error severity, and the \"Generate test report\" step in \`integration-tests.yml\` trips SC2129.

## What

The step had ~6 \`echo \"...\" >> \$GITHUB_STEP_SUMMARY\` lines. Shellcheck flags this as SC2129 (\"Consider using { cmd1; cmd2; } >> file instead of individual redirects\") and reviewdog reports it as error.

Three small changes to that one step:

1. **Group the echos** in \`{ ... } >> \"\$GITHUB_STEP_SUMMARY\"\` — clears SC2129
2. **Pass each \`needs.<job>.result\` via \`env:\`** instead of inline \`\${{ }}\` substitution into the shell body — same security pattern landed in #119, consistent with actionlint's expression-injection rule
3. **Quote \`\$GITHUB_STEP_SUMMARY\`** — clears SC2086

Net: identical output to the GitHub run summary, no behavior change.

## Why this didn't trip on PR #128

PR #128 only changed \`.github/workflows/actionlint.yml\`. The actionlint workflow's \`paths\` filter triggers on \`.github/workflows/**\`, but its job runs against ALL workflow files in the repo. On the PR, actionlint reported the same SC2129 inline as a comment, but no required CI gate held it back. Once #128 merged to main, the actionlint workflow ran on main itself and exited non-zero — what we expected of a strict GHA linter, just with no PR-time signal because the affected workflow file (integration-tests.yml) hadn't changed.

A nicer follow-up would be to also kick actionlint on PRs that modify *any* file (not just \`.github/workflows/**\`), so we always know the global state. Out of scope for this fix.

## Test plan

- [x] \`actionlint integration-tests.yml\` clean (0 findings)
- [x] \`actionlint .github/workflows/*.yml\` has zero error/style findings
- [x] YAML valid
- [ ] CI confirmation, including actionlint check on this PR