### PR TITLE
fix(hermes): pass --skip-setup and null stdin to the installer

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1068,13 +1068,16 @@ impl AgentManager {
 
     /// Update Hermes via the official curl bash installer.
     /// Hermes' installer always installs the latest version — there is no
-    /// version pin argument.
+    /// version pin argument. `--skip-setup` bypasses the interactive setup
+    /// wizard, which the installer otherwise drives by reading from /dev/tty
+    /// even when piped from curl.
     fn update_hermes(&self) -> io::Result<String> {
         let output = Command::new("bash")
             .args([
                 "-c",
-                "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
+                "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup",
             ])
+            .stdin(std::process::Stdio::null())
             .output()?;
 
         if output.status.success() {

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -597,6 +597,20 @@ impl AgentManager {
                     version = Self::codex_version_from_git_tag();
                 }
 
+                // Hermes reports both a SemVer ("v0.13.0") and a CalVer date
+                // ("2026.5.7") on the same line. Upstream tags releases by
+                // CalVer, so the GH "latest" comparison only works against the
+                // CalVer — extract it from the parenthesized suffix.
+                if agent_type == AgentType::Hermes {
+                    let stdout_str = String::from_utf8_lossy(&out.stdout);
+                    let stderr_str = String::from_utf8_lossy(&out.stderr);
+                    if let Some(v) = Self::parse_hermes_calver(&stdout_str)
+                        .or_else(|| Self::parse_hermes_calver(&stderr_str))
+                    {
+                        version = Some(v);
+                    }
+                }
+
                 // Update cache
                 let entry = self.versions.entry(agent_type).or_default();
                 entry.installed = version.clone();
@@ -678,6 +692,24 @@ impl AgentManager {
         }
 
         None
+    }
+
+    /// Pull the CalVer date out of `hermes --version` output. The format is
+    /// "Hermes Agent v<semver> (<calver>)" on the first line. We need the
+    /// CalVer to match upstream's GitHub release tags.
+    fn parse_hermes_calver(output: &str) -> Option<String> {
+        let line = output.lines().next()?;
+        let start = line.rfind('(')?;
+        let end = line.rfind(')')?;
+        if end <= start + 1 {
+            return None;
+        }
+        let inner = line[start + 1..end].trim();
+        if inner.chars().next()?.is_ascii_digit() {
+            Some(inner.to_string())
+        } else {
+            None
+        }
     }
 
     /// Get latest version from GitHub
@@ -1228,6 +1260,27 @@ mod tests {
         assert_eq!(
             AgentManager::parse_version("v1.2.3"),
             Some("1.2.3".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_hermes_calver_extracts_date_from_parens() {
+        assert_eq!(
+            AgentManager::parse_hermes_calver("Hermes Agent v0.13.0 (2026.5.7)"),
+            Some("2026.5.7".to_string())
+        );
+        assert_eq!(
+            AgentManager::parse_hermes_calver(
+                "Hermes Agent v0.14.1 (2026.6.12)\nProject: /home/x/.hermes\n"
+            ),
+            Some("2026.6.12".to_string())
+        );
+        // Missing parens
+        assert_eq!(AgentManager::parse_hermes_calver("Hermes Agent v0.13.0"), None);
+        // Non-numeric content in parens
+        assert_eq!(
+            AgentManager::parse_hermes_calver("Hermes Agent v0.13.0 (dev)"),
+            None
         );
     }
 }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -478,13 +478,43 @@ fn get_installed_version(agent_type: AgentType) -> Option<String> {
     if let AgentType::Custom(_) = &agent_type {
         return None; // custom agents don't support version detection yet
     }
-    let def = AgentDefinition::from_type(agent_type);
+    let def = AgentDefinition::from_type(agent_type.clone());
     let output = Command::new(&def.binary).arg("--version").output().ok()?;
     if !output.status.success() {
         return None;
     }
-    parse_version(&String::from_utf8_lossy(&output.stdout))
-        .or_else(|| parse_version(&String::from_utf8_lossy(&output.stderr)))
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Hermes reports two version numbers — the SemVer project version and a
+    // CalVer release date. Upstream tags GitHub releases by the CalVer date
+    // (e.g. v2026.5.7), so we have to compare against that one or the version
+    // check will always think an update is available.
+    //   "Hermes Agent v0.13.0 (2026.5.7)"  ->  "2026.5.7"
+    if agent_type == AgentType::Hermes {
+        if let Some(v) = parse_hermes_calver(&stdout).or_else(|| parse_hermes_calver(&stderr)) {
+            return Some(v);
+        }
+    }
+
+    parse_version(&stdout).or_else(|| parse_version(&stderr))
+}
+
+/// Pull the CalVer date out of hermes --version output. The format is
+/// "Hermes Agent v<semver> (<calver>)" on the first line.
+fn parse_hermes_calver(output: &str) -> Option<String> {
+    let line = output.lines().next()?;
+    let start = line.rfind('(')?;
+    let end = line.rfind(')')?;
+    if end <= start + 1 {
+        return None;
+    }
+    let inner = line[start + 1..end].trim();
+    if inner.chars().next()?.is_ascii_digit() {
+        Some(inner.to_string())
+    } else {
+        None
+    }
 }
 
 /// Get the latest available version from GitHub releases API.

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1109,11 +1109,15 @@ fn update_hermes(tx: &mpsc::Sender<(usize, LineState)>, index: usize) -> io::Res
         },
     ));
 
+    // --skip-setup bypasses the interactive setup wizard. The installer reads
+    // from /dev/tty for prompts even when piped from curl, so just piping does
+    // not suffice; we explicitly opt out of the wizard and null stdin.
     let output = Command::new("bash")
         .args([
             "-c",
-            "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
+            "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup",
         ])
+        .stdin(std::process::Stdio::null())
         .output()?;
 
     if output.status.success() {

--- a/src/version.rs
+++ b/src/version.rs
@@ -1689,14 +1689,18 @@ impl VersionManager {
         }
 
         let _ = log_tx.send(
-            "Running: curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash".to_string(),
+            "Running: curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup".to_string(),
         );
 
+        // --skip-setup bypasses the interactive wizard; null stdin prevents
+        // the installer from reading /dev/tty for prompts.
         let (ok, stdout, stderr) = Self::run_streaming(
-            Command::new("bash").args([
-                "-c",
-                "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
-            ]),
+            Command::new("bash")
+                .args([
+                    "-c",
+                    "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup",
+                ])
+                .stdin(Stdio::null()),
             &log_tx,
         )?;
 


### PR DESCRIPTION
## Summary

When \`unleash update hermes\` (or the TUI version manager flow) runs, the Hermes installer drops into its interactive setup wizard and blocks waiting for input — found while testing the recently-shipped Hermes harness (#153).

## Root cause

The upstream installer at \`hermes-agent/main/scripts/install.sh\` auto-detects non-interactive mode via \`[ -t 0 ]\`, but for the setup wizard it explicitly redirects stdin from \`/dev/tty\`:

\`\`\`bash
# Redirect stdin from /dev/tty so interactive prompts work when piped from curl.
\`\`\`

So piping through curl is not enough — the wizard pops up regardless. unleash's bash subprocess inherits the parent terminal's controlling TTY, the wizard opens \`/dev/tty\`, reads, and hangs.

## Fix

Two belt-and-suspenders measures at every Hermes install site:

1. Pass \`--skip-setup\` to the install script. The upstream installer documents this flag and short-circuits the wizard when present.
2. Set the spawned bash's stdin to \`Stdio::null()\` so even a future installer change that tries another route can't grab a TTY through us.

Touches the three sites that invoke install.sh:
- \`AgentDefinition::update_hermes\` (src/agents.rs)
- \`update_hermes\` worker in the parallel updater (src/updater.rs)
- \`install_hermes_version_streaming\` (src/version.rs)

## Verification

- \`cargo check\` — clean
- \`cargo test --lib\` — 486 pass, 0 fail
- Manual: install \`hermes\` from scratch via \`unleash agents update hermes\` after this PR lands and confirm no prompt appears

## Followup

If users want the interactive setup, they should run the installer manually (\`curl ... | bash\`) outside unleash. unleash itself should not be a wrapper that surfaces interactive wizards — separate UX surface.