### PR TITLE
ci: fix remaining SC2129 in binary-smoke-test and docker-publish

### DIFF
--- a/.github/workflows/binary-smoke-test.yml
+++ b/.github/workflows/binary-smoke-test.yml
@@ -99,12 +99,17 @@ jobs:
           echo "--- sessions list OK ---"
 
       - name: Summary
+        env:
+          ARTIFACT: ${{ matrix.artifact }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          echo "## Smoke Test: ${{ matrix.artifact }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Platform: $(uname -s) $(uname -m)" >> $GITHUB_STEP_SUMMARY
-          echo "- Binary: ${{ matrix.artifact }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Tag: ${{ steps.tag.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Status: All checks passed" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Smoke Test: $ARTIFACT"
+            echo "- Platform: $(uname -s) $(uname -m)"
+            echo "- Binary: $ARTIFACT"
+            echo "- Tag: $TAG"
+            echo "- Status: All checks passed"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   alpine-smoke-test:
     name: unleash-linux-x86_64 (Alpine musl)
@@ -165,9 +170,13 @@ jobs:
           echo "--- sessions list OK ---"
 
       - name: Summary
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          echo "## Smoke Test: unleash-linux-x86_64 (Alpine)" >> $GITHUB_STEP_SUMMARY
-          echo "- Platform: Alpine Linux (musl)" >> $GITHUB_STEP_SUMMARY
-          echo "- Binary: unleash-linux-x86_64" >> $GITHUB_STEP_SUMMARY
-          echo "- Tag: ${{ steps.tag.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Status: All checks passed" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Smoke Test: unleash-linux-x86_64 (Alpine)"
+            echo "- Platform: Alpine Linux (musl)"
+            echo "- Binary: unleash-linux-x86_64"
+            echo "- Tag: $TAG"
+            echo "- Status: All checks passed"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -108,10 +108,15 @@ jobs:
           done
 
       - name: Summary
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          echo "## Docker Image Published" >> $GITHUB_STEP_SUMMARY
-          echo "- Version: ${{ steps.meta.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Tags: ${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Docker Image Published"
+            echo "- Version: $VERSION"
+            echo "- Tags: $TAGS"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
Follow-up to #129. After #129 cleared one site, three more identical SC2129 violations still trip the actionlint workflow on main:

- \`.github/workflows/binary-smoke-test.yml:102\` (per-platform smoke summary)
- \`.github/workflows/binary-smoke-test.yml:172\` (Alpine smoke summary)
- \`.github/workflows/docker-publish.yml:110\` (Docker publish summary)

reviewdog elevates shellcheck \`style:\` to error severity, so any of these block the actionlint check.

Same fix pattern as #129: group the echos in \`{ ... } >> \"\$GITHUB_STEP_SUMMARY\"\`, pass \`\${{ }}\` values via \`env:\` rather than inline shell substitution, quote \`\$GITHUB_STEP_SUMMARY\`. No behavior change in the run summaries.

## Test plan

- [x] \`actionlint .github/workflows/*.yml\` reports zero SC2129 / style / error findings (only \`info:\` / \`warning:\` quoting nits remain, below the \`fail_level: error\` threshold)
- [x] YAML valid on both files
- [ ] CI confirmation