### PR TITLE
fix(cli): wrapper-reentry bypasses polyfill parsing for flagged profile invocations

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -138,6 +138,58 @@ pub struct PolyfillArgs {
     pub dry_run: bool,
 }
 
+/// Returns true if `arg` is a polyfill flag that should be parsed by
+/// `PolyfillArgs::parse_from_raw`. Used by the wrapper-reentry shortcut in
+/// `lib.rs` to detect explicit profile invocations and skip the shortcut so
+/// polyfill parsing takes effect instead of forwarding the flag unchanged.
+pub fn is_polyfill_flag(arg: &str) -> bool {
+    matches!(
+        arg,
+        "--safe"
+            | "--yolo"
+            | "--fork"
+            | "-c"
+            | "--continue"
+            | "-a"
+            | "--auto"
+            | "-v"
+            | "--verbose"
+            | "--sandbox"
+            | "--dry-run"
+            | "-p"
+            | "--prompt"
+            | "-m"
+            | "--model"
+            | "-e"
+            | "--effort"
+            | "-r"
+            | "--resume"
+            | "-x"
+            | "--crossload"
+            | "-u"
+            | "--ucf"
+            | "--output-format"
+            | "--system-prompt"
+            | "--allowed-tools"
+            | "--name"
+            | "--add-dir"
+            | "--approval-mode"
+            | "--worktree"
+    ) || arg.starts_with("--prompt=")
+        || arg.starts_with("--model=")
+        || arg.starts_with("--effort=")
+        || arg.starts_with("--resume=")
+        || arg.starts_with("--crossload=")
+        || arg.starts_with("--ucf=")
+        || arg.starts_with("--output-format=")
+        || arg.starts_with("--system-prompt=")
+        || arg.starts_with("--allowed-tools=")
+        || arg.starts_with("--name=")
+        || arg.starts_with("--add-dir=")
+        || arg.starts_with("--approval-mode=")
+        || arg.starts_with("--worktree=")
+}
+
 impl PolyfillArgs {
     /// Parse polyfill flags from raw args (for external_subcommand path).
     /// Returns (polyfill_args, passthrough_args) where passthrough_args are
@@ -855,6 +907,34 @@ mod tests {
         assert!(polyfill.dry_run);
         assert_eq!(polyfill.model, Some("opus".to_string()));
         assert!(passthrough.is_empty());
+    }
+
+    #[test]
+    fn test_is_polyfill_flag_recognizes_common_flags() {
+        // Short and long forms
+        assert!(is_polyfill_flag("--dry-run"));
+        assert!(is_polyfill_flag("-p"));
+        assert!(is_polyfill_flag("--prompt"));
+        assert!(is_polyfill_flag("-m"));
+        assert!(is_polyfill_flag("--model"));
+        assert!(is_polyfill_flag("--yolo"));
+        assert!(is_polyfill_flag("--safe"));
+        assert!(is_polyfill_flag("-c"));
+        assert!(is_polyfill_flag("--continue"));
+        assert!(is_polyfill_flag("-r"));
+        assert!(is_polyfill_flag("--resume"));
+        assert!(is_polyfill_flag("--fork"));
+        assert!(is_polyfill_flag("-x"));
+        assert!(is_polyfill_flag("--crossload"));
+        // = form for value-taking flags
+        assert!(is_polyfill_flag("--model=opus"));
+        assert!(is_polyfill_flag("--prompt=hello"));
+        // Non-polyfill flags should not match
+        assert!(!is_polyfill_flag("--help"));
+        assert!(!is_polyfill_flag("--version"));
+        assert!(!is_polyfill_flag("--unknown"));
+        assert!(!is_polyfill_flag("claude"));
+        assert!(!is_polyfill_flag(""));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,7 +505,10 @@ pub fn run() -> io::Result<()> {
     // If AGENT_CMD is set AND we're running under the wrapper (AGENT_UNLEASH=1),
     // enter wrapper mode directly. This prevents stale AGENT_CMD from a previous
     // session from hijacking a fresh `unleash codex` invocation.
-    // Skip wrapper mode for help/version flags — let clap handle those
+    // Skip wrapper mode for help/version flags — let clap handle those.
+    // Skip wrapper mode when polyfill flags are present — the user is making an
+    // explicit fresh invocation (e.g. `unleash claude --dry-run`) and expects
+    // the Commands::Profile path to translate flags, not bypass parsing.
     let has_meta_flag = args
         .iter()
         .skip(1)
@@ -514,9 +517,15 @@ pub fn run() -> io::Result<()> {
         .get(1)
         .map(|a| is_known_subcommand(a.as_str()))
         .unwrap_or(false);
+    // Only scan args before `--` so passthrough flags don't trigger the bypass.
+    let has_polyfill_flag = args
+        .iter()
+        .skip(1)
+        .take_while(|a| a.as_str() != "--")
+        .any(|a| cli::is_polyfill_flag(a));
     let is_wrapper_reentry = env::var("AGENT_CMD").is_ok()
         && env::var(launcher::UNLEASHED_ENV_VAR).ok().as_deref() == Some("1");
-    if is_wrapper_reentry && !has_meta_flag && !first_arg_is_subcommand {
+    if is_wrapper_reentry && !has_meta_flag && !first_arg_is_subcommand && !has_polyfill_flag {
         let args: Vec<String> = env::args().skip(1).collect();
 
         // Check for --crossload/-x or --ucf/-u in wrapper mode — handle before launch


### PR DESCRIPTION
## Summary

Fixes #158.

When unleash is invoked from a child shell of an active unleash session, \`AGENT_UNLEASH=1\` is inherited, triggering the wrapper-reentry shortcut in \`run()\`. The shortcut bypasses clap entirely and forwards args unchanged to the launcher, so polyfill flags (\`--dry-run\`, \`-p\`, \`-m\`, \`--yolo\`, \`-c\`, \`-r\`, \`--resume\`, etc.) are silently passed to the underlying agent which rejects them.

## Repro on main

\`\`\`console
$ unleash claude  # establishes AGENT_UNLEASH=1
[ inside the agent ]
$ unleash claude --dry-run -p \"hi\"
✓ Using credentials from ~/.claude/.credentials.json
error: unknown option '--dry-run'
\`\`\`

## After this PR

\`\`\`console
$ unleash claude --dry-run -p \"hi\"
Would execute: claude --dangerously-skip-permissions -p hi
\`\`\`

## Approach

Adds \`cli::is_polyfill_flag()\` helper enumerating every short/long form and \`=\`-value variant that \`PolyfillArgs::parse_from_raw\` recognizes. In \`lib.rs::run()\`, scans args (only those before \`--\`, so passthrough flags don't trigger the bypass) for any polyfill flag and adds that to the wrapper-reentry skip conditions alongside the existing \`has_meta_flag\` and \`first_arg_is_subcommand\` guards.

Bare \`unleash\` re-entry (no flags) and bare \`unleash claude\` re-entry (no flags) are unaffected — the shortcut still fires for those.

## Tradeoff

Option 1 from #158 (an explicit \`UNLEASH_REEXEC=1\` marker set only during re-exec) is the durable fix but requires touching every re-exec site. This PR is option 2 — pragmatic patch. The \`is_polyfill_flag\` list needs to stay in sync with \`PolyfillArgs::parse_from_raw\`; covered by a unit test that will flag the most common drift.

## Test plan

- [ ] \`cargo test --lib cli::\` (32 cli tests including new \`test_is_polyfill_flag_recognizes_common_flags\`)
- [ ] CI green (full test suite, llvm-cov, headless commands, etc.)
- [ ] Manual: \`unleash claude --dry-run -p test\` from inside an unleash session prints \"Would execute:\" instead of erroring
- [ ] Manual: bare \`unleash claude\` re-entry still launches the agent (regression check)