### PR TITLE
ci: invoke actionlint directly + exclude SC2086/SC2155 (final actionlint fix)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -9,6 +9,14 @@ name: Lint workflows
 #    and would have allowed RCE on the runner from a malicious commit body)
 #  - Wrong action `uses:` versions, missing inputs, and other static checks
 #
+# We invoke actionlint directly (no reviewdog wrapper) so we can:
+#   1. Exclude pre-existing shellcheck nits (SC2086 etc.) without churning
+#      every other workflow
+#   2. Avoid GitHub's annotation limit (50/job) — the reviewdog wrapper
+#      annotates every finding and crashes once there are too many, even if
+#      none are actually error-level (the entire #131 round-trip on this
+#      workflow was that bug)
+#
 # Background: https://github.com/rhysd/actionlint
 
 on:
@@ -32,20 +40,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install actionlint
+        id: install
+        run: |
+          # Official download script from rhysd/actionlint
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          echo "actionlint=$PWD/actionlint" >> "$GITHUB_OUTPUT"
+
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@v1
-        with:
-          # Only REPORT findings at `error` severity. `level: error` is needed
-          # in addition to `fail_level: error` because reviewdog annotates every
-          # reported finding, and GitHub caps annotations per run (50/job,
-          # 10/step). With the default `level: info`, reviewdog tried to
-          # annotate ~40 pre-existing shellcheck `info:` / `warning:` quoting
-          # nits across other workflows and hit "Too many results (annotations)
-          # in diff" as a fatal error — even though none of the findings were
-          # actually error-level. The two fields combined mean: report only
-          # error findings, fail only on error findings.
-          level: error
-          fail_level: error
-          # Annotate problems on the PR diff via reviewdog rather than only
-          # in the run log; makes the failures discoverable inline.
-          reporter: github-pr-check
+        env:
+          ACTIONLINT: ${{ steps.install.outputs.actionlint }}
+        run: |
+          # -shellcheck arg is forwarded as `shellcheck <these args>`. We
+          # exclude pre-existing nits so the linter only blocks merge on real
+          # bugs (script-injection, GHA syntax errors, expression typos).
+          # The excluded codes:
+          #   SC2086: Double quote to prevent globbing and word splitting
+          #   SC2155: Declare and assign separately to avoid masking return
+          # Both are style/info; worth cleaning up eventually but not gating CI.
+          "$ACTIONLINT" -color -shellcheck "shellcheck -e SC2086,SC2155"


### PR DESCRIPTION
Replaces \`reviewdog/action-actionlint\` with a direct \`actionlint\` invocation. After three rounds of fixes (#129, #130, #131) the reviewdog wrapper was still failing on main because it tries to annotate every shellcheck finding regardless of severity and crashes once GitHub's per-run annotation cap (50/job) is reached:

\`\`\`
##[error]reviewdog: Too many results (annotations) in diff.
\`\`\`

\`fail_level: error\` only filtered the exit-code threshold; \`level: error\` didn't filter what reviewdog reported. The repo has ~40 pre-existing SC2086/SC2155 quoting nits across other workflows, so the cap was always breached.

## Fix

Skip the wrapper. Download actionlint via its official script and run it directly:

\`\`\`yaml
- run: |
    bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
    ./actionlint -color -shellcheck \"shellcheck -e SC2086,SC2155\"
\`\`\`

The \`-shellcheck\` flag forwards args to shellcheck; \`-e SC2086,SC2155\` excludes the noisy info/style codes that don't represent real bugs. Real bugs still trigger non-zero exit:

- GHA syntax errors (\`error:\`)
- The \`expression\`-rule script-injection lint that flags \`\${{ github.event.* }}\` going into a \`run:\` block — the original motivation for #128

## Verified locally

\`\`\`
$ actionlint -shellcheck \"shellcheck -e SC2086,SC2155\" .github/workflows/*.yml ; echo \$?
0    # clean tree

$ cat <<'YML' > /tmp/inj.yml
on: push
jobs:
  bad:
    runs-on: ubuntu-latest
    steps:
      - run: echo '\${{ github.event.pull_request.body }}'
YML
$ actionlint -shellcheck \"shellcheck -e SC2086,SC2155\" /tmp/inj.yml ; echo \$?
... is potentially untrusted ... [expression]
1    # injection caught
\`\`\`

So: clean tree → exit 0, scripted injection → exit 1. Exactly the gate we want, with no annotation overflow.

## Test plan

- [x] YAML valid
- [x] Local test: clean tree → 0, injection → 1
- [ ] CI confirmation