### PR TITLE
test(hyprland): serialize env-mutating tests to fix CI flake

### DIFF
--- a/src/hyprland.rs
+++ b/src/hyprland.rs
@@ -269,10 +269,17 @@ pub fn focus_cleanup(wrapper_pid: u32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Serializes tests that mutate HYPRLAND_INSTANCE_SIGNATURE. cargo test
+    // runs tests in parallel by default, and process-global env state races
+    // across threads — without this lock, two tests can interleave their
+    // set_var/remove_var calls and one sees the wrong value at assertion time.
+    static HYPR_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_is_hyprland_detection() {
-        // Save and clear the env var for a clean test
+        let _guard = HYPR_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let original = env::var("HYPRLAND_INSTANCE_SIGNATURE").ok();
         env::remove_var("HYPRLAND_INSTANCE_SIGNATURE");
 
@@ -290,6 +297,7 @@ mod tests {
 
     #[test]
     fn test_get_info_without_hyprland() {
+        let _guard = HYPR_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let original = env::var("HYPRLAND_INSTANCE_SIGNATURE").ok();
         env::remove_var("HYPRLAND_INSTANCE_SIGNATURE");
 
@@ -303,6 +311,7 @@ mod tests {
 
     #[test]
     fn test_get_info_with_signature() {
+        let _guard = HYPR_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let original = env::var("HYPRLAND_INSTANCE_SIGNATURE").ok();
         env::set_var("HYPRLAND_INSTANCE_SIGNATURE", "test_sig_12345");
 


### PR DESCRIPTION
## Summary

Three tests in \`src/hyprland.rs\` mutate process-global \`HYPRLAND_INSTANCE_SIGNATURE\`:
- \`test_is_hyprland_detection\`
- \`test_get_info_without_hyprland\`
- \`test_get_info_with_signature\`

cargo test runs them in parallel, so two threads racing \`set_var\`/\`remove_var\` on the same key cause intermittent assertion failures. This has shown up as flakes in \`cargo-llvm-cov\` runs on dependabot PRs (#143, #144), where the suite occasionally fails with \`test_is_hyprland_detection ... FAILED\` or \`test_get_info_without_hyprland ... FAILED\`. The fail rate appears to be roughly 5-10% per CI run.

## Fix

Add a module-local \`Mutex<()>\` and lock it at the top of each affected test. Uses \`unwrap_or_else(|e| e.into_inner())\` to recover gracefully if a prior panicking test left the lock poisoned — without that, a single flaky run could cascade into 3 spurious failures on subsequent retries.

## Test plan

- [ ] \`cargo test --lib hyprland::\` green
- [ ] Full suite \`cargo test --lib\` green (486 tests, no regressions)
- [ ] CI green
- [ ] Re-run dependabot PR CI after merge to confirm flake is gone

## Followup

Two other test sites in the repo touch process-global env vars in tests (\`src/cli.rs\` and \`src/launcher.rs\` per CLAUDE.md memory). The version manager already uses a different pattern (\`command_path_override\` per-Command) to avoid this exact issue. If the flake persists elsewhere, the durable fix is to migrate those tests to dependency injection instead of env mutation.