### PR TITLE
ci: filter reviewdog reporting to error level (fixes annotation overflow)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -35,11 +35,16 @@ jobs:
       - name: Run actionlint
         uses: reviewdog/action-actionlint@v1
         with:
-          # Fail the check on `error`-severity findings (e.g. real GHA syntax
-          # errors and the `expression`-injection lint that flags
-          # `${{ github.event.* }}` going into a `run:` block — the exact
-          # class of bug #119 fixed). `info`/`warning` shellcheck noise like
-          # SC2086/SC2155 is left to land as PR comments without blocking.
+          # Only REPORT findings at `error` severity. `level: error` is needed
+          # in addition to `fail_level: error` because reviewdog annotates every
+          # reported finding, and GitHub caps annotations per run (50/job,
+          # 10/step). With the default `level: info`, reviewdog tried to
+          # annotate ~40 pre-existing shellcheck `info:` / `warning:` quoting
+          # nits across other workflows and hit "Too many results (annotations)
+          # in diff" as a fatal error — even though none of the findings were
+          # actually error-level. The two fields combined mean: report only
+          # error findings, fail only on error findings.
+          level: error
           fail_level: error
           # Annotate problems on the PR diff via reviewdog rather than only
           # in the run log; makes the failures discoverable inline.


### PR DESCRIPTION
Final fix for the actionlint workflow on main. After #128 + #129 + #130 cleared the SC2129 \`style:\` violations, actionlint still fails because reviewdog's default reporting level is \`info\`, so every shellcheck \`info:\`/\`warning:\` finding gets posted as a GitHub annotation. GitHub caps annotations per run (10/step warnings, 10/step errors, 50/job total). The repo has ~40 pre-existing SC2086/SC2155 quoting nits across other workflows, which trips the cap and reviewdog exits non-zero with \"Too many results (annotations) in diff\" — even though no actual error-level finding exists.

\`fail_level: error\` only controls the **exit-code threshold**. It does not filter what gets **reported** as annotations.

Fix: add \`level: error\` alongside the existing \`fail_level: error\`:

\`\`\`yaml
- uses: reviewdog/action-actionlint@v1
  with:
    level: error
    fail_level: error
    reporter: github-pr-check
\`\`\`

- \`level: error\` → reviewdog reports only error findings (suppresses the info/warning flood)
- \`fail_level: error\` → check fails only on error findings (the original gate)

Net behavior is what we wanted from #128 originally: the GHA expression-injection rule and real syntax errors block merge; pre-existing shellcheck quoting nits don't block AND don't crash the linter.

## Test plan

- [x] YAML valid
- [x] Verified locally that current workflow tree has zero error-level findings
- [ ] CI confirmation on this PR + on main after merge