### PR TITLE
feat(agents): add Hermes Agent as built-in harness

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -22,6 +22,7 @@ pub enum AgentType {
     Gemini,
     OpenCode,
     Pi,
+    Hermes,
     Custom(String),
 }
 
@@ -34,6 +35,7 @@ impl AgentType {
             AgentType::Gemini,
             AgentType::OpenCode,
             AgentType::Pi,
+            AgentType::Hermes,
         ]
     }
 
@@ -55,6 +57,7 @@ impl AgentType {
             AgentType::Gemini => Cow::Borrowed("Gemini CLI"),
             AgentType::OpenCode => Cow::Borrowed("OpenCode"),
             AgentType::Pi => Cow::Borrowed("Pi"),
+            AgentType::Hermes => Cow::Borrowed("Hermes Agent"),
             AgentType::Custom(name) => Cow::Owned(name.clone()),
         }
     }
@@ -66,6 +69,7 @@ impl AgentType {
             "gemini" | "gemini-cli" => Some(AgentType::Gemini),
             "opencode" | "open-code" => Some(AgentType::OpenCode),
             "pi" | "pi-coding-agent" => Some(AgentType::Pi),
+            "hermes" | "hermes-agent" => Some(AgentType::Hermes),
             _ => None,
         }
     }
@@ -286,6 +290,7 @@ impl AgentDefinition {
             AgentType::Gemini => Self::gemini(),
             AgentType::OpenCode => Self::opencode(),
             AgentType::Pi => Self::pi(),
+            AgentType::Hermes => Self::hermes(),
             AgentType::Custom(ref name) => panic!(
                 "AgentDefinition::from_type() called with Custom(\"{}\"). Use from_custom_config() instead.",
                 name
@@ -462,6 +467,40 @@ impl AgentDefinition {
             enabled: true,
         }
     }
+
+    /// Create Hermes Agent definition
+    pub fn hermes() -> Self {
+        Self {
+            agent_type: AgentType::Hermes,
+            name: "Hermes Agent".to_string(),
+            binary: "hermes".to_string(),
+            description: "NousResearch's autonomous AI agent with persistent memory".to_string(),
+            polyfill: AgentPolyfillConfig {
+                headless: HeadlessStrategy::Flag("-z".to_string()),
+                session: SessionStrategy {
+                    continue_strategy: ResumeStrategy::Flag("--continue".to_string()),
+                    resume_strategy: ResumeStrategy::Flag("--resume".to_string()),
+                },
+                fork: ForkStrategy::Flag("--worktree".to_string()),
+                yolo_flag: Some("--yolo".to_string()),
+                model_flag: "-m".to_string(),
+                effort_flag: None,
+                auto_flag: None,
+                verbose_flag: Some("--verbose".to_string()),
+                output_format_flag: None,
+                system_prompt_flag: None,
+                allowed_tools_flag: None,
+                sandbox: SandboxStrategy::Unsupported,
+                name_flag: None,
+                add_dir_flag: None,
+                approval_mode_flag: None,
+                worktree_flag: Some("--worktree".to_string()),
+            },
+            github_repo: Some("NousResearch/hermes-agent".to_string()),
+            npm_package: None,
+            enabled: true,
+        }
+    }
 }
 
 /// Version information for an agent
@@ -508,6 +547,7 @@ impl AgentManager {
         manager.register_agent(AgentDefinition::gemini());
         manager.register_agent(AgentDefinition::opencode());
         manager.register_agent(AgentDefinition::pi());
+        manager.register_agent(AgentDefinition::hermes());
 
         // Load cached versions
         manager.load_version_cache()?;
@@ -716,6 +756,7 @@ impl AgentManager {
             AgentType::Gemini => self.update_npm_agent("@google/gemini-cli", "Gemini CLI"),
             AgentType::OpenCode => self.update_opencode(),
             AgentType::Pi => self.update_npm_agent("@mariozechner/pi-coding-agent", "Pi"),
+            AgentType::Hermes => self.update_hermes(),
             AgentType::Custom(_) => Err(io::Error::other(
                 "Version management is not yet supported for custom agents",
             )),
@@ -1025,6 +1066,27 @@ impl AgentManager {
         }
     }
 
+    /// Update Hermes via the official curl bash installer.
+    /// Hermes' installer always installs the latest version — there is no
+    /// version pin argument.
+    fn update_hermes(&self) -> io::Result<String> {
+        let output = Command::new("bash")
+            .args([
+                "-c",
+                "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
+            ])
+            .output()?;
+
+        if output.status.success() {
+            Ok("Hermes Agent updated successfully".to_string())
+        } else {
+            Err(io::Error::other(format!(
+                "Failed to update Hermes Agent: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )))
+        }
+    }
+
     /// Get version cache file path
     fn version_cache_path(&self) -> PathBuf {
         self.config_dir.join("agent-versions.json")
@@ -1123,6 +1185,32 @@ mod tests {
     }
 
     // Version comparison tests moved to src/version.rs (canonical implementation)
+
+    #[test]
+    fn hermes_has_no_npm_package() {
+        let hermes = AgentDefinition::hermes();
+        assert!(hermes.npm_package.is_none());
+        assert_eq!(hermes.binary, "hermes");
+        assert_eq!(hermes.agent_type, AgentType::Hermes);
+        assert_eq!(hermes.github_repo.as_deref(), Some("NousResearch/hermes-agent"));
+    }
+
+    #[test]
+    fn hermes_is_in_builtin_after_pi() {
+        let builtins = AgentType::builtin();
+        let pi_idx = builtins
+            .iter()
+            .position(|t| *t == AgentType::Pi)
+            .expect("Pi in builtins");
+        let hermes_idx = builtins
+            .iter()
+            .position(|t| *t == AgentType::Hermes)
+            .expect("Hermes in builtins");
+        assert!(
+            hermes_idx > pi_idx,
+            "Hermes must come after Pi to preserve existing builtin-index assertions"
+        );
+    }
 
     #[test]
     fn parse_version_various_formats() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ fn resolve_target_binary(target_cli: &str) -> String {
         "gemini" | "gemini-cli" => Some(AgentType::Gemini),
         "opencode" => Some(AgentType::OpenCode),
         "pi" | "pi-coding-agent" => Some(AgentType::Pi),
+        "hermes" | "hermes-agent" => Some(AgentType::Hermes),
         _ => None,
     };
     match canonical {
@@ -322,6 +323,7 @@ fn run_agent_with_polyfill(
         AgentType::Gemini => "gemini",
         AgentType::OpenCode => "opencode",
         AgentType::Pi => "pi",
+        AgentType::Hermes => "hermes",
         AgentType::Custom(name) => {
             target_cli_owned = name.clone();
             &target_cli_owned
@@ -582,6 +584,7 @@ pub fn run() -> io::Result<()> {
                             AgentType::Gemini => "gemini",
                             AgentType::OpenCode => "opencode",
                             AgentType::Pi => "pi",
+                            AgentType::Hermes => "hermes",
                             AgentType::Custom(_) => "claude", // custom agents fall back to claude for crossload
                         })
                         .unwrap_or("claude")

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -274,6 +274,7 @@ pub fn resolve_agent_binary_path(
         AgentType::Gemini => AgentDefinition::gemini().binary,
         AgentType::OpenCode => AgentDefinition::opencode().binary,
         AgentType::Pi => AgentDefinition::pi().binary,
+        AgentType::Hermes => AgentDefinition::hermes().binary,
         AgentType::Custom(name) => custom
             .iter()
             .find(|d| matches!(&d.agent_type, AgentType::Custom(n) if n == name))
@@ -886,6 +887,7 @@ impl App {
             ("gemini", AgentType::Gemini),
             ("opencode", AgentType::OpenCode),
             ("pi", AgentType::Pi),
+            ("hermes", AgentType::Hermes),
         ];
         for (key, agent_type) in agent_keys {
             if let Some(versions) = embedded.get(*key) {
@@ -917,6 +919,7 @@ impl App {
                     AgentType::Gemini,
                     AgentType::OpenCode,
                     AgentType::Pi,
+                    AgentType::Hermes,
                 ] {
                     let v = mgr.get_installed_version(agent_type.clone()).ok().flatten();
                     let _ = version_tx.send((agent_type.clone(), v));
@@ -1477,6 +1480,14 @@ impl App {
                     let versions = vm.get_pi_version_list(installed.as_deref());
                     let conflicts = vm.detect_conflicts("pi");
                     let _ = tx.send((AgentType::Pi, versions, conflicts));
+                });
+            }
+            AgentType::Hermes => {
+                thread::spawn(move || {
+                    let vm = VersionManager::new();
+                    let versions = vm.get_hermes_version_list(installed.as_deref());
+                    let conflicts = vm.detect_conflicts("hermes");
+                    let _ = tx.send((AgentType::Hermes, versions, conflicts));
                 });
             }
             AgentType::Custom(_) => {
@@ -2523,6 +2534,9 @@ impl App {
                             AgentType::Pi => {
                                 vm.install_pi_version_streaming(&version, log_tx)
                             }
+                            AgentType::Hermes => {
+                                vm.install_hermes_version_streaming(&version, log_tx)
+                            }
                             _ => Ok(crate::version::InstallResult {
                                 success: false,
                                 stdout: String::new(),
@@ -2586,6 +2600,7 @@ impl App {
                     AgentType::Gemini => "gemini",
                     AgentType::OpenCode => "opencode",
                     AgentType::Pi => "pi",
+                    AgentType::Hermes => "hermes",
                     AgentType::Custom(name) => {
                         agent_str_owned = name.clone();
                         &agent_str_owned
@@ -2843,6 +2858,9 @@ impl App {
                         vm.install_opencode_version_streaming(&version_clone, log_tx)
                     }
                     AgentType::Pi => vm.install_pi_version_streaming(&version_clone, log_tx),
+                    AgentType::Hermes => {
+                        vm.install_hermes_version_streaming(&version_clone, log_tx)
+                    }
                     AgentType::Custom(_) => Ok(InstallResult {
                         success: false,
                         stdout: String::new(),
@@ -6443,7 +6461,7 @@ mod tests {
         app.version_focus = VersionFocus::AgentPicker;
         assert_eq!(app.version_agent, AgentType::Claude);
 
-        // Navigate down: Claude -> Codex -> Gemini -> OpenCode -> Pi
+        // Navigate down: Claude -> Codex -> Gemini -> OpenCode -> Pi -> Hermes
         let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
         assert_eq!(app.version_agent, AgentType::Codex);
 
@@ -6456,9 +6474,12 @@ mod tests {
         let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
         assert_eq!(app.version_agent, AgentType::Pi);
 
+        let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
+        assert_eq!(app.version_agent, AgentType::Hermes);
+
         // Clamp at bottom (no wrap)
         let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
-        assert_eq!(app.version_agent, AgentType::Pi);
+        assert_eq!(app.version_agent, AgentType::Hermes);
     }
 
     #[test]
@@ -6726,12 +6747,13 @@ mod tests {
     #[test]
     fn test_all_agent_types_in_cycle() {
         let agents = AgentType::builtin();
-        assert_eq!(agents.len(), 5);
+        assert_eq!(agents.len(), 6);
         assert_eq!(agents[0], AgentType::Claude);
         assert_eq!(agents[1], AgentType::Codex);
         assert_eq!(agents[2], AgentType::Gemini);
         assert_eq!(agents[3], AgentType::OpenCode);
         assert_eq!(agents[4], AgentType::Pi);
+        assert_eq!(agents[5], AgentType::Hermes);
     }
 
     #[test]
@@ -6741,6 +6763,7 @@ mod tests {
         assert_eq!(AgentType::Gemini.display_name(), "Gemini CLI");
         assert_eq!(AgentType::OpenCode.display_name(), "OpenCode");
         assert_eq!(AgentType::Pi.display_name(), "Pi");
+        assert_eq!(AgentType::Hermes.display_name(), "Hermes Agent");
     }
 
     #[test]
@@ -6753,6 +6776,11 @@ mod tests {
         assert_eq!(AgentType::from_str("open-code"), Some(AgentType::OpenCode));
         assert_eq!(AgentType::from_str("pi"), Some(AgentType::Pi));
         assert_eq!(AgentType::from_str("pi-coding-agent"), Some(AgentType::Pi));
+        assert_eq!(AgentType::from_str("hermes"), Some(AgentType::Hermes));
+        assert_eq!(
+            AgentType::from_str("hermes-agent"),
+            Some(AgentType::Hermes)
+        );
         assert_eq!(AgentType::from_str("unknown"), None);
     }
 
@@ -6852,7 +6880,7 @@ mod tests {
         // Press 'G' to jump to bottom
         let big_g_key = KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT);
         let _ = app.handle_version_input(NavAction::None, big_g_key);
-        assert_eq!(app.version_agent, AgentType::Pi);
+        assert_eq!(app.version_agent, AgentType::Hermes);
     }
 
     #[test]
@@ -6891,13 +6919,14 @@ mod tests {
     #[test]
     fn test_picker_entries_default_order() {
         let entries = build_agent_cli_picker_entries(&[]);
-        assert_eq!(entries.len(), 6);
+        assert_eq!(entries.len(), 7);
         assert_eq!(entries[0], AgentCliPickerEntry::Agent(AgentType::Claude));
         assert_eq!(entries[1], AgentCliPickerEntry::Agent(AgentType::Codex));
         assert_eq!(entries[2], AgentCliPickerEntry::Agent(AgentType::Gemini));
         assert_eq!(entries[3], AgentCliPickerEntry::Agent(AgentType::OpenCode));
         assert_eq!(entries[4], AgentCliPickerEntry::Agent(AgentType::Pi));
-        assert_eq!(entries[5], AgentCliPickerEntry::AddCustom);
+        assert_eq!(entries[5], AgentCliPickerEntry::Agent(AgentType::Hermes));
+        assert_eq!(entries[6], AgentCliPickerEntry::AddCustom);
     }
 
     /// Custom agents appear in the picker between built-ins and AddCustom.
@@ -6908,12 +6937,12 @@ mod tests {
         def.name = "aider".to_string();
         def.binary = "aider".to_string();
         let entries = build_agent_cli_picker_entries(&[def]);
-        assert_eq!(entries.len(), 7);
+        assert_eq!(entries.len(), 8);
         assert_eq!(
-            entries[5],
+            entries[6],
             AgentCliPickerEntry::Agent(AgentType::Custom("aider".to_string()))
         );
-        assert_eq!(entries[6], AgentCliPickerEntry::AddCustom);
+        assert_eq!(entries[7], AgentCliPickerEntry::AddCustom);
     }
 
     /// Right key advances and wraps; left key wraps backwards.
@@ -6938,9 +6967,9 @@ mod tests {
         app.handle_agent_cli_picker_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
         assert_eq!(app.agent_picker_index, 0);
 
-        // Left from 0 wraps to last (AddCustom = 5 with no custom agents)
+        // Left from 0 wraps to last (AddCustom = 6 with no custom agents)
         app.handle_agent_cli_picker_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
-        assert_eq!(app.agent_picker_index, 5);
+        assert_eq!(app.agent_picker_index, 6);
 
         // Right from last wraps back to 0
         app.handle_agent_cli_picker_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
@@ -7020,10 +7049,10 @@ mod tests {
         app.app_config.custom_agents.push(cfg);
 
         let entries = app.agent_cli_picker_entries();
-        // 5 builtins + 1 custom + AddCustom = 7
-        assert_eq!(entries.len(), 7);
+        // 6 builtins + 1 custom + AddCustom = 8
+        assert_eq!(entries.len(), 8);
         assert!(matches!(
-            &entries[5],
+            &entries[6],
             AgentCliPickerEntry::Agent(AgentType::Custom(n)) if n == "aider"
         ));
     }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -873,6 +873,7 @@ fn update_agent(
         AgentType::Gemini => update_gemini(tx, index),
         AgentType::OpenCode => update_opencode(tx, index),
         AgentType::Pi => update_pi(tx, index),
+        AgentType::Hermes => update_hermes(tx, index),
         AgentType::Custom(_) => Err(io::Error::other(
             "Version management is not yet supported for custom agents",
         )),
@@ -1092,6 +1093,35 @@ fn update_pi(tx: &mpsc::Sender<(usize, LineState)>, index: usize) -> io::Result<
     } else {
         Err(io::Error::other(format!(
             "npm install failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )))
+    }
+}
+
+/// Update Hermes Agent via the official curl bash installer.
+/// Hermes is not distributed via npm; the installer always pulls latest.
+fn update_hermes(tx: &mpsc::Sender<(usize, LineState)>, index: usize) -> io::Result<String> {
+    let _ = tx.send((
+        index,
+        LineState::Building {
+            version: String::new(),
+            phase: "running install.sh...".into(),
+        },
+    ));
+
+    let output = Command::new("bash")
+        .args([
+            "-c",
+            "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
+        ])
+        .output()?;
+
+    if output.status.success() {
+        let version = get_installed_version(AgentType::Hermes).unwrap_or_else(|| "latest".into());
+        Ok(version)
+    } else {
+        Err(io::Error::other(format!(
+            "hermes install failed: {}",
             String::from_utf8_lossy(&output.stderr)
         )))
     }

--- a/src/version.rs
+++ b/src/version.rs
@@ -58,7 +58,7 @@ pub fn load_embedded_versions() -> HashMap<String, Vec<String>> {
     let content = std::fs::read_to_string(&path).unwrap_or_else(|_| "{}".to_string());
     let parsed: serde_json::Value = serde_json::from_str(&content).unwrap_or_default();
     let mut map = HashMap::new();
-    for key in &["claude", "codex", "gemini", "opencode", "pi"] {
+    for key in &["claude", "codex", "gemini", "opencode", "pi", "hermes"] {
         if let Some(arr) = parsed.get(key).and_then(|v| v.as_array()) {
             let versions: Vec<String> = arr
                 .iter()
@@ -80,6 +80,7 @@ pub fn save_embedded_versions(map: &HashMap<crate::agents::AgentType, Vec<Versio
             crate::agents::AgentType::Gemini => "gemini",
             crate::agents::AgentType::OpenCode => "opencode",
             crate::agents::AgentType::Pi => "pi",
+            crate::agents::AgentType::Hermes => "hermes",
             crate::agents::AgentType::Custom(_) => continue, // skip custom agents in embedded versions
         };
         let arr: Vec<serde_json::Value> = versions
@@ -1145,6 +1146,18 @@ impl VersionManager {
         versions
     }
 
+    // ── Hermes ──────────────────────────────────────────────
+
+    /// Get the Hermes version list. Hermes is installed via a curl bash
+    /// script that always installs latest, so we expose a single "latest"
+    /// entry. The installed flag reflects whether the binary is present.
+    pub fn get_hermes_version_list(&self, installed: Option<&str>) -> Vec<VersionInfo> {
+        vec![VersionInfo {
+            version: "latest".to_string(),
+            is_installed: installed.is_some(),
+        }]
+    }
+
     // ── OpenCode ────────────────────────────────────────────
 
     /// Get available OpenCode versions from npm registry.
@@ -1655,6 +1668,49 @@ impl VersionManager {
                 None
             } else {
                 Some(format!("Failed to install Pi v{}: {}", version, stderr))
+            },
+        })
+    }
+
+    /// Install Hermes Agent with streaming log output.
+    /// Hermes is distributed via a curl bash installer that always installs
+    /// the latest version — there is no version pin argument. If the caller
+    /// requests a non-"latest" version we log a note and proceed with latest.
+    pub fn install_hermes_version_streaming(
+        &self,
+        version: &str,
+        log_tx: mpsc::Sender<String>,
+    ) -> io::Result<InstallResult> {
+        if version != "latest" {
+            let _ = log_tx.send(format!(
+                "Note: Hermes installer always installs the latest version; the requested version '{}' is ignored.",
+                version
+            ));
+        }
+
+        let _ = log_tx.send(
+            "Running: curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash".to_string(),
+        );
+
+        let (ok, stdout, stderr) = Self::run_streaming(
+            Command::new("bash").args([
+                "-c",
+                "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
+            ]),
+            &log_tx,
+        )?;
+
+        Ok(InstallResult {
+            success: ok,
+            stdout,
+            stderr: stderr.clone(),
+            error: if ok {
+                None
+            } else {
+                Some(format!(
+                    "Failed to install Hermes Agent v{}: {}",
+                    version, stderr
+                ))
             },
         })
     }


### PR DESCRIPTION
## Summary

Adds **NousResearch's [Hermes Agent](https://github.com/NousResearch/hermes-agent)** as the 6th built-in harness, alongside Claude, Codex, Gemini, OpenCode, and Pi.

Wires hermes through the polyfill abstraction, TUI pickers, version manager, and updater. The agent is launchable via `unleash hermes [flags]` with unified flags translated to native hermes syntax.

## Polyfill mapping

| Unified flag | Hermes native |
|---|---|
| `-p / --prompt` | `-z <prompt>` (pure-scripted mode) |
| `-c / --continue` | `--continue` |
| `-r / --resume` | `--resume` |
| `--fork` | `--worktree` |
| `--yolo` (off by default; safe restores) | `--yolo` |
| `-m / --model` | `-m` |
| `-v / --verbose` | `--verbose` |
| `--worktree` | `--worktree` |

## Install

Hermes' upstream installer is a curl bash script (no npm, no GitHub release binaries). \`update_hermes()\` shells out to:
\`\`\`
curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
\`\`\`
The installer doesn't accept a version pin — it always installs latest. \`install_hermes_version_streaming\` logs a note when a specific version is requested and ignored.

## Out of scope

**Crossload / interchange is intentionally deferred.** Hermes stores sessions in SQLite at \`~/.hermes/\`, not JSONL — adding it to \`src/interchange/\` requires a dedicated converter that uses \`hermes sessions export\` or reads the SQLite schema directly. Tracked as a follow-up.

## Verification

- \`cargo check\` — clean
- \`cargo test --lib\` — 485 pass, 0 fail
- \`cargo clippy --all-targets -- -D warnings\` — identical lint count to main (no new lints introduced)
- End-to-end smoke test: \`unleash hermes -- -V\` launches the real hermes v0.13.0 binary on the maintainer's machine and prints version info via unleash's launcher pipeline
- Builtin ordering preserved (Hermes appended after Pi, so existing \`agents[4] == Pi\` assertions stay green)

## Test plan

- [ ] CI passes (lib tests, integration tests, clippy, audit, flake-check)
- [ ] \`unleash hermes -m <model>\` invokes hermes with \`-m\` correctly
- [ ] \`unleash hermes -p "hello"\` invokes hermes with \`-z "hello"\` (scripted mode)
- [ ] \`unleash hermes -c\` continues hermes' most recent session
- [ ] TUI agent picker shows "Hermes Agent" as the 6th entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)