### PR TITLE
fix(ci): remove double-scope from dependabot commit prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,8 +28,12 @@ updates:
       - "dependencies"
       - "rust"
     commit-message:
+      # Prefix already encodes the scope. Do NOT add `include: "scope"` —
+      # combining the two produces `chore(deps)(deps): ...` which the
+      # conventional-commits parser used by release-please can't parse,
+      # silently dropping every dependabot merge from the release notes
+      # (and blocking version bumps entirely if no other commit lands).
       prefix: "chore(deps)"
-      include: "scope"
     groups:
       # Roll up patch + minor bumps into one PR per group so the queue stays
       # small. Major bumps still get their own PRs (default behaviour).
@@ -56,8 +60,8 @@ updates:
       - "dependencies"
       - "github-actions"
     commit-message:
+      # See the cargo block above for why `include: "scope"` is omitted.
       prefix: "ci(deps)"
-      include: "scope"
     groups:
       actions-minor-patch:
         applies-to: version-updates


### PR DESCRIPTION
## Summary

Dependabot was configured with both \`prefix: \"chore(deps)\"\` (or \`ci(deps)\`) **and** \`include: \"scope\"\`. The two combine to produce commit messages like:

\`\`\`
chore(deps)(deps): bump tiktoken-rs from 0.9.1 to 0.11.0 (#143)
\`\`\`

The double scope is **unparseable** by the conventional-commits regex that release-please uses. Result: every dependabot merge silently drops from the release notes, and if no other parseable commit lands on \`main\`, **release-please refuses to cut a new version at all** — what just happened: 10 PRs merged since v0.1.27 but no v0.1.28 release.

Repro from the release-please log on the run after the last batch of dependabot merges (\`run 25824684612\` etc):

\`\`\`
❯ commit could not be parsed: chore(deps)(deps): bump tiktoken-rs from 0.9.1 to 0.11.0 (#143)
❯ error message: Error: unexpected token '(' at 1:12, valid tokens [!, :]
...
❯ commits: 0
✔ Considering: 0 commits
✔ No commits for path: ., skipping
\`\`\`

## Fix

Drop \`include: \"scope\"\` from both ecosystems. The explicit prefix already conveys the conventional-commit scope.

After this lands:
- cargo bumps:  \`chore(deps): bump foo from x to y\`
- github-actions bumps:  \`ci(deps): bump foo from x to y\`

Both are valid conventional commits.

## Test plan

- [ ] CI green
- [ ] After merge, next dependabot PR (or rebased existing one) shows a single-scope commit title
- [ ] release-please cuts v0.1.28 once a parseable commit lands

## Followup

The next dependabot run will use the new format. The five currently-open PRs (#145, #146, #147, #148, #149) have the old commit message — rebasing them via \`@dependabot rebase\` will regenerate the message with the corrected prefix.