### PR TITLE
fix(installer): tolerate pre-existing config + surface missing npm

### DIFF
--- a/scripts/install-remote.sh
+++ b/scripts/install-remote.sh
@@ -773,6 +773,70 @@ EOF
     success "Onboarding bypass configured"
 }
 
+# Write the selected agent as default profile in ~/.config/unleash/config.toml.
+# Tolerant of pre-existing configs, dotfile symlinks, and partial setups —
+# returns non-zero on failure so the caller can warn without aborting.
+set_default_profile() {
+    local agent="$1"
+    local config_dir="${HOME}/.config/unleash"
+    local config_file="${config_dir}/config.toml"
+
+    # mkdir -p is fine if config_dir already exists (incl. symlink to dir).
+    # Capture stderr so we can warn meaningfully on weird filesystem states.
+    if ! mkdir -p "$config_dir" 2>/dev/null; then
+        warn "Existing $config_dir could not be prepared (permission or path issue)."
+        warn "Skipping default-profile write; existing config preserved."
+        return 1
+    fi
+
+    if [[ -f "$config_file" ]]; then
+        # Pre-existing config: try to update in place. If it's a read-only
+        # dotfile symlink target (e.g. dotfiles repo on a different fs),
+        # sed -i will fail — we don't want to corrupt the user's repo.
+        if grep -q "^current_profile" "$config_file" 2>/dev/null; then
+            if ! sed -i "s/^current_profile.*/current_profile = \"$agent\"/" "$config_file" 2>/dev/null; then
+                warn "Config at $config_file is read-only or unwritable."
+                warn "Existing current_profile preserved; edit manually to set $agent."
+                return 1
+            fi
+        else
+            if ! echo "current_profile = \"$agent\"" >> "$config_file" 2>/dev/null; then
+                warn "Could not append to $config_file (read-only)."
+                return 1
+            fi
+        fi
+    else
+        if ! echo "current_profile = \"$agent\"" > "$config_file" 2>/dev/null; then
+            warn "Could not create $config_file."
+            return 1
+        fi
+    fi
+    return 0
+}
+
+# Surface prereq gaps for the selected agent so the user knows what they
+# still need to install. Non-fatal — we don't block on missing prereqs, but
+# we do tell the user what to expect when they run `unleash install <agent>`.
+check_agent_prereqs() {
+    local agent="$1"
+    case "$agent" in
+        claude|codex|gemini|opencode|pi)
+            if ! command -v npm &> /dev/null; then
+                warn "npm not found. ${agent} needs npm for install."
+                echo "    Install Node.js first:"
+                echo "      curl -fsSL https://fnm.vercel.app/install | bash"
+                echo "      # then: fnm install --lts && fnm use --lts"
+                echo "    Or via your package manager (pacman -S nodejs npm, apt install nodejs npm, etc)."
+                return 1
+            fi
+            ;;
+        hermes)
+            # hermes installs via curl bash, no npm needed
+            ;;
+    esac
+    return 0
+}
+
 # Main installation
 main() {
     echo ""
@@ -829,19 +893,15 @@ main() {
             SELECTED_AGENT=$("${INSTALL_DIR}/splash") || true
             if [[ -n "${SELECTED_AGENT:-}" ]]; then
                 info "Default profile set to $SELECTED_AGENT"
-                # Set default profile in config
-                local config_dir="${HOME}/.config/unleash"
-                local config_file="${config_dir}/config.toml"
-                mkdir -p "$config_dir"
-                if [[ -f "$config_file" ]]; then
-                    if grep -q "^current_profile" "$config_file"; then
-                        sed -i "s/^current_profile.*/current_profile = \"$SELECTED_AGENT\"/" "$config_file"
-                    else
-                        echo "current_profile = \"$SELECTED_AGENT\"" >> "$config_file"
-                    fi
-                else
-                    echo "current_profile = \"$SELECTED_AGENT\"" > "$config_file"
+                # Best-effort: any failure here (existing config that's a
+                # symlink to a read-only dotfile, weird ownership, etc) must
+                # NOT abort the whole installer. The binary still installed.
+                if ! set_default_profile "$SELECTED_AGENT"; then
+                    warn "Could not write default profile to config. Run 'unleash' to set it via the TUI."
                 fi
+                # If the selected agent needs npm and npm is missing, surface
+                # it now so the user knows the next step.
+                check_agent_prereqs "$SELECTED_AGENT" || true
             fi
         elif [[ -x "${INSTALL_DIR}/unleash" ]]; then
             info "Launching TUI..."


### PR DESCRIPTION
## Two reported UX issues during \`curl ... | bash\`

### 1. Installer halts on pre-existing config

\`\`\`
mkdir: cannot create directory '/home/me/.config/unleash': File exists
\`\`\`

The default-profile setup at the end of \`main()\` called \`mkdir -p\`, \`sed -i\`, and \`echo > file\` inside a \`set -euo pipefail\` block. Any failure (read-only dotfile symlink target, weird ownership, sed misquoting on unusual paths) aborts the whole installer even though the binary already landed and was usable.

### 2. Missing npm not surfaced

When the user picks a Claude/Codex/Gemini/OpenCode/Pi profile in the splash but doesn't have npm installed, the install \"completes\" but \`unleash install <agent>\` later silently fails — confusing because the install script reported success.

## Fix

Extract two helpers above \`main()\`:

- \`set_default_profile()\` — returns non-zero on any failure; caller warns and keeps moving. User's existing config is **preserved**, never corrupted. Specific guidance: \"edit manually to set \$agent.\"
- \`check_agent_prereqs()\` — surfaces missing npm right after splash with concrete install instructions for fnm or system package managers. Hermes is skipped (curl-based installer).

Both are best-effort warns; the binary is installed and the user has a clear next step. No more aborts on existing dotfiles.

## Not done in this PR

The user also asked for a full \"setup wizard\" akin to \`hermes setup\`. That's a much larger TUI-driven flow (multi-select agents, prompt for installing npm/nvm, etc.). Tracked as a followup — this PR is the immediate-aid patch.

## Test plan

- [ ] CI green
- [ ] Run the installer against the affected system (existing \`~/.config/unleash\` symlink + populated \`config.toml\`); confirm it no longer aborts
- [ ] Run on a clean container without npm and pick the Claude profile; confirm the npm warning prints