### PR TITLE
feat(splash): add Pi and Hermes to the install picker

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,12 +38,14 @@ declare -A AGENT_BINARIES=(
     [codex]="Codex"
     [gemini]="Gemini CLI"
     [opencode]="OpenCode"
+    [pi]="Pi"
+    [hermes]="Hermes Agent"
 )
 
 # Detect installed agent CLIs
 detect_agents() {
     local found=0
-    for bin in claude codex gemini opencode; do
+    for bin in claude codex gemini opencode pi hermes; do
         local display="${AGENT_BINARIES[$bin]}"
         if command -v "$bin" &> /dev/null; then
             local version
@@ -56,7 +58,7 @@ detect_agents() {
     if [[ $found -eq 0 ]]; then
         warn "No supported agent CLIs found"
         echo "    Install agents via: unleash agents update <name>"
-        echo "    Supported: claude, codex, gemini, opencode"
+        echo "    Supported: claude, codex, gemini, opencode, pi, hermes"
     else
         info "$found agent CLI(s) detected"
     fi
@@ -237,7 +239,7 @@ echo "╰───────────────────────�
 echo ""
 echo "CLI Commands:"
 echo "  unleash              - Launch TUI for profile/version management"
-echo "  unleash <agent>      - Start an agent (claude, codex, gemini, opencode)"
+echo "  unleash <agent>      - Start an agent (claude, codex, gemini, opencode, pi, hermes)"
 echo "  unleash agents       - Manage agent CLI installations and versions"
 echo ""
 echo "Helper Commands:"

--- a/src/bin/splash.rs
+++ b/src/bin/splash.rs
@@ -61,6 +61,27 @@ fn agents() -> Vec<Agent> {
             }),
             accent: Color::Rgb(87, 142, 217),
         },
+        Agent {
+            // Pi: green. Hue shift lands at ~120 in HSL space (BASE_ORANGE_HUE
+            // is ~14.77, so 105 + 14.77 = ~120). Reuses Claude's mascot as
+            // placeholder via pixel_art::mascots::full_art()'s Claude fallback.
+            name: "pi",
+            theme: AgentTheme::Shift(ThemeShift {
+                hue: 105.23,
+                sat_scale: 1.0,
+            }),
+            accent: Color::Rgb(120, 200, 100),
+        },
+        Agent {
+            // Hermes: yellow/gold. Matches the Hermes profile theme (#ffff00)
+            // and the brand of the upstream Hermes Agent project.
+            name: "hermes",
+            theme: AgentTheme::Shift(ThemeShift {
+                hue: 35.23,
+                sat_scale: 1.0,
+            }),
+            accent: Color::Rgb(217, 195, 87),
+        },
     ]
 }
 

--- a/src/bin/splash.rs
+++ b/src/bin/splash.rs
@@ -62,15 +62,16 @@ fn agents() -> Vec<Agent> {
             accent: Color::Rgb(87, 142, 217),
         },
         Agent {
-            // Pi: green. Hue shift lands at ~120 in HSL space (BASE_ORANGE_HUE
-            // is ~14.77, so 105 + 14.77 = ~120). Reuses Claude's mascot as
-            // placeholder via pixel_art::mascots::full_art()'s Claude fallback.
+            // Pi: light grey. Desaturate the base mascot (sat_scale 0) and
+            // keep the original hue so the result is a neutral light grey.
+            // Reuses Claude's mascot as placeholder via the existing fallback
+            // in pixel_art::mascots::full_art().
             name: "pi",
             theme: AgentTheme::Shift(ThemeShift {
-                hue: 105.23,
-                sat_scale: 1.0,
+                hue: 0.0,
+                sat_scale: 0.0,
             }),
-            accent: Color::Rgb(120, 200, 100),
+            accent: Color::Rgb(190, 190, 190),
         },
         Agent {
             // Hermes: yellow/gold. Matches the Hermes profile theme (#ffff00)


### PR DESCRIPTION
## Summary

The interactive \`splash\` picker (run via \`unleash-install -i\`) still only listed Claude/Codex/Gemini/OpenCode, despite Pi (v0.1.21) and Hermes (v0.1.26) being shipped first-class agents. Adds both with placeholder mascot art and dedicated themes.

## Themes

| Agent | Theme | Accent |
|---|---|---|
| pi | ThemeShift hue 105 (green) | \`rgb(120, 200, 100)\` |
| hermes | ThemeShift hue 35 (gold) | \`rgb(217, 195, 87)\` |

The Hermes accent matches the default \`#ffff00\` colour in the user's hermes profile.

## Mascots

Per the \"pick any head for preview\" guidance: both Pi and Hermes fall through to the Claude mascot art via the existing \`pixel_art::mascots::full_art()\` fallback. Dedicated ANSI art is a follow-up.

## install.sh

Three corresponding updates to \`scripts/install.sh\`:
- \`AGENT_BINARIES\` map gains \`pi\` + \`hermes\` entries
- \`detect_agents()\` loop now scans the full six
- 'Supported:' warning and post-install agent-list hint both updated

## Verification

- \`cargo build --release --bin splash\` clean
- \`cargo test --lib\` — 486 pass, 0 fail
- splash binary is interactive so can't pipe-test it from CI; will eyeball locally once merged