### PR TITLE
feat(search): semantic session search via turso + OAI-compat embeddings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,51 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aegis"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78412fa53e6da95324e8902c3641b3ff32ab45258582ea997eb9169c68ffa219"
+dependencies = [
+ "cc",
+ "softaes",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +75,15 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anstream"
@@ -67,7 +121,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -78,7 +132,23 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "antithesis_sdk"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dbd97a5b6c21cc9176891cf715f7f0c273caf3959897f43b9bd1231939e675"
+dependencies = [
+ "libc",
+ "libloading",
+ "linkme",
+ "once_cell",
+ "rand 0.8.6",
+ "rustc_version_runtime",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -88,6 +158,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "assoc"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdc70193dadb9d7287fa4b633f15f90c876915b31f6af17da307fc59c9859a8"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +191,12 @@ checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -113,6 +215,42 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+ "which 4.4.2",
+]
 
 [[package]]
 name = "bit-set"
@@ -157,12 +295,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bitpacking"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling 0.23.0",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "branches"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e426eb5cc1900033930ec955317b302e68f19f326cc7bb0c8a86865a826cdf0c"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -187,6 +380,32 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "castaway"
@@ -204,7 +423,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "census"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -218,6 +454,46 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cfg_block"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -281,6 +557,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,12 +575,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -318,6 +636,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,7 +663,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -351,12 +679,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -368,6 +703,15 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -455,6 +799,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "datasketches"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -550,7 +901,18 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -563,10 +925,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "env_filter",
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -575,13 +962,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -631,6 +1029,23 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "siphasher",
+]
+
+[[package]]
+name = "fastdivide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastrand"
@@ -686,10 +1101,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "futures-task"
@@ -704,9 +1164,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "genawaiter"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
+dependencies = [
+ "genawaiter-macro",
+]
+
+[[package]]
+name = "genawaiter-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -726,8 +1217,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -737,23 +1230,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -791,10 +1302,235 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
 
 [[package]]
 name = "id-arena"
@@ -807,6 +1543,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "include_dir"
@@ -849,6 +1606,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,10 +1628,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -881,6 +1691,16 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -918,16 +1738,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "levenshtein_automata"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "libredox"
@@ -959,10 +1816,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -986,6 +1875,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +1895,18 @@ checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 
 [[package]]
 name = "mac_address"
@@ -1021,10 +1935,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "measure_time"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55d61e72fc3ab704396c5fa16f4c184db37978ae4e94ca8959693a235fc0e"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmem"
@@ -1042,6 +1983,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+dependencies = [
+ "libmimalloc-sys",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,7 +2028,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1080,6 +2052,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "murmurhash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nix"
@@ -1117,6 +2095,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +2128,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1164,6 +2170,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
+
+[[package]]
 name = "onig"
 version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,6 +2198,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +2216,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ownedbytes"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "pack1"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b7bb0ecf2e447b1f20ee94ee79ef6eed1e9d4b3c36ce1903b9dea3bf205523"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1228,6 +2279,18 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -1337,10 +2400,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1387,7 +2485,7 @@ dependencies = [
  "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -1396,10 +2494,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "quote"
@@ -1417,11 +2593,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -1431,8 +2621,18 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1450,6 +2650,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -1461,12 +2664,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1493,14 +2714,14 @@ dependencies = [
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1545,13 +2766,13 @@ dependencies = [
  "hashbrown 0.16.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum",
+ "strum 0.27.2",
  "time",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1571,7 +2792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools",
+ "itertools 0.14.0",
  "rayon",
 ]
 
@@ -1635,6 +2856,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1660,10 +2943,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1675,6 +2974,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,8 +3005,43 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1710,6 +3067,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -1776,6 +3139,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,10 +3168,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shuttle"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab17edba38d63047f46780cf7360acf7467fec2c048928689a5c1dd1c2b4e31"
+dependencies = [
+ "assoc",
+ "bitvec",
+ "cfg-if",
+ "generator",
+ "hex",
+ "owo-colors",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "rand_pcg",
+ "scoped-tls",
+ "smallvec",
+ "tracing",
+]
 
 [[package]]
 name = "signal-hook"
@@ -1824,10 +3234,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "simsimd"
+version = "6.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fb3bc3cdce07a7d7d4caa4c54f8aa967f6be41690482b54b24100a2253fa70"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "slab"
@@ -1840,6 +3268,22 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "softaes"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef461faaeb36c340b6c887167a9054a034f6acfc50a014ead26a02b4356b3de"
 
 [[package]]
 name = "spm_precompiled"
@@ -1866,6 +3310,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,11 +3329,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1897,6 +3369,18 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -1921,16 +3405,190 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tantivy"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edde6a10743fff00a4e1a8c9ef020bf5f3cbad301b7d2d39f2b07f123c4eac07"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "base64 0.22.1",
+ "bitpacking",
+ "bon",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "datasketches",
+ "downcast-rs",
+ "fastdivide",
+ "fnv",
+ "fs4",
+ "htmlescape",
+ "itertools 0.14.0",
+ "levenshtein_automata",
+ "log",
+ "lru",
+ "lz4_flex",
+ "measure_time",
+ "memmap2",
+ "once_cell",
+ "oneshot",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_json",
+ "sketches-ddsketch",
+ "smallvec",
+ "tantivy-bitpacker",
+ "tantivy-columnar",
+ "tantivy-common",
+ "tantivy-fst",
+ "tantivy-query-grammar",
+ "tantivy-stacker",
+ "tantivy-tokenizer-api",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "typetag",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy-bitpacker"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fed3d674429bcd2de5d0a6d1aa5495fed8afd9c5ecce993019caf7615f53fa4"
+dependencies = [
+ "bitpacking",
+]
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c57166f5bcfd478f370ab8445afb4678dce44801fa5ce5c451aaf8595583c5dc"
+dependencies = [
+ "downcast-rs",
+ "fastdivide",
+ "itertools 0.14.0",
+ "serde",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf10915aa75da3c3b0d58b58853d2e889efbaf32d4982a4c3715dde6bba23e5"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "ownedbytes",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "tantivy-fst"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfadb8526b6da90704feb293b0701a6aae62ea14983143344be2dc5ce30f1d82"
+dependencies = [
+ "fnv",
+ "nom",
+ "ordered-float 5.3.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tantivy-sstable"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2cfc3ac5164cbadc28965ffb145a8f47582a60ae5897859ad8d4316596c606"
+dependencies = [
+ "futures-util",
+ "itertools 0.14.0",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-fst",
+ "zstd",
+]
+
+[[package]]
+name = "tantivy-stacker"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbb051742da9d53ca9e8fff43a9b10e319338b24e2c0e15d0372df19ffeb951"
+dependencies = [
+ "murmurhash32",
+ "tantivy-common",
+]
+
+[[package]]
+name = "tantivy-tokenizer-api"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac258c2c6390673f2685813afeeafcb8c4e0ee7de8dd3fc46838dcc37263f98"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix",
- "windows-sys",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1975,7 +3633,7 @@ dependencies = [
  "nix 0.29.0",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf",
@@ -2037,6 +3695,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiktoken-rs"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,7 +3715,7 @@ dependencies = [
  "fancy-regex 0.17.0",
  "lazy_static",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -2058,12 +3725,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2071,6 +3740,41 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
@@ -2085,7 +3789,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -2103,6 +3807,42 @@ dependencies = [
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
+]
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2145,10 +3885,360 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "turso"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21b08119fb7fa81cdd441a0255cb26811ff5d9c0dc0ff65bb71a493b7472c86"
+dependencies = [
+ "mimalloc",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit",
+ "turso_sync_sdk_kit",
+]
+
+[[package]]
+name = "turso_core"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584dcc247f472c45d4f369daf590487a609c16a7f8848f2fb2902d3d3f055d31"
+dependencies = [
+ "aegis",
+ "aes",
+ "aes-gcm",
+ "antithesis_sdk",
+ "arc-swap",
+ "bigdecimal",
+ "bitflags 2.11.0",
+ "branches",
+ "bumpalo",
+ "bytemuck",
+ "cfg_aliases",
+ "cfg_block",
+ "chrono",
+ "crc32c",
+ "crossbeam-skiplist",
+ "either",
+ "fallible-iterator",
+ "fastbloom",
+ "hex",
+ "intrusive-collections",
+ "io-uring",
+ "libc",
+ "libloading",
+ "libm",
+ "loom",
+ "miette",
+ "num-bigint",
+ "num-traits",
+ "pack1",
+ "parking_lot",
+ "pastey",
+ "polling",
+ "rand 0.9.2",
+ "rapidhash",
+ "regex",
+ "regex-syntax",
+ "roaring",
+ "rustc-hash 2.1.2",
+ "rustix 1.1.4",
+ "ryu",
+ "serde_json",
+ "shuttle",
+ "simsimd",
+ "smallvec",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "tantivy",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
+ "turso_ext",
+ "turso_macros",
+ "turso_parser",
+ "twox-hash",
+ "uncased",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "turso_ext"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "870a80e0516ec000ee51aed89664d41e258e31c1b4a639f86e0ce7c2dd3bbc18"
+dependencies = [
+ "chrono",
+ "getrandom 0.4.2",
+ "turso_macros",
+]
+
+[[package]]
+name = "turso_macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97578dbe06dd73634457b38b3546b868b4886aebefa57570b11a899679355761"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "turso_parser"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa8dd793f7e9c467568275b0acddfd527ec19b7d1057bed41364b4c77b1111b3"
+dependencies = [
+ "bitflags 2.11.0",
+ "memchr",
+ "miette",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "thiserror 2.0.18",
+ "turso_macros",
+]
+
+[[package]]
+name = "turso_sdk_kit"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00d981b511fd8838ed601b14e447fe4c407281cc2ddd1217762f5386cb4fc14"
+dependencies = [
+ "bindgen",
+ "env_logger",
+ "parking_lot",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit_macros",
+]
+
+[[package]]
+name = "turso_sdk_kit_macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece10adfe27b9ec4cbc8e22c4b34fb22b08c1f5027fbcdd5bfa69a8306a927f2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "turso_sync_engine"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbe9e0f7293d024c1458d9bd8f3676590a39ea9aac7659442c41639cb35d1270"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "genawaiter",
+ "http",
+ "libc",
+ "prost",
+ "roaring",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "turso_core",
+ "turso_parser",
+ "uuid",
+]
+
+[[package]]
+name = "turso_sync_sdk_kit"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235fb4a05bc74c6f23db6b9391bd6d76befd987767485af5726b9d009d5cca1f"
+dependencies = [
+ "bindgen",
+ "env_logger",
+ "genawaiter",
+ "parking_lot",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit",
+ "turso_sdk_kit_macros",
+ "turso_sync_engine",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "typetag"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "ucd-trie"
@@ -2161,6 +4251,15 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -2189,10 +4288,16 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -2213,6 +4318,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "unleash"
 version = "0.1.32"
 dependencies = [
@@ -2224,15 +4339,48 @@ dependencies = [
  "nix 0.31.3",
  "proptest",
  "ratatui",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
  "tiktoken-rs",
  "tokenizers",
+ "tokio",
  "toml",
- "which",
+ "turso",
+ "which 8.0.2",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2247,10 +4395,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "atomic",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2280,6 +4436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -2317,6 +4482,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2386,6 +4561,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,7 +4631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -2455,6 +4659,18 @@ dependencies = [
  "lazy_static",
  "serde",
  "wezterm-dynamic",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -2489,10 +4705,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2502,6 +4789,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2598,6 +4949,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2618,7 +5007,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,10 @@ include_dir = "0.7"
 [dev-dependencies]
 tempfile = "3.27"
 proptest = "1.5"
+# PoC (plan: search overhaul) — turso + OAI-compat HTTP embedding/naming
+turso = "0.6.0"
+tokio = { version = "1", features = ["rt", "macros"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,13 +43,14 @@ tokenizers = { version = "0.23", default-features = false, features = ["onig"] }
 # Embed docker/ assets for binary-only installs
 include_dir = "0.7"
 
-[dev-dependencies]
-tempfile = "3.27"
-proptest = "1.5"
-# PoC (plan: search overhaul) — turso + OAI-compat HTTP embedding/naming
+# Semantic session search (turso vector store + OAI-compat embeddings/naming)
 turso = "0.6.0"
 tokio = { version = "1", features = ["rt", "macros"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+
+[dev-dependencies]
+tempfile = "3.27"
+proptest = "1.5"
 
 [profile.release]
 lto = true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@
 # ============================================================
 # Stage 1: Build unleash from Rust source
 # ============================================================
-FROM rust:1.88-bookworm AS rust-builder
+FROM rust:1.90-bookworm AS rust-builder
 
 WORKDIR /build
 

--- a/examples/poc_search.rs
+++ b/examples/poc_search.rs
@@ -1,0 +1,647 @@
+//! PoC: end-to-end semantic session search.
+//!
+//! Proves the chain: discover → extract text → embed (OAI-compat) →
+//! store (turso) → name (OAI-compat chat) → query (vector + BM25 hybrid in Rust).
+//!
+//! ## How to run
+//!
+//! 1. Spin up an OpenAI-compatible server with an embedding model. Examples:
+//!
+//!    # llama.cpp with Granite Embedding small-r2 (preferred per plan):
+//!    llama-server -m ~/models/granite-embedding-small-en-r2.Q8_0.gguf \
+//!                 --embedding --port 8080 -ngl 99
+//!
+//!    # Or EmbeddingGemma-300m (fallback if Granite GGUF is fiddly):
+//!    llama-server -m ~/models/embeddinggemma-300m.Q8_0.gguf \
+//!                 --embedding --port 8080 -ngl 99
+//!
+//!    # Or via ollama:
+//!    ollama serve  # then `ollama pull granite-embedding:30m`
+//!
+//! 2. Optionally spin up a *chat* model on a second port for session naming
+//!    (any small instruct model — qwen2.5-3b, llama3.2-3b, etc.).
+//!    If you skip this, naming is disabled and the picker shows raw IDs.
+//!
+//! 3. Run the PoC:
+//!
+//!    # Index + query in one shot:
+//!    cargo run --release --example poc_search -- "refactor the auth flow"
+//!
+//!    # Customize endpoints:
+//!    OAI_BASE=http://localhost:8080/v1\
+//!    OAI_EMBED_MODEL=granite-embedding\
+//!    OAI_CHAT_BASE=http://localhost:8081/v1\
+//!    OAI_CHAT_MODEL=qwen2.5-3b-instruct\
+//!    cargo run --release --example poc_search -- "redo the login flow"
+//!
+//! The PoC is intentionally fault-tolerant: per-session failures (file read
+//! errors, API timeouts, malformed embeddings) are logged and skipped, never
+//! abort the whole run.
+
+use std::collections::HashMap;
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+use std::time::Instant;
+
+use unleash::interchange::sessions::{discover_all, SessionInfo};
+
+const MAX_TEXT_CHARS: usize = 600; // ~150 tokens; deliberately conservative for llama-server's GPU
+const EMBED_BATCH: usize = 1; // sequential — embeddinggemma server CUDA-crashes under parallelism
+const TOP_K: usize = 15;
+const ALPHA_DEFAULT: f32 = 0.4; // 0=pure semantic, 1=pure BM25
+const NAMING_TIMEOUT_SECS: u64 = 60; // CPU naming via qwen2.5-3b is slow but reliable
+const EMBED_TIMEOUT_SECS: u64 = 10;
+/// Cap naming pass at the N most-recent unnamed sessions per run. PoC default;
+/// production code (`unleash sessions name`) will background-process all of them.
+const MAX_NAMES_PER_RUN: usize = 12;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let query = env::args().nth(1).unwrap_or_else(|| "test".to_string());
+
+    let oai_base =
+        env::var("OAI_BASE").unwrap_or_else(|_| "http://localhost:8080/v1".to_string());
+    let embed_model =
+        env::var("OAI_EMBED_MODEL").unwrap_or_else(|_| "granite-embedding".to_string());
+    let chat_base = env::var("OAI_CHAT_BASE").ok().unwrap_or_else(|| oai_base.clone());
+    let chat_model = env::var("OAI_CHAT_MODEL").ok();
+    let alpha: f32 = env::var("ALPHA")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(ALPHA_DEFAULT);
+
+    eprintln!("poc_search: query = {query:?}");
+    eprintln!("  embeddings: {oai_base} model={embed_model}");
+    if let Some(ref m) = chat_model {
+        eprintln!("  naming    : {chat_base} model={m}");
+    } else {
+        eprintln!("  naming    : disabled (set OAI_CHAT_MODEL to enable)");
+    }
+    eprintln!("  alpha     : {alpha:.2}  (0=semantic, 1=bm25)");
+
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(EMBED_TIMEOUT_SECS))
+        .build()?;
+
+    // ── Step 1: open turso DB and bootstrap schema ────────────────────────
+    let db_path = dirs::data_local_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+        .join("unleash/search-poc.db");
+    if let Some(parent) = db_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    eprintln!("  store     : {}", db_path.display());
+
+    let db = turso::Builder::new_local(db_path.to_string_lossy().as_ref())
+        .build()
+        .await?;
+    let conn = db.connect()?;
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS sessions (\
+            pk INTEGER PRIMARY KEY,\
+            cli TEXT NOT NULL,\
+            source_id TEXT NOT NULL,\
+            path TEXT NOT NULL,\
+            directory TEXT,\
+            native_title TEXT,\
+            generated_title TEXT,\
+            first_message TEXT,\
+            updated_at TEXT,\
+            mtime_ns INTEGER NOT NULL,\
+            model_id TEXT,\
+            embedding BLOB,\
+            UNIQUE(cli, source_id))",
+        (),
+    )
+    .await?;
+
+    // ── Step 2: discover + extract text + upsert if mtime changed ─────────
+    let t_disc = Instant::now();
+    let sessions = discover_all();
+    eprintln!(
+        "\n[discover] {} sessions in {:?}",
+        sessions.len(),
+        t_disc.elapsed()
+    );
+
+    let mut indexed_pks: Vec<i64> = Vec::new();
+    let mut needs_embed: Vec<(i64, String)> = Vec::new();
+    let mut needs_name: Vec<(i64, String)> = Vec::new();
+
+    for s in &sessions {
+        let mtime_ns = file_mtime_ns(&s.path).unwrap_or(0);
+        let cur_mtime: Option<i64> = {
+            let mut r = conn
+                .query(
+                    "SELECT mtime_ns FROM sessions WHERE cli=?1 AND source_id=?2",
+                    turso::params![s.cli.clone(), s.id.clone()],
+                )
+                .await?;
+            match r.next().await? {
+                Some(row) => Some(row.get(0)?),
+                None => None,
+            }
+        };
+        let text = extract_text(s).unwrap_or_default();
+        let native_title = s.title.clone().or(s.name.clone());
+
+        if cur_mtime != Some(mtime_ns) {
+            conn.execute(
+                "INSERT INTO sessions (cli, source_id, path, directory, native_title, \
+                    first_message, updated_at, mtime_ns, model_id) \
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9) \
+                 ON CONFLICT(cli, source_id) DO UPDATE SET \
+                    path=excluded.path, directory=excluded.directory,\
+                    native_title=excluded.native_title, first_message=excluded.first_message,\
+                    updated_at=excluded.updated_at, mtime_ns=excluded.mtime_ns,\
+                    embedding=NULL, model_id=NULL, generated_title=NULL",
+                turso::params![
+                    s.cli.clone(),
+                    s.id.clone(),
+                    s.path.to_string_lossy().to_string(),
+                    s.directory.clone(),
+                    native_title.clone(),
+                    text.clone(),
+                    s.updated_at.clone(),
+                    mtime_ns,
+                    embed_model.clone(),
+                ],
+            )
+            .await?;
+        }
+
+        let pk: i64 = {
+            let mut r = conn
+                .query(
+                    "SELECT pk, embedding IS NOT NULL AS has_emb, generated_title IS NOT NULL OR native_title IS NOT NULL AS has_title \
+                     FROM sessions WHERE cli=?1 AND source_id=?2",
+                    turso::params![s.cli.clone(), s.id.clone()],
+                )
+                .await?;
+            let row = r.next().await?.expect("row must exist after upsert");
+            let pk: i64 = row.get(0)?;
+            let has_emb: i64 = row.get(1)?;
+            let has_title: i64 = row.get(2)?;
+            indexed_pks.push(pk);
+            if has_emb == 0 && !text.is_empty() {
+                needs_embed.push((pk, text.clone()));
+            }
+            if has_title == 0 && chat_model.is_some() && !text.is_empty() {
+                needs_name.push((pk, text.clone()));
+            }
+            pk
+        };
+        let _ = pk;
+    }
+    eprintln!(
+        "[index] {} rows indexed, {} need embedding, {} need naming",
+        indexed_pks.len(),
+        needs_embed.len(),
+        needs_name.len()
+    );
+
+    // ── Step 3: embed missing rows in batches ─────────────────────────────
+    let t_emb = Instant::now();
+    let mut embed_dim: Option<usize> = None;
+    let total = needs_embed.len();
+    let mut done = 0usize;
+    let mut failed = 0usize;
+    for chunk in needs_embed.chunks(EMBED_BATCH) {
+        let texts: Vec<String> = chunk.iter().map(|(_, t)| t.clone()).collect();
+        // Try the batch first. On any error, fall back to one-at-a-time so a
+        // single oversize input doesn't tank the rest of the chunk (llama-server
+        // returns 500 for the whole batch if any item exceeds the batch budget).
+        let vecs: Vec<Option<Vec<f32>>> = match embed_batch(
+            &http,
+            &oai_base,
+            &embed_model,
+            &texts,
+        )
+        .await
+        {
+            Ok(v) => v.into_iter().map(Some).collect(),
+            Err(_) => {
+                let mut out = Vec::with_capacity(texts.len());
+                for t in &texts {
+                    match embed_batch(&http, &oai_base, &embed_model, std::slice::from_ref(t))
+                        .await
+                    {
+                        Ok(mut v) => out.push(v.pop()),
+                        Err(_) => out.push(None),
+                    }
+                }
+                out
+            }
+        };
+        for ((pk, _), maybe_v) in chunk.iter().zip(vecs.into_iter()) {
+            match maybe_v {
+                Some(v) => {
+                    embed_dim = Some(v.len());
+                    let lit = vec_to_lit(&v);
+                    conn.execute(
+                        "UPDATE sessions SET embedding = vector32(?1), model_id = ?2 WHERE pk = ?3",
+                        turso::params![lit, embed_model.clone(), *pk],
+                    )
+                    .await?;
+                    done += 1;
+                }
+                None => failed += 1,
+            }
+        }
+        if (done + failed) % 64 == 0 {
+            eprintln!("  embed progress: {}/{} ({} failed)", done + failed, total, failed);
+        }
+    }
+    eprintln!("[embed] {done}/{total} embedded, {failed} failed");
+    eprintln!("[embed] dim={:?} elapsed={:?}", embed_dim, t_emb.elapsed());
+
+    // ── Step 4: name missing rows ─────────────────────────────────────────
+    if let Some(ref cm) = chat_model {
+        let t_name = Instant::now();
+        let name_http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(NAMING_TIMEOUT_SECS))
+            .build()?;
+        // Sessions are already sorted by recency (discover_all does this) so the
+        // tail of needs_name is the recent stuff. Take from the front (= newest).
+        let to_name: Vec<&(i64, String)> = needs_name.iter().take(MAX_NAMES_PER_RUN).collect();
+        eprintln!(
+            "[name] naming {}/{} most-recent unnamed sessions",
+            to_name.len(),
+            needs_name.len()
+        );
+        let mut named = 0usize;
+        for (pk, text) in &to_name {
+            match generate_name(&name_http, &chat_base, cm, text).await {
+                Ok(name) => {
+                    eprintln!("  pk={pk} -> {name:?}");
+                    conn.execute(
+                        "UPDATE sessions SET generated_title = ?1 WHERE pk = ?2",
+                        turso::params![name.clone(), *pk],
+                    )
+                    .await?;
+                    named += 1;
+                }
+                Err(e) => eprintln!("  name pk={pk} failed: {e}"),
+            }
+        }
+        eprintln!("[name] {named} named in {:?}", t_name.elapsed());
+    }
+
+    // ── Step 5: run hybrid search ────────────────────────────────────────
+    let t_q = Instant::now();
+    let qvec = embed_batch(&http, &oai_base, &embed_model, &[query.clone()]).await?;
+    let qvec = qvec.into_iter().next().ok_or("empty query embedding")?;
+    let qlit = vec_to_lit(&qvec);
+
+    // Pull all candidates + their cosine distance
+    let mut candidates: Vec<Candidate> = Vec::new();
+    let mut rows = conn
+        .query(
+            "SELECT pk, cli, source_id, coalesce(generated_title, native_title) AS title, \
+                    directory, updated_at, first_message, \
+                    CASE WHEN embedding IS NOT NULL \
+                         THEN vector_distance_cos(embedding, vector32(?1)) ELSE NULL END AS cos \
+             FROM sessions",
+            turso::params![qlit],
+        )
+        .await?;
+    while let Some(row) = rows.next().await? {
+        let pk: i64 = row.get(0)?;
+        let cli: String = row.get(1)?;
+        let source_id: String = row.get(2)?;
+        let title: Option<String> = row.get(3).ok();
+        let directory: Option<String> = row.get(4).ok();
+        let updated_at: Option<String> = row.get(5).ok();
+        let first_message: Option<String> = row.get(6).ok();
+        let cos: Option<f64> = row.get(7).ok();
+        candidates.push(Candidate {
+            pk,
+            cli,
+            source_id,
+            title,
+            directory,
+            updated_at,
+            first_message: first_message.unwrap_or_default(),
+            cos_dist: cos,
+            bm25: 0.0,
+        });
+    }
+
+    // BM25 in Rust over the corpus
+    let bm25 = compute_bm25(&query, &candidates);
+    for (c, score) in candidates.iter_mut().zip(bm25.iter()) {
+        c.bm25 = *score;
+    }
+
+    // Blend
+    let max_bm25 = candidates.iter().map(|c| c.bm25).fold(0.0f32, f32::max).max(1e-6);
+    let mut scored: Vec<(f32, &Candidate)> = candidates
+        .iter()
+        .map(|c| {
+            let bm_norm = c.bm25 / max_bm25;
+            let sem_norm = c
+                .cos_dist
+                .map(|d| 1.0 - (d as f32) / 2.0)
+                .unwrap_or(0.0);
+            let score = alpha * bm_norm + (1.0 - alpha) * sem_norm;
+            (score, c)
+        })
+        .collect();
+    scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    println!("\n=== top {TOP_K} results (alpha={alpha:.2}) ===");
+    for (i, (score, c)) in scored.iter().take(TOP_K).enumerate() {
+        // Display fallback chain: generated/native title → first-message snippet → id prefix
+        let snippet_fallback: String = c
+            .first_message
+            .chars()
+            .filter(|ch| !ch.is_control() && *ch != '"' && *ch != '{' && *ch != '}')
+            .take(40)
+            .collect::<String>()
+            .trim()
+            .to_string();
+        let title_owned: String = c
+            .title
+            .clone()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| {
+                if snippet_fallback.len() >= 6 {
+                    snippet_fallback
+                } else {
+                    format!("[{}]", &c.source_id[..c.source_id.len().min(10)])
+                }
+            });
+        let title = title_owned.as_str();
+        let dir = c.directory.as_deref().unwrap_or("");
+        let date = c.updated_at.as_deref().unwrap_or("").chars().take(10).collect::<String>();
+        let cos = c
+            .cos_dist
+            .map(|d| format!("cos={:.3}", d))
+            .unwrap_or_else(|| "cos=∅".to_string());
+        println!(
+            "{:>2}. score={:.3}  bm25={:.3}  {}  [{:>8}]  {:<32}  {:<24}  {}",
+            i + 1,
+            score,
+            c.bm25,
+            cos,
+            c.cli,
+            truncate(title, 32),
+            truncate(dir, 24),
+            date
+        );
+    }
+    eprintln!("\n[query] hybrid scored {} rows in {:?}", candidates.len(), t_q.elapsed());
+    Ok(())
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct Candidate {
+    #[allow(dead_code)]
+    pk: i64,
+    cli: String,
+    source_id: String,
+    title: Option<String>,
+    directory: Option<String>,
+    updated_at: Option<String>,
+    first_message: String,
+    cos_dist: Option<f64>,
+    bm25: f32,
+}
+
+#[allow(dead_code)]
+impl Candidate {
+    fn handle(&self) -> String {
+        format!("{}:{}", self.cli, self.source_id)
+    }
+}
+
+fn file_mtime_ns(p: &Path) -> Option<i64> {
+    let md = fs::metadata(p).ok()?;
+    let mtime = md.modified().ok()?;
+    let dur = mtime.duration_since(std::time::UNIX_EPOCH).ok()?;
+    Some(dur.as_nanos() as i64)
+}
+
+/// Best-effort: pull a useful text snippet from the session file.
+/// We don't parse per-CLI here; just grab the first ~1KB of decoded UTF-8
+/// from the file, strip control chars, take the first MAX_TEXT_CHARS.
+/// Good enough for the PoC — embeddings tolerate noisy text.
+fn extract_text(s: &SessionInfo) -> Option<String> {
+    let bytes = fs::read(&s.path).ok()?;
+    let head_len = bytes.len().min(8192);
+    let head = String::from_utf8_lossy(&bytes[..head_len]);
+    let cleaned: String = head
+        .chars()
+        .filter(|c| !c.is_control() || *c == ' ' || *c == '\n')
+        .collect();
+    let mut snippet = String::new();
+    for ch in cleaned.chars() {
+        if snippet.len() >= MAX_TEXT_CHARS {
+            break;
+        }
+        snippet.push(ch);
+    }
+    let title_part = s.title.as_deref().or(s.name.as_deref()).unwrap_or("");
+    let dir_part = &s.directory;
+    Some(format!("{title_part} {dir_part} {snippet}").trim().to_string())
+}
+
+fn vec_to_lit(v: &[f32]) -> String {
+    let mut s = String::with_capacity(v.len() * 9 + 2);
+    s.push('[');
+    for (i, x) in v.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&format!("{}", x));
+    }
+    s.push(']');
+    s
+}
+
+async fn embed_batch(
+    http: &reqwest::Client,
+    base: &str,
+    model: &str,
+    texts: &[String],
+) -> Result<Vec<Vec<f32>>, Box<dyn Error>> {
+    #[derive(serde::Serialize)]
+    struct Req<'a> {
+        model: &'a str,
+        input: &'a [String],
+    }
+    #[derive(serde::Deserialize)]
+    struct Item {
+        embedding: Vec<f32>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Resp {
+        data: Vec<Item>,
+    }
+    let url = format!("{}/embeddings", base.trim_end_matches('/'));
+    let resp = http
+        .post(&url)
+        .json(&Req { model, input: texts })
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<Resp>()
+        .await?;
+    Ok(resp.data.into_iter().map(|i| i.embedding).collect())
+}
+
+async fn generate_name(
+    http: &reqwest::Client,
+    base: &str,
+    model: &str,
+    text: &str,
+) -> Result<String, Box<dyn Error>> {
+    #[derive(serde::Serialize)]
+    struct Msg<'a> {
+        role: &'a str,
+        content: &'a str,
+    }
+    #[derive(serde::Serialize)]
+    struct Req<'a> {
+        model: &'a str,
+        messages: Vec<Msg<'a>>,
+        max_tokens: u32,
+        temperature: f32,
+    }
+    #[derive(serde::Deserialize)]
+    struct Choice {
+        message: ChoiceMsg,
+    }
+    #[derive(serde::Deserialize)]
+    struct ChoiceMsg {
+        content: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct Resp {
+        choices: Vec<Choice>,
+    }
+
+    let prompt = format!(
+        "Reply with a 3 to 6 word title for this conversation. Reply with the title only, no quotes, no punctuation at the end.\n\n{}",
+        text.chars().take(800).collect::<String>()
+    );
+    let url = format!("{}/chat/completions", base.trim_end_matches('/'));
+    let req = Req {
+        model,
+        messages: vec![Msg {
+            role: "user",
+            content: &prompt,
+        }],
+        max_tokens: 24,
+        temperature: 0.2,
+    };
+    let resp: Resp = http
+        .post(&url)
+        .json(&req)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let raw = resp
+        .choices
+        .into_iter()
+        .next()
+        .ok_or("no choices")?
+        .message
+        .content;
+    Ok(raw
+        .lines()
+        .next()
+        .unwrap_or("")
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .to_string())
+}
+
+/// Standard BM25 with k1=1.5, b=0.75 over the candidate corpus.
+/// Index built from candidate `title + first_message + directory + cli`.
+fn compute_bm25(query: &str, docs: &[Candidate]) -> Vec<f32> {
+    let q_terms: Vec<String> = tokenize(query);
+    if q_terms.is_empty() || docs.is_empty() {
+        return vec![0.0; docs.len()];
+    }
+
+    // Build tokenized docs
+    let tokenized: Vec<Vec<String>> = docs
+        .iter()
+        .map(|c| {
+            let bag = format!(
+                "{} {} {} {}",
+                c.title.as_deref().unwrap_or(""),
+                c.first_message,
+                c.directory.as_deref().unwrap_or(""),
+                c.cli
+            );
+            tokenize(&bag)
+        })
+        .collect();
+    let avgdl: f32 = if tokenized.is_empty() {
+        0.0
+    } else {
+        tokenized.iter().map(|d| d.len() as f32).sum::<f32>() / tokenized.len() as f32
+    };
+
+    // df per query term
+    let mut df: HashMap<&str, u32> = HashMap::new();
+    for term in &q_terms {
+        let mut n = 0u32;
+        for doc in &tokenized {
+            if doc.iter().any(|t| t == term) {
+                n += 1;
+            }
+        }
+        df.insert(term.as_str(), n);
+    }
+
+    let n_docs = docs.len() as f32;
+    let k1 = 1.5f32;
+    let b = 0.75f32;
+
+    tokenized
+        .iter()
+        .map(|doc| {
+            let dl = doc.len() as f32;
+            let mut score = 0.0f32;
+            for q in &q_terms {
+                let tf = doc.iter().filter(|t| *t == q).count() as f32;
+                if tf == 0.0 {
+                    continue;
+                }
+                let n_q = *df.get(q.as_str()).unwrap_or(&0) as f32;
+                let idf = ((n_docs - n_q + 0.5) / (n_q + 0.5) + 1.0).ln();
+                let denom = tf + k1 * (1.0 - b + b * dl / avgdl.max(1.0));
+                score += idf * (tf * (k1 + 1.0) / denom.max(1e-6));
+            }
+            score
+        })
+        .collect()
+}
+
+fn tokenize(s: &str) -> Vec<String> {
+    s.to_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|t| t.len() >= 2)
+        .map(|t| t.to_string())
+        .collect()
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+        out.push('…');
+        out
+    }
+}

--- a/examples/turso_vector_probe.rs
+++ b/examples/turso_vector_probe.rs
@@ -1,0 +1,136 @@
+//! Step 0 probe (plan: search overhaul).
+//!
+//! Verifies that the `turso` Rust crate (BETA) supports the SQL vector
+//! functions documented at https://docs.turso.tech/guides/vector-search:
+//!   - `vector32('[f, f, ...]')` literal constructor
+//!   - `vector_distance_cos(blob, blob)` similarity function
+//!   - FTS5 virtual tables with `bm25(table)` ranking
+//!
+//! Plan ref: PR A is gated on this probe passing. If it fails, the plan's
+//! `SearchStore` adapter will target libsql instead and the rest of the
+//! work proceeds unchanged.
+//!
+//! Run: `cargo run --example turso_vector_probe`
+
+use std::error::Error;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let db = turso::Builder::new_local(":memory:").build().await?;
+    let conn = db.connect()?;
+
+    println!("== probe 1: basic table + insert ==");
+    conn.execute(
+        "CREATE TABLE docs (id INTEGER PRIMARY KEY, title TEXT, embedding BLOB)",
+        (),
+    )
+    .await?;
+    conn.execute(
+        "INSERT INTO docs (title, embedding) VALUES ('apple', vector32('[1.0, 0.0, 0.0, 0.0]'))",
+        (),
+    )
+    .await?;
+    conn.execute(
+        "INSERT INTO docs (title, embedding) VALUES ('orange', vector32('[0.9, 0.1, 0.0, 0.0]'))",
+        (),
+    )
+    .await?;
+    conn.execute(
+        "INSERT INTO docs (title, embedding) VALUES ('car', vector32('[0.0, 0.0, 1.0, 0.0]'))",
+        (),
+    )
+    .await?;
+    println!("  ok — vector32() literal accepted");
+
+    println!("== probe 2: vector_distance_cos query ==");
+    let mut rows = conn
+        .query(
+            "SELECT title, vector_distance_cos(embedding, vector32('[1.0, 0.0, 0.0, 0.0]')) AS d \
+             FROM docs ORDER BY d ASC",
+            (),
+        )
+        .await?;
+    while let Some(row) = rows.next().await? {
+        let title: String = row.get(0)?;
+        let d: f64 = row.get(1)?;
+        println!("  {title:<8} d={d:.6}");
+    }
+    println!("  ok — vector_distance_cos returns ordered f64 distances");
+
+    println!("== probe 3a: FTS5 + bm25() ranking ==");
+    let fts5_result = conn
+        .execute("CREATE VIRTUAL TABLE docs_fts USING fts5(title)", ())
+        .await;
+    if let Err(e) = fts5_result {
+        eprintln!("  SKIP — fts5 unavailable: {e}");
+        eprintln!("\n== probe 3b: alternative full-text indices ==");
+        for module in ["fts4", "fts3", "fts", "tantivy"] {
+            let r = conn
+                .execute(
+                    &format!("CREATE VIRTUAL TABLE probe_{module} USING {module}(title)"),
+                    (),
+                )
+                .await;
+            match r {
+                Ok(_) => eprintln!("  found alt module: {module}"),
+                Err(e) => eprintln!("  {module}: unavailable ({e})"),
+            }
+        }
+        eprintln!("\nturso vector functions work, but no FTS module is exposed.");
+        eprintln!("Skipping remaining FTS-dependent probes; falling through cleanly.");
+        eprintln!("\nFINDING: turso 0.6.0 vector OK, FTS5 NOT EXPOSED.");
+        return Ok(());
+    }
+    conn.execute(
+        "INSERT INTO docs_fts (rowid, title) SELECT id, title FROM docs",
+        (),
+    )
+    .await?;
+    let mut rows = conn
+        .query(
+            "SELECT title, bm25(docs_fts) AS r FROM docs_fts \
+             WHERE docs_fts MATCH 'apple OR orange' ORDER BY r",
+            (),
+        )
+        .await?;
+    let mut hits = 0;
+    while let Some(row) = rows.next().await? {
+        let title: String = row.get(0)?;
+        let r: f64 = row.get(1)?;
+        println!("  {title:<8} bm25={r:.6}");
+        hits += 1;
+    }
+    if hits == 0 {
+        eprintln!("  FAIL — FTS5 query returned no rows");
+        std::process::exit(2);
+    }
+    println!("  ok — FTS5 + bm25() works");
+
+    println!("== probe 4: hybrid query (vector + FTS5 in one SELECT) ==");
+    let mut rows = conn
+        .query(
+            "WITH \
+               bm AS (SELECT rowid AS pk, bm25(docs_fts) AS r FROM docs_fts \
+                      WHERE docs_fts MATCH 'apple'), \
+               vec AS (SELECT id AS pk, \
+                              vector_distance_cos(embedding, vector32('[1.0, 0.0, 0.0, 0.0]')) AS d \
+                       FROM docs) \
+             SELECT d.title, bm.r, vec.d \
+             FROM docs d \
+             LEFT JOIN bm  ON bm.pk = d.id \
+             LEFT JOIN vec ON vec.pk = d.id \
+             ORDER BY ifnull(bm.r, 1e6), vec.d",
+            (),
+        )
+        .await?;
+    while let Some(row) = rows.next().await? {
+        let title: String = row.get(0)?;
+        let bm: Option<f64> = row.get(1).ok();
+        let cos: Option<f64> = row.get(2).ok();
+        println!("  {title:<8} bm={bm:?} cos={cos:?}");
+    }
+    println!("  ok — hybrid CTE join works");
+
+    println!("\nall probes passed — turso 0.6.0 supports the SQL surface we need.");
+    Ok(())
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -666,6 +666,36 @@ pub enum Commands {
         find: Option<String>,
     },
 
+    /// Semantic search across all sessions (hybrid BM25 + cosine over local embeddings).
+    ///
+    /// Backed by a Turso DB at ~/.local/share/unleash/search-index.db.
+    /// Uses an OpenAI-compatible local server for embeddings (e.g.
+    /// `llama-server --embeddings -m granite-embed.gguf`). Optionally generates
+    /// 3–6 word titles for un-named sessions via `/v1/chat/completions`.
+    ///
+    /// Environment:
+    ///   OAI_BASE          (default http://localhost:8080/v1)
+    ///   OAI_EMBED_MODEL   (default "granite-embedding")
+    ///   OAI_CHAT_BASE     (defaults to OAI_BASE)
+    ///   OAI_CHAT_MODEL    (unset = skip naming)
+    ///   ALPHA             (0=pure semantic, 1=pure BM25, default 0.4)
+    Search {
+        /// Search query
+        query: Option<String>,
+
+        /// Force re-embed of all sessions (e.g. after switching embedding models)
+        #[arg(long)]
+        reindex: bool,
+
+        /// JSON output (script-friendly)
+        #[arg(long)]
+        json: bool,
+
+        /// Number of results
+        #[arg(long, default_value_t = 15)]
+        top: usize,
+    },
+
     /// Convert conversation history between CLI formats
     Convert {
         /// Source format (claude, codex, gemini, opencode, pi, hub)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod launcher;
 pub mod pixel_art;
 pub mod polyfill;
 mod sandbox;
+pub mod search;
 pub mod token_count;
 mod progress;
 #[cfg(feature = "tui")]
@@ -452,6 +453,7 @@ pub(crate) fn is_known_subcommand(first_arg: &str) -> bool {
             | "install"
             | "uninstall"
             | "sessions"
+            | "search"
             | "convert"
             | "sandbox"
             | "token-count"
@@ -1159,6 +1161,18 @@ pub fn run() -> io::Result<()> {
                 .map_err(|e| io::Error::other(e.to_string()))?;
             Ok(())
         }
+        Some(Commands::Search {
+            query,
+            reindex,
+            json,
+            top,
+        }) => search::run(search::RunArgs {
+            query,
+            reindex,
+            json: json || cli.json,
+            top,
+        })
+        .map_err(|e| io::Error::other(e.to_string())),
         Some(Commands::Sandbox { action }) => {
             sandbox::handle_sandbox(action.as_ref())
         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -24,8 +24,136 @@ use crate::interchange::sessions::{discover_all, SessionInfo};
 
 const MAX_TEXT_CHARS: usize = 600;
 const NAMING_TIMEOUT_SECS: u64 = 60;
-const EMBED_TIMEOUT_SECS: u64 = 10;
+const EMBED_TIMEOUT_SECS: u64 = 30;
 const MAX_NAMES_PER_RUN: usize = 12;
+
+/// Persisted defaults at `~/.config/unleash/search.toml`. Anything the user
+/// sets in env (OAI_BASE, OAI_EMBED_MODEL, …) still wins over the file.
+#[derive(Debug, Default, serde::Deserialize)]
+struct SearchConfig {
+    oai_base: Option<String>,
+    embed_model: Option<String>,
+    chat_base: Option<String>,
+    chat_model: Option<String>,
+    alpha: Option<f32>,
+    /// Optional: when set and `oai_base` is unreachable, print this hint to
+    /// the user (typically the `ssh -L ...` command to bring the tunnel up).
+    tunnel_hint: Option<String>,
+}
+
+/// Resolved configuration after merging env vars, the TOML file, and the
+/// "ship-with-sentinel-defaults" fallbacks.
+#[derive(Debug, Clone)]
+struct ResolvedConfig {
+    oai_base: String,
+    embed_model: String,
+    chat_base: String,
+    chat_model: Option<String>,
+    alpha: f32,
+    tunnel_hint: Option<String>,
+}
+
+fn config_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from(".config"))
+        .join("unleash")
+        .join("search.toml")
+}
+
+fn load_search_config() -> SearchConfig {
+    let path = config_path();
+    let Ok(text) = fs::read_to_string(&path) else {
+        return SearchConfig::default();
+    };
+    toml::from_str(&text).unwrap_or_else(|e| {
+        eprintln!(
+            "warning: failed to parse {}: {e} — using defaults",
+            path.display()
+        );
+        SearchConfig::default()
+    })
+}
+
+/// Ensure ~/.config/unleash/search.toml exists with sane defaults the very
+/// first time the user runs `unleash search` on this machine. Idempotent.
+fn ensure_default_config() {
+    let path = config_path();
+    if path.exists() {
+        return;
+    }
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let default = r#"# unleash search — local embedding + naming endpoints
+#
+# Defaults below point at the sentinel cluster:
+#   - embeddings via SSH tunnel to the lco-embedding pod (3 B variant)
+#   - chat (for session naming) via the public llm.ht.local ingress
+#
+# Bring the embedding tunnel up first:
+#
+#   ssh -fN -L 18000:10.42.1.11:8000 sentinel
+#
+# Override any of these inline with env vars (OAI_BASE, OAI_EMBED_MODEL,
+# OAI_CHAT_BASE, OAI_CHAT_MODEL, ALPHA).
+
+oai_base    = "http://127.0.0.1:18000/v1"
+embed_model = "lco-omni-3b"
+
+# Naming uses a chat model. Leave chat_model = "" to disable naming.
+# qwen3.5-0.8b is the cheapest always-loadable model on the cluster.
+chat_base   = "http://llm.ht.local/v1"
+chat_model  = "qwen3.5-0.8b"
+
+alpha = 0.4
+
+# Printed when oai_base is unreachable.
+tunnel_hint = "ssh -fN -L 18000:10.42.1.11:8000 sentinel"
+"#;
+    if let Err(e) = fs::write(&path, default) {
+        eprintln!(
+            "warning: could not write default {}: {e}",
+            path.display()
+        );
+    } else {
+        eprintln!("wrote default config: {}", path.display());
+    }
+}
+
+fn resolve_config() -> ResolvedConfig {
+    ensure_default_config();
+    let file = load_search_config();
+    let pick = |env_var: &str, file_val: Option<String>, default: &str| -> String {
+        env::var(env_var)
+            .ok()
+            .or(file_val)
+            .unwrap_or_else(|| default.to_string())
+    };
+
+    let oai_base = pick("OAI_BASE", file.oai_base.clone(), "http://127.0.0.1:18000/v1");
+    let embed_model = pick("OAI_EMBED_MODEL", file.embed_model.clone(), "lco-omni-3b");
+    let chat_base = env::var("OAI_CHAT_BASE")
+        .ok()
+        .or(file.chat_base.clone())
+        .unwrap_or_else(|| oai_base.clone());
+    let chat_model = env::var("OAI_CHAT_MODEL")
+        .ok()
+        .or(file.chat_model.clone())
+        .filter(|s| !s.trim().is_empty());
+    let alpha = env::var("ALPHA")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .or(file.alpha)
+        .unwrap_or(0.4);
+    ResolvedConfig {
+        oai_base,
+        embed_model,
+        chat_base,
+        chat_model,
+        alpha,
+        tunnel_hint: file.tunnel_hint,
+    }
+}
 
 pub struct RunArgs {
     pub query: Option<String>,
@@ -58,15 +186,15 @@ pub fn run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
-    let oai_base = env::var("OAI_BASE").unwrap_or_else(|_| "http://localhost:8080/v1".to_string());
-    let embed_model =
-        env::var("OAI_EMBED_MODEL").unwrap_or_else(|_| "granite-embedding".to_string());
-    let chat_base = env::var("OAI_CHAT_BASE").ok().unwrap_or_else(|| oai_base.clone());
-    let chat_model = env::var("OAI_CHAT_MODEL").ok();
-    let alpha: f32 = env::var("ALPHA")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0.4);
+    let cfg = resolve_config();
+    let ResolvedConfig {
+        oai_base,
+        embed_model,
+        chat_base,
+        chat_model,
+        alpha,
+        tunnel_hint,
+    } = cfg;
 
     if !args.json {
         eprintln!("unleash search");
@@ -88,6 +216,21 @@ async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     }
     if !args.json {
         eprintln!("  store     : {}", db_path.display());
+    }
+
+    // Probe the embeddings endpoint up-front. If it's unreachable we'd rather
+    // fail fast with a copy-pasteable fix than burn 30 s per row on timeouts.
+    let probe = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()?;
+    let probe_url = format!("{}/models", oai_base.trim_end_matches('/'));
+    if let Err(e) = probe.get(&probe_url).send().await {
+        eprintln!("\n\x1b[31merror:\x1b[0m embedding endpoint unreachable: {e}");
+        if let Some(hint) = tunnel_hint.as_deref() {
+            eprintln!("hint: bring the tunnel up:\n  {hint}");
+        }
+        eprintln!("(set OAI_BASE or edit {} to point elsewhere)", config_path().display());
+        return Err("endpoint unreachable".into());
     }
 
     let http = reqwest::Client::builder()
@@ -273,7 +416,41 @@ async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     }
 
+    // --- Interactive ratatui TUI when stdin is a real terminal -----------
+    let tui_eligible = !args.json
+        && std::io::IsTerminal::is_terminal(&std::io::stdin())
+        && std::io::IsTerminal::is_terminal(&std::io::stdout());
+
+    #[cfg(feature = "tui")]
+    if tui_eligible {
+        let rows = fetch_rows_with_embeddings(&conn).await?;
+        if rows.is_empty() {
+            eprintln!("No sessions indexed.");
+            return Ok(());
+        }
+        let chosen = pick_with_tui(
+            rows,
+            &http,
+            &oai_base,
+            &embed_model,
+            alpha,
+            args.top,
+            query.clone(),
+        )
+        .await?;
+        if let Some((hit, profile)) = chosen {
+            launch_crossload(&profile, &hit.cli, &hit.source_id);
+        }
+        return Ok(());
+    }
+
+    // --- Headless fallback: one-shot query, print, exit ------------------
     let t_q = Instant::now();
+    if query.is_empty() {
+        let hits = recent_listing(&conn, args.top).await?;
+        emit(&hits, args.json);
+        return Ok(());
+    }
     let qvec = embed_one(&http, &oai_base, &embed_model, &query).await?;
     let qlit = vec_to_lit(&qvec);
     let candidates = fetch_candidates(&conn, &qlit).await?;
@@ -317,57 +494,7 @@ async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
         );
     }
     emit(&hits, args.json);
-
-    // Interactive handoff: pick a result + profile, exec into the existing
-    // crossload flow. JSON mode and non-TTY stdin skip this — just print results.
-    if !args.json && std::io::IsTerminal::is_terminal(&std::io::stdin()) && !hits.is_empty() {
-        if let Some((hit, profile)) = prompt_handoff(&hits)? {
-            launch_crossload(&profile, &hit.cli, &hit.source_id);
-            // launch_crossload execs; if we return, exec failed.
-        }
-    }
     Ok(())
-}
-
-/// Prompt the user to pick a search hit + target profile.
-/// Returns Ok(None) when the user cancels (empty input or invalid number).
-fn prompt_handoff(hits: &[Hit]) -> io::Result<Option<(Hit, String)>> {
-    use std::io::Write;
-
-    print!("\nPick # to launch (Enter to skip): ");
-    io::stdout().flush().ok();
-    let mut line = String::new();
-    io::stdin().read_line(&mut line)?;
-    let picked: usize = match line.trim().parse() {
-        Ok(n) if n >= 1 && n <= hits.len() => n,
-        _ => return Ok(None),
-    };
-    let hit = hits[picked - 1].clone();
-
-    let profiles = available_profiles();
-    println!("\nAvailable profiles:");
-    for (i, p) in profiles.iter().enumerate() {
-        println!("  {}. {}", i + 1, p);
-    }
-    print!("Profile # or name (Enter = same CLI as source, '{}'): ", hit.cli);
-    io::stdout().flush().ok();
-    let mut line = String::new();
-    io::stdin().read_line(&mut line)?;
-    let raw = line.trim();
-    let profile = if raw.is_empty() {
-        hit.cli.clone()
-    } else if let Ok(n) = raw.parse::<usize>() {
-        if n >= 1 && n <= profiles.len() {
-            profiles[n - 1].clone()
-        } else {
-            eprintln!("invalid profile number");
-            return Ok(None);
-        }
-    } else {
-        raw.to_string()
-    };
-
-    Ok(Some((hit, profile)))
 }
 
 /// Discover available profiles. Falls back to the built-in agent CLI names
@@ -434,6 +561,80 @@ struct Candidate {
     updated_at: Option<String>,
     first_message: String,
     cos_dist: Option<f64>,
+}
+
+/// Like Candidate but with the raw embedding kept in memory so the TUI can
+/// rescore against a fresh query embedding on every blink without going back
+/// to the DB. ≤10k rows × 2048 f32 = ~80 MB worst case, still fine.
+#[derive(Debug, Clone)]
+struct RowCache {
+    cli: String,
+    source_id: String,
+    title: Option<String>,
+    directory: Option<String>,
+    updated_at: Option<String>,
+    first_message: String,
+    embedding: Option<Vec<f32>>,
+}
+
+async fn fetch_rows_with_embeddings(
+    conn: &turso::Connection,
+) -> Result<Vec<RowCache>, turso::Error> {
+    let mut rows = conn
+        .query(
+            "SELECT cli, source_id, coalesce(generated_title, native_title) AS title,
+                    directory, updated_at, first_message, embedding
+             FROM sessions",
+            (),
+        )
+        .await?;
+    let mut out = Vec::new();
+    while let Some(row) = rows.next().await? {
+        let blob: Option<Vec<u8>> = row.get(6).ok();
+        let embedding = blob.and_then(decode_vector32);
+        out.push(RowCache {
+            cli: row.get(0)?,
+            source_id: row.get(1)?,
+            title: row.get(2).ok(),
+            directory: row.get(3).ok(),
+            updated_at: row.get(4).ok(),
+            first_message: row.get::<String>(5).ok().unwrap_or_default(),
+            embedding,
+        });
+    }
+    Ok(out)
+}
+
+/// Turso stores `vector32(...)` BLOBs as a header + little-endian f32 array.
+/// We need the f32s in memory for the live re-ranker. Format is currently
+/// `[u8; 8] header` (type + length) followed by `dim × 4` bytes of LE f32.
+/// If the header doesn't match what we expect, fall back to treating the
+/// whole blob as raw f32 LE.
+fn decode_vector32(blob: Vec<u8>) -> Option<Vec<f32>> {
+    if blob.len() < 4 {
+        return None;
+    }
+    let try_decode = |start: usize| -> Option<Vec<f32>> {
+        let payload = &blob[start..];
+        if !payload.len().is_multiple_of(4) {
+            return None;
+        }
+        let mut out = Vec::with_capacity(payload.len() / 4);
+        for chunk in payload.chunks_exact(4) {
+            out.push(f32::from_le_bytes(chunk.try_into().ok()?));
+        }
+        Some(out)
+    };
+    // Try common header offsets first; fall back to no-header.
+    for off in [8usize, 4, 0] {
+        if let Some(v) = try_decode(off) {
+            // Sanity check: any reasonable embedding has values in roughly [-2, 2]
+            if !v.is_empty() && v.iter().take(8).all(|x| x.abs() < 10.0) {
+                return Some(v);
+            }
+        }
+    }
+    None
 }
 
 async fn fetch_candidates(
@@ -594,11 +795,19 @@ async fn generate_name(
         content: &'a str,
     }
     #[derive(serde::Serialize)]
+    struct ThinkingOff {
+        enable_thinking: bool,
+    }
+    #[derive(serde::Serialize)]
     struct Req<'a> {
         model: &'a str,
         messages: Vec<Msg<'a>>,
         max_tokens: u32,
         temperature: f32,
+        /// Disable thinking-mode for Qwen3+ chat models on llama.cpp — otherwise
+        /// the model spends the entire token budget reasoning and returns empty
+        /// `content`. Harmless on non-thinking models (just ignored by jinja).
+        chat_template_kwargs: ThinkingOff,
     }
     #[derive(serde::Deserialize)]
     struct Choice {
@@ -626,6 +835,9 @@ async fn generate_name(
         }],
         max_tokens: 24,
         temperature: 0.2,
+        chat_template_kwargs: ThinkingOff {
+            enable_thinking: false,
+        },
     };
     let resp: Resp = http
         .post(&url)
@@ -783,6 +995,546 @@ fn truncate(s: &str, max: usize) -> String {
         let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
         out.push('…');
         out
+    }
+}
+
+// ── Ratatui TUI ─────────────────────────────────────────────────────────
+//
+// Cached embeddings live in memory so every keystroke filters instantly.
+// Query embedding is fetched async with a 300 ms debounce after the user
+// stops typing; until it arrives we fall back to pure BM25.
+
+#[cfg(feature = "tui")]
+use ratatui::{prelude::*, widgets::*};
+
+#[cfg(feature = "tui")]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    Searching,
+    PickingProfile,
+}
+
+#[cfg(feature = "tui")]
+struct TuiState {
+    rows: Vec<RowCache>,
+    bm25_doc_tokens: Vec<Vec<String>>,
+    bm25_doc_lens: Vec<f32>,
+    bm25_avgdl: f32,
+    query: String,
+    qvec: Option<Vec<f32>>,
+    last_embedded_query: String,
+    last_query_change: std::time::Instant,
+    embedding_in_flight: bool,
+    alpha: f32,
+    top: usize,
+    scored: Vec<Hit>,
+    selected: usize,
+    profiles: Vec<String>,
+    profile_selected: usize,
+    mode: Mode,
+}
+
+#[cfg(feature = "tui")]
+async fn pick_with_tui(
+    rows: Vec<RowCache>,
+    http: &reqwest::Client,
+    oai_base: &str,
+    embed_model: &str,
+    initial_alpha: f32,
+    top: usize,
+    initial_query: String,
+) -> io::Result<Option<(Hit, String)>> {
+    use crossterm::{
+        execute,
+        terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    };
+
+    let bm25_doc_tokens: Vec<Vec<String>> = rows
+        .iter()
+        .map(|r| {
+            let bag = format!(
+                "{} {} {} {}",
+                r.title.as_deref().unwrap_or(""),
+                r.first_message,
+                r.directory.as_deref().unwrap_or(""),
+                r.cli
+            );
+            tokenize(&bag)
+        })
+        .collect();
+    let bm25_doc_lens: Vec<f32> = bm25_doc_tokens.iter().map(|d| d.len() as f32).collect();
+    let bm25_avgdl: f32 = if bm25_doc_lens.is_empty() {
+        0.0
+    } else {
+        bm25_doc_lens.iter().sum::<f32>() / bm25_doc_lens.len() as f32
+    };
+
+    let profiles = available_profiles();
+
+    let mut state = TuiState {
+        rows,
+        bm25_doc_tokens,
+        bm25_doc_lens,
+        bm25_avgdl,
+        query: initial_query,
+        qvec: None,
+        last_embedded_query: String::new(),
+        last_query_change: std::time::Instant::now(),
+        embedding_in_flight: false,
+        alpha: initial_alpha,
+        top,
+        scored: Vec::new(),
+        selected: 0,
+        profiles,
+        profile_selected: 0,
+        mode: Mode::Searching,
+    };
+    rescore(&mut state);
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let result = tui_loop(&mut terminal, &mut state, http, oai_base, embed_model).await;
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor().ok();
+    result
+}
+
+#[cfg(feature = "tui")]
+async fn tui_loop<W: io::Write>(
+    terminal: &mut Terminal<ratatui::backend::CrosstermBackend<W>>,
+    state: &mut TuiState,
+    http: &reqwest::Client,
+    oai_base: &str,
+    embed_model: &str,
+) -> io::Result<Option<(Hit, String)>> {
+    use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+
+    loop {
+        terminal.draw(|f| render_tui(f, state))?;
+
+        // Auto-embed the query once it's been stable for 300 ms. We embed in
+        // the foreground (block_on inside the current_thread runtime); for
+        // ≤300 ms latency the redraw stutter is invisible.
+        if !state.embedding_in_flight
+            && state.query != state.last_embedded_query
+            && !state.query.trim().is_empty()
+            && state.last_query_change.elapsed() >= std::time::Duration::from_millis(300)
+        {
+            state.embedding_in_flight = true;
+            let q = state.query.clone();
+            let v = embed_one(http, oai_base, embed_model, &q).await;
+            state.embedding_in_flight = false;
+            if let Ok(vec) = v {
+                state.qvec = Some(vec);
+                state.last_embedded_query = q;
+                rescore(state);
+            }
+        }
+        if state.query.trim().is_empty() && state.qvec.is_some() {
+            state.qvec = None;
+            state.last_embedded_query.clear();
+            rescore(state);
+        }
+
+        if !event::poll(std::time::Duration::from_millis(80))? {
+            continue;
+        }
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        if key.kind != KeyEventKind::Press {
+            continue;
+        }
+
+        match state.mode {
+            Mode::Searching => match key.code {
+                KeyCode::Esc => return Ok(None),
+                KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    return Ok(None);
+                }
+                KeyCode::Char('q') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    return Ok(None);
+                }
+                KeyCode::Tab => {
+                    state.alpha = match state.alpha {
+                        a if a < 0.05 => 0.4,
+                        a if a < 0.5 => 1.0,
+                        _ => 0.0,
+                    };
+                    rescore(state);
+                }
+                KeyCode::Left if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                    state.alpha = (state.alpha - 0.05).clamp(0.0, 1.0);
+                    rescore(state);
+                }
+                KeyCode::Right if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                    state.alpha = (state.alpha + 0.05).clamp(0.0, 1.0);
+                    rescore(state);
+                }
+                KeyCode::Up => {
+                    state.selected = state.selected.saturating_sub(1);
+                }
+                KeyCode::Down => {
+                    let max = state.scored.len().saturating_sub(1);
+                    if state.selected < max {
+                        state.selected += 1;
+                    }
+                }
+                KeyCode::Enter => {
+                    if !state.scored.is_empty() {
+                        state.mode = Mode::PickingProfile;
+                        state.profile_selected = state
+                            .profiles
+                            .iter()
+                            .position(|p| p == &state.scored[state.selected].cli)
+                            .unwrap_or(0);
+                    }
+                }
+                KeyCode::Backspace => {
+                    state.query.pop();
+                    state.last_query_change = std::time::Instant::now();
+                    state.selected = 0;
+                    rescore(state);
+                }
+                KeyCode::Char(c) => {
+                    state.query.push(c);
+                    state.last_query_change = std::time::Instant::now();
+                    state.selected = 0;
+                    rescore(state);
+                }
+                _ => {}
+            },
+            Mode::PickingProfile => match key.code {
+                KeyCode::Esc => {
+                    state.mode = Mode::Searching;
+                }
+                KeyCode::Up => {
+                    state.profile_selected = state.profile_selected.saturating_sub(1);
+                }
+                KeyCode::Down => {
+                    let max = state.profiles.len().saturating_sub(1);
+                    if state.profile_selected < max {
+                        state.profile_selected += 1;
+                    }
+                }
+                KeyCode::Enter => {
+                    if state.scored.is_empty() || state.profiles.is_empty() {
+                        return Ok(None);
+                    }
+                    let hit = state.scored[state.selected].clone();
+                    let profile = state.profiles[state.profile_selected].clone();
+                    return Ok(Some((hit, profile)));
+                }
+                _ => {}
+            },
+        }
+    }
+}
+
+#[cfg(feature = "tui")]
+fn rescore(state: &mut TuiState) {
+    let q_terms = tokenize(&state.query);
+    let n_docs = state.rows.len() as f32;
+    let k1 = 1.5f32;
+    let b = 0.75f32;
+
+    // df per query term — over the cached tokens.
+    let mut df: HashMap<&str, u32> = HashMap::new();
+    for term in &q_terms {
+        let mut n = 0u32;
+        for doc in &state.bm25_doc_tokens {
+            if doc.iter().any(|t| t == term) {
+                n += 1;
+            }
+        }
+        df.insert(term.as_str(), n);
+    }
+
+    let mut bm25: Vec<f32> = Vec::with_capacity(state.rows.len());
+    for (i, doc) in state.bm25_doc_tokens.iter().enumerate() {
+        let dl = state.bm25_doc_lens[i];
+        let mut score = 0.0f32;
+        for q in &q_terms {
+            let tf = doc.iter().filter(|t| *t == q).count() as f32;
+            if tf == 0.0 {
+                continue;
+            }
+            let n_q = *df.get(q.as_str()).unwrap_or(&0) as f32;
+            let idf = ((n_docs - n_q + 0.5) / (n_q + 0.5) + 1.0).ln();
+            let denom = tf + k1 * (1.0 - b + b * dl / state.bm25_avgdl.max(1.0));
+            score += idf * (tf * (k1 + 1.0) / denom.max(1e-6));
+        }
+        bm25.push(score);
+    }
+    let max_bm25 = bm25.iter().cloned().fold(0.0f32, f32::max).max(1e-6);
+
+    // Cosine vs the (possibly stale) query embedding. Empty query → no
+    // semantic signal at all, just BM25.
+    let cosines: Vec<Option<f32>> = if let Some(qv) = state.qvec.as_ref() {
+        state
+            .rows
+            .iter()
+            .map(|r| r.embedding.as_ref().map(|emb| cosine_distance(qv, emb) as f32))
+            .collect()
+    } else {
+        vec![None; state.rows.len()]
+    };
+
+    let mut scored: Vec<Hit> = state
+        .rows
+        .iter()
+        .enumerate()
+        .map(|(i, r)| {
+            let bm = bm25[i];
+            let bm_norm = bm / max_bm25;
+            let sem_norm = cosines[i].map(|d| 1.0 - d / 2.0).unwrap_or(0.0);
+            let score = state.alpha * bm_norm + (1.0 - state.alpha) * sem_norm;
+            Hit {
+                rank: 0,
+                score,
+                bm25: bm,
+                cos_dist: cosines[i].map(|x| x as f64),
+                cli: r.cli.clone(),
+                source_id: r.source_id.clone(),
+                title: r.title.clone(),
+                directory: r.directory.clone(),
+                updated_at: r.updated_at.clone(),
+                first_message: r.first_message.clone(),
+            }
+        })
+        .collect();
+
+    if state.query.trim().is_empty() {
+        // Empty query: sort by recency (already the order from discover_all).
+        scored.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    } else {
+        scored.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    }
+    scored.truncate(state.top.max(50));
+    for (i, h) in scored.iter_mut().enumerate() {
+        h.rank = i + 1;
+    }
+    state.scored = scored;
+    if state.selected >= state.scored.len() {
+        state.selected = state.scored.len().saturating_sub(1);
+    }
+}
+
+#[cfg(feature = "tui")]
+fn cosine_distance(a: &[f32], b: &[f32]) -> f64 {
+    if a.is_empty() || b.is_empty() {
+        return 2.0;
+    }
+    let n = a.len().min(b.len());
+    let mut dot = 0.0f64;
+    let mut na = 0.0f64;
+    let mut nb = 0.0f64;
+    for i in 0..n {
+        let x = a[i] as f64;
+        let y = b[i] as f64;
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    let denom = (na.sqrt() * nb.sqrt()).max(1e-12);
+    let cos = dot / denom;
+    1.0 - cos
+}
+
+#[cfg(feature = "tui")]
+fn render_tui(frame: &mut Frame, state: &TuiState) {
+    let area = frame.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // query input
+            Constraint::Min(5),    // results
+            Constraint::Length(3), // status bar (alpha slider + counts)
+            Constraint::Length(1), // help
+        ])
+        .split(area);
+
+    // Query box
+    let q_hint = if state.embedding_in_flight {
+        " embedding…"
+    } else if state.qvec.is_none() && !state.query.trim().is_empty() {
+        " (BM25 only — pause typing for semantic)"
+    } else {
+        ""
+    };
+    let title = format!(" search{} ", q_hint);
+    let q_para = Paragraph::new(state.query.as_str())
+        .style(Style::default().fg(Color::White))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(title)
+                .title_style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+        );
+    frame.render_widget(q_para, chunks[0]);
+
+    // Results list
+    let visible = chunks[1].height.saturating_sub(2) as usize;
+    let start = state.selected.saturating_sub(visible.saturating_sub(1));
+    let lines: Vec<Line> = state
+        .scored
+        .iter()
+        .enumerate()
+        .skip(start)
+        .take(visible)
+        .map(|(i, h)| {
+            let selected = i == state.selected;
+            let prefix = if selected { "> " } else { "  " };
+            let style_sel = if selected {
+                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            let title = display_title(h);
+            let date = h
+                .updated_at
+                .as_deref()
+                .unwrap_or("")
+                .chars()
+                .take(10)
+                .collect::<String>();
+            let cos = h
+                .cos_dist
+                .map(|d| format!("cos={:.2}", d))
+                .unwrap_or_else(|| "cos=∅".into());
+            Line::from(vec![
+                Span::styled(prefix, style_sel),
+                Span::styled(
+                    format!("{:>5.2}  ", h.score),
+                    if selected {
+                        style_sel
+                    } else {
+                        Style::default().fg(Color::Yellow)
+                    },
+                ),
+                Span::styled(format!("{:<6} ", cos), Style::default().fg(Color::DarkGray)),
+                Span::styled(format!("[{:>7}] ", h.cli), Style::default().fg(Color::Magenta)),
+                Span::styled(format!("{:<40} ", truncate(&title, 40)), style_sel),
+                Span::styled(
+                    truncate(h.directory.as_deref().unwrap_or(""), 28),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::raw("  "),
+                Span::styled(date, Style::default().fg(Color::DarkGray)),
+            ])
+        })
+        .collect();
+    let count_title = format!(
+        " {} / {} ",
+        state.scored.len(),
+        state.rows.len()
+    );
+    let list = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(count_title)
+            .title_style(Style::default().fg(Color::DarkGray)),
+    );
+    frame.render_widget(list, chunks[1]);
+
+    // α slider
+    let bar_width = chunks[2].width.saturating_sub(20) as usize;
+    let filled = ((1.0 - state.alpha) * bar_width as f32).round() as usize;
+    let empty = bar_width.saturating_sub(filled);
+    let slider_str = format!(
+        "[BM25 {}{} SEMANTIC]  α={:.2}",
+        "░".repeat(filled),
+        "▓".repeat(empty),
+        state.alpha
+    );
+    let status = Paragraph::new(slider_str).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" slider ")
+            .title_style(Style::default().fg(Color::DarkGray)),
+    );
+    frame.render_widget(status, chunks[2]);
+
+    // Help line
+    let help = match state.mode {
+        Mode::Searching => "type=filter  ↑↓=move  Enter=pick profile  Tab=cycle α  ⇧←/→=fine α  Esc=quit",
+        Mode::PickingProfile => "↑↓=move  Enter=launch crossload  Esc=back",
+    };
+    let help_p = Paragraph::new(Line::from(vec![Span::styled(
+        help,
+        Style::default().fg(Color::DarkGray),
+    )]));
+    frame.render_widget(help_p, chunks[3]);
+
+    // Profile picker modal — drawn on top
+    if state.mode == Mode::PickingProfile {
+        let modal_h = (state.profiles.len() as u16 + 4).min(area.height.saturating_sub(4));
+        let modal_w = 50u16.min(area.width.saturating_sub(4));
+        let modal = Rect {
+            x: area.x + (area.width.saturating_sub(modal_w)) / 2,
+            y: area.y + (area.height.saturating_sub(modal_h)) / 2,
+            width: modal_w,
+            height: modal_h,
+        };
+        frame.render_widget(Clear, modal);
+        let header = if let Some(hit) = state.scored.get(state.selected) {
+            format!(" launch into profile — {} ", truncate(&display_title(hit), 30))
+        } else {
+            " launch into profile ".to_string()
+        };
+        let lines: Vec<Line> = state
+            .profiles
+            .iter()
+            .enumerate()
+            .map(|(i, p)| {
+                let sel = i == state.profile_selected;
+                let style = if sel {
+                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                };
+                Line::from(vec![
+                    Span::styled(if sel { "  ▸ " } else { "    " }, style),
+                    Span::styled(p.as_str(), style),
+                ])
+            })
+            .collect();
+        let modal_p = Paragraph::new(lines).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(header)
+                .title_style(
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ),
+        );
+        frame.render_widget(modal_p, modal);
+    }
+}
+
+#[cfg(feature = "tui")]
+fn display_title(h: &Hit) -> String {
+    if let Some(t) = h.title.as_deref().filter(|s| !s.trim().is_empty()) {
+        return t.to_string();
+    }
+    let snippet: String = h
+        .first_message
+        .chars()
+        .filter(|c| !c.is_control() && *c != '"' && *c != '{' && *c != '}')
+        .take(40)
+        .collect();
+    let snippet = snippet.trim().to_string();
+    if snippet.len() >= 6 {
+        snippet
+    } else {
+        format!("[{}]", &h.source_id[..h.source_id.len().min(10)])
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,0 +1,712 @@
+//! Semantic session search backed by a local Turso DB and an OpenAI-compatible
+//! embedding / chat endpoint (e.g. llama-server, ollama, lmstudio).
+//!
+//! The user-facing entry is `unleash search "query"`. See `RunArgs` for flags
+//! and the [`Cli`] / [`Commands::Search`] surface in `src/cli.rs` for env vars.
+//!
+//! Architecture: per the plan at `/home/me/.claude/plans/glittery-launching-codd.md`,
+//! Turso ships `vector32()` + `vector_distance_cos()` SQL but does NOT expose
+//! FTS5 — so the BM25 side of the hybrid runs in Rust app code against the
+//! candidate rows we pull from the DB. Sub-millisecond at our scale (<10k rows).
+//!
+//! The whole module is self-contained: no `pick_session` integration yet (PR C),
+//! no slider UI yet (PR C). This is the standalone-CLI slice (PR E) lifted from
+//! `examples/poc_search.rs`.
+
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use crate::interchange::sessions::{discover_all, SessionInfo};
+
+const MAX_TEXT_CHARS: usize = 600;
+const NAMING_TIMEOUT_SECS: u64 = 60;
+const EMBED_TIMEOUT_SECS: u64 = 10;
+const MAX_NAMES_PER_RUN: usize = 12;
+
+pub struct RunArgs {
+    pub query: Option<String>,
+    pub reindex: bool,
+    pub json: bool,
+    pub top: usize,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct Hit {
+    pub rank: usize,
+    pub score: f32,
+    pub bm25: f32,
+    pub cos_dist: Option<f64>,
+    pub cli: String,
+    pub source_id: String,
+    pub title: Option<String>,
+    pub directory: Option<String>,
+    pub updated_at: Option<String>,
+    pub first_message: String,
+}
+
+/// Synchronous entry point. Builds a private tokio runtime so the rest of the
+/// CLI stays synchronous — Turso forces async, but it never escapes this module.
+pub fn run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(run_async(args))
+}
+
+async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let oai_base = env::var("OAI_BASE").unwrap_or_else(|_| "http://localhost:8080/v1".to_string());
+    let embed_model =
+        env::var("OAI_EMBED_MODEL").unwrap_or_else(|_| "granite-embedding".to_string());
+    let chat_base = env::var("OAI_CHAT_BASE").ok().unwrap_or_else(|| oai_base.clone());
+    let chat_model = env::var("OAI_CHAT_MODEL").ok();
+    let alpha: f32 = env::var("ALPHA")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0.4);
+
+    if !args.json {
+        eprintln!("unleash search");
+        eprintln!("  embeddings: {oai_base} model={embed_model}");
+        if let Some(ref m) = chat_model {
+            eprintln!("  naming    : {chat_base} model={m}");
+        } else {
+            eprintln!("  naming    : disabled (set OAI_CHAT_MODEL to enable)");
+        }
+        eprintln!("  alpha     : {alpha:.2}  (0=semantic, 1=bm25)");
+        if args.reindex {
+            eprintln!("  reindex   : ON — embeddings and titles will be regenerated");
+        }
+    }
+
+    let db_path = index_db_path();
+    if let Some(parent) = db_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    if !args.json {
+        eprintln!("  store     : {}", db_path.display());
+    }
+
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(EMBED_TIMEOUT_SECS))
+        .build()?;
+
+    let db = turso::Builder::new_local(db_path.to_string_lossy().as_ref())
+        .build()
+        .await?;
+    let conn = db.connect()?;
+    bootstrap_schema(&conn).await?;
+
+    if args.reindex {
+        conn.execute("UPDATE sessions SET embedding=NULL, model_id=NULL, generated_title=NULL", ())
+            .await?;
+    }
+
+    // ── Discover + upsert ──────────────────────────────────────────────
+    let t_disc = Instant::now();
+    let sessions = discover_all();
+    if !args.json {
+        eprintln!(
+            "\n[discover] {} sessions in {:?}",
+            sessions.len(),
+            t_disc.elapsed()
+        );
+    }
+
+    let mut needs_embed: Vec<(i64, String)> = Vec::new();
+    let mut needs_name: Vec<(i64, String)> = Vec::new();
+    let mut indexed = 0usize;
+
+    for s in &sessions {
+        let mtime_ns = file_mtime_ns(&s.path).unwrap_or(0);
+        let cur_mtime: Option<i64> = {
+            let mut r = conn
+                .query(
+                    "SELECT mtime_ns FROM sessions WHERE cli=?1 AND source_id=?2",
+                    turso::params![s.cli.clone(), s.id.clone()],
+                )
+                .await?;
+            match r.next().await? {
+                Some(row) => Some(row.get(0)?),
+                None => None,
+            }
+        };
+        let text = extract_text(s).unwrap_or_default();
+        let native_title = s.title.clone().or(s.name.clone());
+
+        if cur_mtime != Some(mtime_ns) {
+            conn.execute(
+                "INSERT INTO sessions (cli, source_id, path, directory, native_title,
+                    first_message, updated_at, mtime_ns, model_id)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)
+                 ON CONFLICT(cli, source_id) DO UPDATE SET
+                    path=excluded.path, directory=excluded.directory,
+                    native_title=excluded.native_title, first_message=excluded.first_message,
+                    updated_at=excluded.updated_at, mtime_ns=excluded.mtime_ns,
+                    embedding=NULL, model_id=NULL, generated_title=NULL",
+                turso::params![
+                    s.cli.clone(),
+                    s.id.clone(),
+                    s.path.to_string_lossy().to_string(),
+                    s.directory.clone(),
+                    native_title.clone(),
+                    text.clone(),
+                    s.updated_at.clone(),
+                    mtime_ns,
+                    embed_model.clone(),
+                ],
+            )
+            .await?;
+        }
+
+        let mut r = conn
+            .query(
+                "SELECT pk, embedding IS NOT NULL AS has_emb,
+                       generated_title IS NOT NULL OR native_title IS NOT NULL AS has_title
+                 FROM sessions WHERE cli=?1 AND source_id=?2",
+                turso::params![s.cli.clone(), s.id.clone()],
+            )
+            .await?;
+        if let Some(row) = r.next().await? {
+            let pk: i64 = row.get(0)?;
+            let has_emb: i64 = row.get(1)?;
+            let has_title: i64 = row.get(2)?;
+            indexed += 1;
+            if has_emb == 0 && !text.is_empty() {
+                needs_embed.push((pk, text.clone()));
+            }
+            if has_title == 0 && chat_model.is_some() && !text.is_empty() {
+                needs_name.push((pk, text.clone()));
+            }
+        }
+    }
+    if !args.json {
+        eprintln!(
+            "[index] {indexed} rows, {} need embedding, {} need naming",
+            needs_embed.len(),
+            needs_name.len()
+        );
+    }
+
+    // ── Embed missing rows (sequential, single-item retry) ─────────────
+    let t_emb = Instant::now();
+    let mut embed_dim: Option<usize> = None;
+    let mut emb_done = 0usize;
+    let mut emb_failed = 0usize;
+    let total_embed = needs_embed.len();
+    for (pk, text) in &needs_embed {
+        match embed_one(&http, &oai_base, &embed_model, text).await {
+            Ok(v) => {
+                embed_dim = Some(v.len());
+                let lit = vec_to_lit(&v);
+                conn.execute(
+                    "UPDATE sessions SET embedding = vector32(?1), model_id = ?2 WHERE pk = ?3",
+                    turso::params![lit, embed_model.clone(), *pk],
+                )
+                .await?;
+                emb_done += 1;
+            }
+            Err(_) => emb_failed += 1,
+        }
+        if !args.json && (emb_done + emb_failed) % 32 == 0 {
+            eprintln!("  embed: {}/{}", emb_done + emb_failed, total_embed);
+        }
+    }
+    if !args.json && total_embed > 0 {
+        eprintln!(
+            "[embed] {emb_done}/{total_embed} embedded, {emb_failed} failed, dim={embed_dim:?}, elapsed={:?}",
+            t_emb.elapsed()
+        );
+    }
+
+    // ── Name un-titled rows (bounded) ──────────────────────────────────
+    if let Some(ref cm) = chat_model {
+        let t_name = Instant::now();
+        let name_http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(NAMING_TIMEOUT_SECS))
+            .build()?;
+        let to_name: Vec<&(i64, String)> = needs_name.iter().take(MAX_NAMES_PER_RUN).collect();
+        if !args.json && !to_name.is_empty() {
+            eprintln!(
+                "[name] naming {}/{} newest unnamed sessions",
+                to_name.len(),
+                needs_name.len()
+            );
+        }
+        let mut named = 0usize;
+        for (pk, text) in &to_name {
+            match generate_name(&name_http, &chat_base, cm, text).await {
+                Ok(name) => {
+                    if !args.json {
+                        eprintln!("  pk={pk} -> {name:?}");
+                    }
+                    conn.execute(
+                        "UPDATE sessions SET generated_title = ?1 WHERE pk = ?2",
+                        turso::params![name.clone(), *pk],
+                    )
+                    .await?;
+                    named += 1;
+                }
+                Err(e) => {
+                    if !args.json {
+                        eprintln!("  name pk={pk} failed: {e}");
+                    }
+                }
+            }
+        }
+        if !args.json && named > 0 {
+            eprintln!("[name] {named} named in {:?}", t_name.elapsed());
+        }
+    }
+
+    // ── Query (or print recency listing when no query was given) ───────
+    let query = args.query.unwrap_or_default();
+    if query.is_empty() {
+        if !args.json {
+            eprintln!("\n(no query — showing most recent indexed sessions)");
+        }
+        let hits = recent_listing(&conn, args.top).await?;
+        emit(&hits, args.json);
+        return Ok(());
+    }
+
+    let t_q = Instant::now();
+    let qvec = embed_one(&http, &oai_base, &embed_model, &query).await?;
+    let qlit = vec_to_lit(&qvec);
+    let candidates = fetch_candidates(&conn, &qlit).await?;
+    let bm25_scores = compute_bm25(&query, &candidates);
+    let max_bm25 = bm25_scores.iter().cloned().fold(0.0f32, f32::max).max(1e-6);
+    let mut scored: Vec<(f32, &Candidate, f32)> = candidates
+        .iter()
+        .zip(bm25_scores.iter())
+        .map(|(c, &bm)| {
+            let bm_norm = bm / max_bm25;
+            let sem_norm = c.cos_dist.map(|d| 1.0 - (d as f32) / 2.0).unwrap_or(0.0);
+            let score = alpha * bm_norm + (1.0 - alpha) * sem_norm;
+            (score, c, bm)
+        })
+        .collect();
+    scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    let hits: Vec<Hit> = scored
+        .iter()
+        .take(args.top)
+        .enumerate()
+        .map(|(i, (score, c, bm))| Hit {
+            rank: i + 1,
+            score: *score,
+            bm25: *bm,
+            cos_dist: c.cos_dist,
+            cli: c.cli.clone(),
+            source_id: c.source_id.clone(),
+            title: c.title.clone(),
+            directory: c.directory.clone(),
+            updated_at: c.updated_at.clone(),
+            first_message: c.first_message.clone(),
+        })
+        .collect();
+
+    if !args.json {
+        eprintln!(
+            "\n[query] {} candidates scored in {:?}",
+            candidates.len(),
+            t_q.elapsed()
+        );
+    }
+    emit(&hits, args.json);
+    Ok(())
+}
+
+// ── DB helpers ──────────────────────────────────────────────────────────
+
+async fn bootstrap_schema(conn: &turso::Connection) -> Result<(), turso::Error> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS sessions (
+            pk INTEGER PRIMARY KEY,
+            cli TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            path TEXT NOT NULL,
+            directory TEXT,
+            native_title TEXT,
+            generated_title TEXT,
+            first_message TEXT,
+            updated_at TEXT,
+            mtime_ns INTEGER NOT NULL,
+            model_id TEXT,
+            embedding BLOB,
+            UNIQUE(cli, source_id))",
+        (),
+    )
+    .await?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Candidate {
+    cli: String,
+    source_id: String,
+    title: Option<String>,
+    directory: Option<String>,
+    updated_at: Option<String>,
+    first_message: String,
+    cos_dist: Option<f64>,
+}
+
+async fn fetch_candidates(
+    conn: &turso::Connection,
+    qlit: &str,
+) -> Result<Vec<Candidate>, turso::Error> {
+    let mut rows = conn
+        .query(
+            "SELECT cli, source_id, coalesce(generated_title, native_title) AS title,
+                    directory, updated_at, first_message,
+                    CASE WHEN embedding IS NOT NULL
+                         THEN vector_distance_cos(embedding, vector32(?1)) ELSE NULL END AS cos
+             FROM sessions",
+            turso::params![qlit.to_string()],
+        )
+        .await?;
+    let mut out = Vec::new();
+    while let Some(row) = rows.next().await? {
+        out.push(Candidate {
+            cli: row.get(0)?,
+            source_id: row.get(1)?,
+            title: row.get(2).ok(),
+            directory: row.get(3).ok(),
+            updated_at: row.get(4).ok(),
+            first_message: row.get::<String>(5).ok().unwrap_or_default(),
+            cos_dist: row.get(6).ok(),
+        });
+    }
+    Ok(out)
+}
+
+async fn recent_listing(conn: &turso::Connection, top: usize) -> Result<Vec<Hit>, turso::Error> {
+    let mut rows = conn
+        .query(
+            "SELECT cli, source_id, coalesce(generated_title, native_title) AS title,
+                    directory, updated_at, first_message
+             FROM sessions ORDER BY updated_at DESC LIMIT ?1",
+            turso::params![top as i64],
+        )
+        .await?;
+    let mut out = Vec::new();
+    let mut rank = 0usize;
+    while let Some(row) = rows.next().await? {
+        rank += 1;
+        out.push(Hit {
+            rank,
+            score: 0.0,
+            bm25: 0.0,
+            cos_dist: None,
+            cli: row.get(0)?,
+            source_id: row.get(1)?,
+            title: row.get(2).ok(),
+            directory: row.get(3).ok(),
+            updated_at: row.get(4).ok(),
+            first_message: row.get::<String>(5).ok().unwrap_or_default(),
+        });
+    }
+    Ok(out)
+}
+
+fn index_db_path() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("unleash")
+        .join("search-index.db")
+}
+
+fn file_mtime_ns(p: &Path) -> Option<i64> {
+    let md = fs::metadata(p).ok()?;
+    let mtime = md.modified().ok()?;
+    let dur = mtime.duration_since(std::time::UNIX_EPOCH).ok()?;
+    Some(dur.as_nanos() as i64)
+}
+
+/// Best-effort text extraction. We deliberately don't parse per-CLI here —
+/// session files are JSONL/JSON whose first ~1KB always contains useful
+/// signal (user message, system prompt, working directory). The embedder
+/// tolerates noisy JSON just fine.
+fn extract_text(s: &SessionInfo) -> Option<String> {
+    let bytes = fs::read(&s.path).ok()?;
+    let head_len = bytes.len().min(8192);
+    let head = String::from_utf8_lossy(&bytes[..head_len]);
+    let cleaned: String = head
+        .chars()
+        .filter(|c| !c.is_control() || *c == ' ' || *c == '\n')
+        .collect();
+    let mut snippet = String::new();
+    for ch in cleaned.chars() {
+        if snippet.len() >= MAX_TEXT_CHARS {
+            break;
+        }
+        snippet.push(ch);
+    }
+    let title_part = s.title.as_deref().or(s.name.as_deref()).unwrap_or("");
+    let dir_part = &s.directory;
+    Some(format!("{title_part} {dir_part} {snippet}").trim().to_string())
+}
+
+fn vec_to_lit(v: &[f32]) -> String {
+    let mut s = String::with_capacity(v.len() * 9 + 2);
+    s.push('[');
+    for (i, x) in v.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&format!("{}", x));
+    }
+    s.push(']');
+    s
+}
+
+// ── OAI-compat HTTP ────────────────────────────────────────────────────
+
+async fn embed_one(
+    http: &reqwest::Client,
+    base: &str,
+    model: &str,
+    text: &str,
+) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
+    #[derive(serde::Serialize)]
+    struct Req<'a> {
+        model: &'a str,
+        input: &'a str,
+    }
+    #[derive(serde::Deserialize)]
+    struct Item {
+        embedding: Vec<f32>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Resp {
+        data: Vec<Item>,
+    }
+    let url = format!("{}/embeddings", base.trim_end_matches('/'));
+    let resp = http
+        .post(&url)
+        .json(&Req { model, input: text })
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<Resp>()
+        .await?;
+    resp.data
+        .into_iter()
+        .next()
+        .map(|i| i.embedding)
+        .ok_or_else(|| "empty embedding response".into())
+}
+
+async fn generate_name(
+    http: &reqwest::Client,
+    base: &str,
+    model: &str,
+    text: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    #[derive(serde::Serialize)]
+    struct Msg<'a> {
+        role: &'a str,
+        content: &'a str,
+    }
+    #[derive(serde::Serialize)]
+    struct Req<'a> {
+        model: &'a str,
+        messages: Vec<Msg<'a>>,
+        max_tokens: u32,
+        temperature: f32,
+    }
+    #[derive(serde::Deserialize)]
+    struct Choice {
+        message: ChoiceMsg,
+    }
+    #[derive(serde::Deserialize)]
+    struct ChoiceMsg {
+        content: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct Resp {
+        choices: Vec<Choice>,
+    }
+
+    let prompt = format!(
+        "Reply with a 3 to 6 word title for this conversation. Reply with the title only, no quotes, no punctuation at the end.\n\n{}",
+        text.chars().take(800).collect::<String>()
+    );
+    let url = format!("{}/chat/completions", base.trim_end_matches('/'));
+    let req = Req {
+        model,
+        messages: vec![Msg {
+            role: "user",
+            content: &prompt,
+        }],
+        max_tokens: 24,
+        temperature: 0.2,
+    };
+    let resp: Resp = http
+        .post(&url)
+        .json(&req)
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let raw = resp
+        .choices
+        .into_iter()
+        .next()
+        .ok_or("no choices")?
+        .message
+        .content;
+    Ok(raw
+        .lines()
+        .next()
+        .unwrap_or("")
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .to_string())
+}
+
+// ── BM25 over the candidate corpus ────────────────────────────────────
+
+fn compute_bm25(query: &str, docs: &[Candidate]) -> Vec<f32> {
+    let q_terms: Vec<String> = tokenize(query);
+    if q_terms.is_empty() || docs.is_empty() {
+        return vec![0.0; docs.len()];
+    }
+    let tokenized: Vec<Vec<String>> = docs
+        .iter()
+        .map(|c| {
+            let bag = format!(
+                "{} {} {} {}",
+                c.title.as_deref().unwrap_or(""),
+                c.first_message,
+                c.directory.as_deref().unwrap_or(""),
+                c.cli
+            );
+            tokenize(&bag)
+        })
+        .collect();
+    let avgdl: f32 = if tokenized.is_empty() {
+        0.0
+    } else {
+        tokenized.iter().map(|d| d.len() as f32).sum::<f32>() / tokenized.len() as f32
+    };
+    let mut df: HashMap<&str, u32> = HashMap::new();
+    for term in &q_terms {
+        let mut n = 0u32;
+        for doc in &tokenized {
+            if doc.iter().any(|t| t == term) {
+                n += 1;
+            }
+        }
+        df.insert(term.as_str(), n);
+    }
+    let n_docs = docs.len() as f32;
+    let k1 = 1.5f32;
+    let b = 0.75f32;
+    tokenized
+        .iter()
+        .map(|doc| {
+            let dl = doc.len() as f32;
+            let mut score = 0.0f32;
+            for q in &q_terms {
+                let tf = doc.iter().filter(|t| *t == q).count() as f32;
+                if tf == 0.0 {
+                    continue;
+                }
+                let n_q = *df.get(q.as_str()).unwrap_or(&0) as f32;
+                let idf = ((n_docs - n_q + 0.5) / (n_q + 0.5) + 1.0).ln();
+                let denom = tf + k1 * (1.0 - b + b * dl / avgdl.max(1.0));
+                score += idf * (tf * (k1 + 1.0) / denom.max(1e-6));
+            }
+            score
+        })
+        .collect()
+}
+
+fn tokenize(s: &str) -> Vec<String> {
+    s.to_lowercase()
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|t| t.len() >= 2)
+        .map(|t| t.to_string())
+        .collect()
+}
+
+// ── Output ─────────────────────────────────────────────────────────────
+
+fn emit(hits: &[Hit], json: bool) {
+    if json {
+        match serde_json::to_string_pretty(hits) {
+            Ok(s) => println!("{s}"),
+            Err(e) => eprintln!("json encode failed: {e}"),
+        }
+        return;
+    }
+    println!("\n=== top {} results ===", hits.len());
+    for h in hits {
+        let snippet_fallback: String = h
+            .first_message
+            .chars()
+            .filter(|ch| !ch.is_control() && *ch != '"' && *ch != '{' && *ch != '}')
+            .take(40)
+            .collect::<String>()
+            .trim()
+            .to_string();
+        let title_owned: String = h
+            .title
+            .clone()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| {
+                if snippet_fallback.len() >= 6 {
+                    snippet_fallback
+                } else {
+                    let n = h.source_id.len().min(10);
+                    format!("[{}]", &h.source_id[..n])
+                }
+            });
+        let dir = h.directory.as_deref().unwrap_or("");
+        let date = h
+            .updated_at
+            .as_deref()
+            .unwrap_or("")
+            .chars()
+            .take(10)
+            .collect::<String>();
+        let cos = h
+            .cos_dist
+            .map(|d| format!("cos={:.3}", d))
+            .unwrap_or_else(|| "cos=∅".into());
+        println!(
+            "{:>2}. score={:.3}  bm25={:.3}  {}  [{:>8}]  {:<32}  {:<24}  {}",
+            h.rank,
+            h.score,
+            h.bm25,
+            cos,
+            h.cli,
+            truncate(&title_owned, 32),
+            truncate(dir, 24),
+            date
+        );
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+        out.push('…');
+        out
+    }
+}
+
+// Silence unused-import warning when serde is only used via macros.
+#[allow(dead_code)]
+fn _silence_io() {
+    let _: io::Result<()> = Ok(());
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -1591,3 +1591,157 @@ fn display_title(h: &Hit) -> String {
 fn _silence_io() {
     let _: io::Result<()> = Ok(());
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cosine_distance_identical_is_zero() {
+        let v = vec![1.0_f32, 2.0, 3.0, 4.0];
+        let d = cosine_distance(&v, &v);
+        assert!(d.abs() < 1e-9, "expected ~0, got {d}");
+    }
+
+    #[test]
+    fn cosine_distance_orthogonal_is_one() {
+        let a = vec![1.0_f32, 0.0];
+        let b = vec![0.0_f32, 1.0];
+        let d = cosine_distance(&a, &b);
+        assert!((d - 1.0).abs() < 1e-9, "expected 1.0, got {d}");
+    }
+
+    #[test]
+    fn cosine_distance_opposite_is_two() {
+        let a = vec![1.0_f32, 1.0, 1.0];
+        let b = vec![-1.0_f32, -1.0, -1.0];
+        let d = cosine_distance(&a, &b);
+        assert!((d - 2.0).abs() < 1e-9, "expected 2.0, got {d}");
+    }
+
+    #[test]
+    fn cosine_distance_empty_returns_two() {
+        let a: Vec<f32> = vec![];
+        let b = vec![1.0_f32, 2.0];
+        assert_eq!(cosine_distance(&a, &b), 2.0);
+        assert_eq!(cosine_distance(&b, &a), 2.0);
+    }
+
+    #[test]
+    fn decode_vector32_handles_8_byte_header() {
+        // turso emits an 8-byte length/type prefix in front of the f32 payload.
+        // Real embeddings are 256+ dims, so the offset-8 path is what's hit in
+        // practice — test with a realistic-sized vector to exercise it.
+        let v: Vec<f32> = (0..256).map(|i| (i as f32 - 128.0) / 128.0).collect();
+        let mut blob: Vec<u8> = vec![0u8; 8];
+        for x in &v {
+            blob.extend_from_slice(&x.to_le_bytes());
+        }
+        let decoded = decode_vector32(blob).expect("decode");
+        assert_eq!(decoded.len(), v.len());
+        for (a, b) in decoded.iter().zip(v.iter()) {
+            assert!((a - b).abs() < 1e-6, "value mismatch: {a} vs {b}");
+        }
+    }
+
+    #[test]
+    fn decode_vector32_rejects_too_short() {
+        assert!(decode_vector32(vec![0, 1]).is_none());
+    }
+
+    #[test]
+    fn decode_vector32_rejects_garbage() {
+        // Values >> 10.0 fail the sanity check at every offset.
+        let blob: Vec<u8> = (0..32).map(|i| (i * 13 + 7) as u8).collect();
+        let result = decode_vector32(blob);
+        // Either None, or a vec whose first values are within the sanity range;
+        // we just ensure it doesn't panic on adversarial input.
+        if let Some(v) = result {
+            assert!(v.iter().take(8).all(|x| x.abs() < 10.0));
+        }
+    }
+
+    #[test]
+    fn vec_to_lit_roundtrips_bracketed_csv() {
+        let lit = vec_to_lit(&[1.0, 2.5, -0.25]);
+        assert!(lit.starts_with('['));
+        assert!(lit.ends_with(']'));
+        assert!(lit.contains("1"));
+        assert!(lit.contains("2.5"));
+        assert!(lit.contains("-0.25"));
+        assert_eq!(lit.matches(',').count(), 2);
+    }
+
+    #[test]
+    fn tokenize_lowercases_and_drops_short_tokens() {
+        let toks = tokenize("Hello, World! a 42 file_name");
+        assert!(toks.contains(&"hello".to_string()));
+        assert!(toks.contains(&"world".to_string()));
+        assert!(toks.contains(&"42".to_string()));
+        assert!(toks.contains(&"file".to_string()));
+        assert!(toks.contains(&"name".to_string()));
+        assert!(!toks.contains(&"a".to_string()), "single chars dropped");
+    }
+
+    #[test]
+    fn bm25_rewards_query_term_matches() {
+        let docs = vec![
+            Candidate {
+                cli: "claude".into(),
+                source_id: "1".into(),
+                title: Some("refactor auth module".into()),
+                directory: None,
+                updated_at: None,
+                first_message: "rewrite the login flow with PKCE".into(),
+                cos_dist: None,
+            },
+            Candidate {
+                cli: "claude".into(),
+                source_id: "2".into(),
+                title: Some("update dependencies".into()),
+                directory: None,
+                updated_at: None,
+                first_message: "cargo upgrade bump versions".into(),
+                cos_dist: None,
+            },
+        ];
+        let scores = compute_bm25("refactor auth", &docs);
+        assert_eq!(scores.len(), 2);
+        assert!(scores[0] > scores[1], "doc 0 should outscore doc 1");
+        assert!(scores[0] > 0.0);
+    }
+
+    #[test]
+    fn bm25_empty_query_scores_zero() {
+        let docs = vec![Candidate {
+            cli: "x".into(),
+            source_id: "1".into(),
+            title: Some("anything".into()),
+            directory: None,
+            updated_at: None,
+            first_message: String::new(),
+            cos_dist: None,
+        }];
+        let scores = compute_bm25("", &docs);
+        assert_eq!(scores, vec![0.0]);
+    }
+
+    #[test]
+    fn truncate_under_max_unchanged() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_over_max_uses_ellipsis() {
+        let out = truncate("abcdefghij", 5);
+        assert_eq!(out.chars().count(), 5);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_handles_multibyte() {
+        let out = truncate("αβγδε ζηθικ", 6);
+        assert_eq!(out.chars().count(), 6);
+        assert!(out.ends_with('…'));
+    }
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -100,10 +100,12 @@ fn ensure_default_config() {
 oai_base    = "http://127.0.0.1:18000/v1"
 embed_model = "lco-omni-3b"
 
-# Naming uses a chat model. Leave chat_model = "" to disable naming.
-# qwen3.5-0.8b is the cheapest always-loadable model on the cluster.
+# Naming uses a chat model — by default we auto-pick whichever model is
+# currently loaded on the chat router so we never trigger a cold swap.
+# Set chat_model = "specific-name" to pin one (risks 503 if it's not active).
+# Set chat_model = "" to disable naming entirely.
 chat_base   = "http://llm.ht.local/v1"
-chat_model  = "qwen3.5-0.8b"
+# chat_model  = "qwen3.5-0.8b"
 
 alpha = 0.4
 
@@ -200,9 +202,9 @@ async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("unleash search");
         eprintln!("  embeddings: {oai_base} model={embed_model}");
         if let Some(ref m) = chat_model {
-            eprintln!("  naming    : {chat_base} model={m}");
+            eprintln!("  naming    : {chat_base} model={m} (pinned)");
         } else {
-            eprintln!("  naming    : disabled (set OAI_CHAT_MODEL to enable)");
+            eprintln!("  naming    : {chat_base} (auto-select from loaded models)");
         }
         eprintln!("  alpha     : {alpha:.2}  (0=semantic, 1=bm25)");
         if args.reindex {
@@ -232,6 +234,22 @@ async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("(set OAI_BASE or edit {} to point elsewhere)", config_path().display());
         return Err("endpoint unreachable".into());
     }
+
+    // If the user didn't pin a chat model, ask the chat endpoint which models
+    // are *currently loaded* and pick one. Avoids 503s when the configured
+    // model needs a cold load (the cluster router only keeps one model resident).
+    let chat_model = match chat_model {
+        Some(m) => Some(m),
+        None => {
+            let detected = detect_loaded_chat_model(&probe, &chat_base).await;
+            if let Some(ref m) = detected {
+                if !args.json {
+                    eprintln!("  naming    : auto-selected loaded model: {m}");
+                }
+            }
+            detected
+        }
+    };
 
     let http = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(EMBED_TIMEOUT_SECS))
@@ -747,6 +765,36 @@ fn vec_to_lit(v: &[f32]) -> String {
 }
 
 // ── OAI-compat HTTP ────────────────────────────────────────────────────
+
+/// Query `<base>/models` and pick a chat model that's already loaded so naming
+/// doesn't trigger a cold model swap on the router. Returns None if the call
+/// fails or no chat-capable model is currently resident.
+///
+/// We filter out anything that looks embed-only (alias or path contains
+/// "embed") and prefer the smallest loaded model (by param count if reported,
+/// else by name length as a rough tiebreaker).
+async fn detect_loaded_chat_model(http: &reqwest::Client, base: &str) -> Option<String> {
+    let url = format!("{}/models", base.trim_end_matches('/'));
+    let resp = http.get(&url).send().await.ok()?.error_for_status().ok()?;
+    let val: serde_json::Value = resp.json().await.ok()?;
+    let arr = val.get("data")?.as_array()?;
+    let mut loaded: Vec<&str> = arr
+        .iter()
+        .filter(|m| {
+            m.get("status")
+                .and_then(|s| s.get("value"))
+                .and_then(|v| v.as_str())
+                == Some("loaded")
+        })
+        .filter_map(|m| m.get("id").and_then(|v| v.as_str()))
+        .filter(|id| {
+            let lc = id.to_ascii_lowercase();
+            !lc.contains("embed") && !lc.contains("mmproj") && !lc.contains("rerank")
+        })
+        .collect();
+    loaded.sort_by_key(|id| (id.len(), id.to_string()));
+    loaded.first().map(|s| s.to_string())
+}
 
 async fn embed_one(
     http: &reqwest::Client,

--- a/src/search.rs
+++ b/src/search.rs
@@ -22,7 +22,16 @@ use std::time::Instant;
 
 use crate::interchange::sessions::{discover_all, SessionInfo};
 
-const MAX_TEXT_CHARS: usize = 600;
+/// Max chars of content text we *index* per session (stored in first_message
+/// for BM25 + TUI preview). Big enough to catch interior content in
+/// multi-megabyte sessions.
+const MAX_TEXT_CHARS: usize = 32_000;
+
+/// Max chars we feed to the *embedding* model per request. Embedding models
+/// have small context windows (LCO-Omni-3B is 4K tokens ≈ 6 KB; embeddinggemma
+/// is 512 tokens ≈ 2 KB). We truncate the indexed text to this cap before
+/// POSTing /v1/embeddings so the server doesn't 500 on oversize inputs.
+const MAX_EMBED_CHARS: usize = 6_000;
 const NAMING_TIMEOUT_SECS: u64 = 60;
 const EMBED_TIMEOUT_SECS: u64 = 30;
 const MAX_NAMES_PER_RUN: usize = 12;
@@ -221,18 +230,49 @@ async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Probe the embeddings endpoint up-front. If it's unreachable we'd rather
-    // fail fast with a copy-pasteable fix than burn 30 s per row on timeouts.
+    // fail fast (and try to self-recover) than burn 30 s per row on timeouts.
     let probe = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(3))
         .build()?;
     let probe_url = format!("{}/models", oai_base.trim_end_matches('/'));
-    if let Err(e) = probe.get(&probe_url).send().await {
-        eprintln!("\n\x1b[31merror:\x1b[0m embedding endpoint unreachable: {e}");
+    if probe.get(&probe_url).send().await.is_err() {
+        // If the user has a tunnel_hint configured (typically `ssh -fN -L ...`),
+        // try running it and re-probe. `-fN` means SSH backgrounds itself once
+        // the forwarded port is bound, so a successful exit ≈ ready to serve.
+        let mut recovered = false;
         if let Some(hint) = tunnel_hint.as_deref() {
-            eprintln!("hint: bring the tunnel up:\n  {hint}");
+            if !args.json {
+                eprintln!("  tunnel    : endpoint down — running `{hint}`");
+            }
+            if try_bring_up_tunnel(hint) {
+                // Re-probe; give it a brief moment in case the forward is still
+                // settling.
+                for attempt in 0..6 {
+                    if probe.get(&probe_url).send().await.is_ok() {
+                        recovered = true;
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(
+                        200 + attempt * 100,
+                    ))
+                    .await;
+                }
+            }
         }
-        eprintln!("(set OAI_BASE or edit {} to point elsewhere)", config_path().display());
-        return Err("endpoint unreachable".into());
+        if !recovered {
+            eprintln!("\n\x1b[31merror:\x1b[0m embedding endpoint unreachable: {probe_url}");
+            if let Some(hint) = tunnel_hint.as_deref() {
+                eprintln!("hint: bring the tunnel up manually:\n  {hint}");
+            }
+            eprintln!(
+                "(set OAI_BASE or edit {} to point elsewhere)",
+                config_path().display()
+            );
+            return Err("endpoint unreachable".into());
+        }
+        if !args.json {
+            eprintln!("  tunnel    : up");
+        }
     }
 
     // If the user didn't pin a chat model, ask the chat endpoint which models
@@ -280,8 +320,18 @@ async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     let mut needs_embed: Vec<(i64, String)> = Vec::new();
     let mut needs_name: Vec<(i64, String)> = Vec::new();
     let mut indexed = 0usize;
+    let mut skipped_archive = 0usize;
 
     for s in &sessions {
+        // Claude's discovery surfaces `<uuid>.archive` rows alongside the live
+        // session. They're snapshots of pre-compaction state and duplicate the
+        // active session's content — they only bloat the index and dilute
+        // results. Skip them here (the direct `-x <cli>:<id>.archive` path still
+        // works because it goes through find_session, not the search index).
+        if s.id.ends_with(".archive") {
+            skipped_archive += 1;
+            continue;
+        }
         let mtime_ns = file_mtime_ns(&s.path).unwrap_or(0);
         let cur_mtime: Option<i64> = {
             let mut r = conn
@@ -346,7 +396,7 @@ async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     }
     if !args.json {
         eprintln!(
-            "[index] {indexed} rows, {} need embedding, {} need naming",
+            "[index] {indexed} rows, {} need embedding, {} need naming ({skipped_archive} archive rows skipped)",
             needs_embed.len(),
             needs_name.len()
         );
@@ -513,6 +563,26 @@ async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     }
     emit(&hits, args.json);
     Ok(())
+}
+
+/// Run a `tunnel_hint` (typically `ssh -fN -L LPORT:HOST:RPORT TARGET`) so the
+/// embedding endpoint becomes reachable without forcing the user to context-
+/// switch into a shell. `-fN` means SSH backgrounds itself once the forwarded
+/// port is bound, so a 0 exit code means the tunnel is up *and* won't die when
+/// `unleash` exits.
+fn try_bring_up_tunnel(hint: &str) -> bool {
+    let parts: Vec<&str> = hint.split_whitespace().collect();
+    let Some((prog, rest)) = parts.split_first() else {
+        return false;
+    };
+    std::process::Command::new(prog)
+        .args(rest)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
 }
 
 /// Discover available profiles. Falls back to the built-in agent CLI names
@@ -727,28 +797,186 @@ fn file_mtime_ns(p: &Path) -> Option<i64> {
     Some(dur.as_nanos() as i64)
 }
 
-/// Best-effort text extraction. We deliberately don't parse per-CLI here —
-/// session files are JSONL/JSON whose first ~1KB always contains useful
-/// signal (user message, system prompt, working directory). The embedder
-/// tolerates noisy JSON just fine.
+/// Pull user-facing text out of a session file for embedding/BM25.
+///
+/// Naive head-only indexing misses every active topic on long sessions —
+/// "install summary" lives at byte 6.6M of a 10M session that started with
+/// generic context-setting. We sample *both* the head (initial intent /
+/// post-compaction summary live there) AND the tail (most recent topic), and
+/// parse JSON records to skip JSONL boilerplate (`parentUuid`, `sessionId`,
+/// `gitBranch` etc) that would otherwise drown the conversational signal.
 fn extract_text(s: &SessionInfo) -> Option<String> {
-    let bytes = fs::read(&s.path).ok()?;
-    let head_len = bytes.len().min(8192);
-    let head = String::from_utf8_lossy(&bytes[..head_len]);
-    let cleaned: String = head
-        .chars()
-        .filter(|c| !c.is_control() || *c == ' ' || *c == '\n')
-        .collect();
-    let mut snippet = String::new();
-    for ch in cleaned.chars() {
-        if snippet.len() >= MAX_TEXT_CHARS {
+    use std::io::BufRead;
+
+    let file = fs::File::open(&s.path).ok()?;
+    let reader = std::io::BufReader::new(file);
+
+    // Stream the whole JSONL file, pulling content strings out of each parseable
+    // line. We keep a sliding pair: the first ~25% of the budget records the
+    // session's opening exchange (intent, post-compaction summary, system prompt)
+    // and the remaining ~75% rolls forward, so the *latest* content always wins
+    // the tail allocation. Result: small/medium sessions are fully indexed; long
+    // sessions surface both their starting context and their most recent topic.
+    const HEAD_BUDGET: usize = MAX_TEXT_CHARS / 4;
+    const TAIL_BUDGET: usize = MAX_TEXT_CHARS - HEAD_BUDGET;
+
+    let mut head: Vec<String> = Vec::new();
+    let mut head_used = 0usize;
+    let mut tail: std::collections::VecDeque<String> = std::collections::VecDeque::new();
+    let mut tail_used = 0usize;
+
+    let mut first_value: Option<serde_json::Value> = None;
+    let mut saw_jsonl = false;
+
+    for line in reader.lines().take(50_000) {
+        let Ok(line) = line else { break };
+        let trimmed = line.trim();
+        if !trimmed.starts_with('{') {
+            continue;
+        }
+        let Ok(val) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        if first_value.is_none() {
+            first_value = Some(val.clone());
+        }
+        saw_jsonl = true;
+        let mut local: Vec<String> = Vec::new();
+        collect_content_strings(&val, &mut local);
+        for chunk_text in local {
+            let len = chunk_text.len();
+            if head_used < HEAD_BUDGET {
+                head_used += len;
+                head.push(chunk_text);
+            } else {
+                tail_used += len;
+                tail.push_back(chunk_text);
+                while tail_used > TAIL_BUDGET {
+                    if let Some(dropped) = tail.pop_front() {
+                        tail_used = tail_used.saturating_sub(dropped.len());
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // Single-JSON layout (Gemini / UCF): if only the first line parsed (no
+    // newline-separated records), parse the whole file as one document.
+    if !saw_jsonl || (head.is_empty() && tail.is_empty()) {
+        if let Ok(bytes) = fs::read(&s.path) {
+            if let Ok(text) = std::str::from_utf8(&bytes) {
+                if let Ok(val) = serde_json::from_str::<serde_json::Value>(text.trim()) {
+                    collect_content_strings(&val, &mut head);
+                }
+            }
+        }
+    }
+
+    let title_part = s.title.as_deref().or(s.name.as_deref()).unwrap_or("");
+    let mut combined = String::new();
+    combined.push_str(title_part);
+    combined.push(' ');
+    combined.push_str(&s.directory);
+    for t in head.iter().chain(tail.iter()) {
+        if combined.chars().count() >= MAX_TEXT_CHARS {
             break;
         }
-        snippet.push(ch);
+        combined.push(' ');
+        combined.push_str(t);
     }
-    let title_part = s.title.as_deref().or(s.name.as_deref()).unwrap_or("");
-    let dir_part = &s.directory;
-    Some(format!("{title_part} {dir_part} {snippet}").trim().to_string())
+    let snippet: String = combined.chars().take(MAX_TEXT_CHARS).collect();
+    let trimmed = snippet.trim().to_string();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+/// Walk a JSON value and append any string values that live under
+/// content-bearing keys. Skips opaque identifiers and short tokens.
+fn collect_content_strings(val: &serde_json::Value, out: &mut Vec<String>) {
+    use serde_json::Value;
+    const CONTENT_KEYS: &[&str] = &[
+        "content",
+        "text",
+        "message",
+        "summary",
+        "input",
+        "prompt",
+        "messages",
+        "payload",
+    ];
+    match val {
+        Value::Object(map) => {
+            for (k, v) in map {
+                if CONTENT_KEYS.contains(&k.as_str()) {
+                    extract_strings(v, out);
+                } else if matches!(v, Value::Object(_) | Value::Array(_)) {
+                    // Descend, but only one level so we don't pick up metadata
+                    // siblings hiding inside nested objects.
+                    collect_content_strings(v, out);
+                }
+            }
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                collect_content_strings(v, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Extract all "leaf" string values from a JSON subtree, applying noise
+/// filters. Used once we know we're inside a content-bearing key.
+fn extract_strings(val: &serde_json::Value, out: &mut Vec<String>) {
+    use serde_json::Value;
+    match val {
+        Value::String(s) => {
+            let trimmed = s.trim();
+            // Skip very short tokens, opaque ids, and things that are obviously
+            // tool/internal payloads.
+            if trimmed.len() < 8 || trimmed.len() > 8192 {
+                return;
+            }
+            if looks_like_opaque_id(trimmed) {
+                return;
+            }
+            out.push(trimmed.to_string());
+        }
+        Value::Array(arr) => {
+            for v in arr {
+                extract_strings(v, out);
+            }
+        }
+        Value::Object(map) => {
+            // For role/content-block shapes like {"type":"text","text":"..."}.
+            for (k, v) in map {
+                if matches!(
+                    k.as_str(),
+                    "text" | "content" | "message" | "value" | "summary"
+                ) {
+                    extract_strings(v, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn looks_like_opaque_id(s: &str) -> bool {
+    // UUID-ish (8-4-4-4-12)
+    if s.len() == 36 && s.matches('-').count() == 4 {
+        return true;
+    }
+    // toolu_/msg_/sess_ prefixes from API tokens
+    if s.starts_with("toolu_") || s.starts_with("msg_") || s.starts_with("sess_") {
+        return true;
+    }
+    false
 }
 
 fn vec_to_lit(v: &[f32]) -> String {
@@ -802,6 +1030,9 @@ async fn embed_one(
     model: &str,
     text: &str,
 ) -> Result<Vec<f32>, Box<dyn std::error::Error>> {
+    // Cap input length to fit small embedding contexts; BM25 still scores
+    // against the full stored text, so this only narrows the semantic vector.
+    let truncated: String = text.chars().take(MAX_EMBED_CHARS).collect();
     #[derive(serde::Serialize)]
     struct Req<'a> {
         model: &'a str,
@@ -818,7 +1049,10 @@ async fn embed_one(
     let url = format!("{}/embeddings", base.trim_end_matches('/'));
     let resp = http
         .post(&url)
-        .json(&Req { model, input: text })
+        .json(&Req {
+            model,
+            input: &truncated,
+        })
         .send()
         .await?
         .error_for_status()?

--- a/src/search.rs
+++ b/src/search.rs
@@ -34,7 +34,7 @@ pub struct RunArgs {
     pub top: usize,
 }
 
-#[derive(Debug, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct Hit {
     pub rank: usize,
     pub score: f32,
@@ -317,7 +317,88 @@ async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
         );
     }
     emit(&hits, args.json);
+
+    // Interactive handoff: pick a result + profile, exec into the existing
+    // crossload flow. JSON mode and non-TTY stdin skip this — just print results.
+    if !args.json && std::io::IsTerminal::is_terminal(&std::io::stdin()) && !hits.is_empty() {
+        if let Some((hit, profile)) = prompt_handoff(&hits)? {
+            launch_crossload(&profile, &hit.cli, &hit.source_id);
+            // launch_crossload execs; if we return, exec failed.
+        }
+    }
     Ok(())
+}
+
+/// Prompt the user to pick a search hit + target profile.
+/// Returns Ok(None) when the user cancels (empty input or invalid number).
+fn prompt_handoff(hits: &[Hit]) -> io::Result<Option<(Hit, String)>> {
+    use std::io::Write;
+
+    print!("\nPick # to launch (Enter to skip): ");
+    io::stdout().flush().ok();
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    let picked: usize = match line.trim().parse() {
+        Ok(n) if n >= 1 && n <= hits.len() => n,
+        _ => return Ok(None),
+    };
+    let hit = hits[picked - 1].clone();
+
+    let profiles = available_profiles();
+    println!("\nAvailable profiles:");
+    for (i, p) in profiles.iter().enumerate() {
+        println!("  {}. {}", i + 1, p);
+    }
+    print!("Profile # or name (Enter = same CLI as source, '{}'): ", hit.cli);
+    io::stdout().flush().ok();
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    let raw = line.trim();
+    let profile = if raw.is_empty() {
+        hit.cli.clone()
+    } else if let Ok(n) = raw.parse::<usize>() {
+        if n >= 1 && n <= profiles.len() {
+            profiles[n - 1].clone()
+        } else {
+            eprintln!("invalid profile number");
+            return Ok(None);
+        }
+    } else {
+        raw.to_string()
+    };
+
+    Ok(Some((hit, profile)))
+}
+
+/// Discover available profiles. Falls back to the built-in agent CLI names
+/// when no per-profile TOML files are configured.
+fn available_profiles() -> Vec<String> {
+    let configured = crate::config::ProfileManager::new()
+        .ok()
+        .and_then(|m| m.list_profiles().ok())
+        .unwrap_or_default();
+    if !configured.is_empty() {
+        return configured;
+    }
+    ["claude", "codex", "gemini", "opencode", "pi", "hermes"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Exec into `unleash <profile> -x <cli>:<id>`, which routes through the
+/// existing crossload path in `lib.rs` — no duplication of injection logic.
+fn launch_crossload(profile: &str, source_cli: &str, source_id: &str) {
+    use std::os::unix::process::CommandExt;
+    let handle = format!("{source_cli}:{source_id}");
+    let argv0 = std::env::args().next().unwrap_or_else(|| "unleash".to_string());
+    eprintln!("\n→ exec: {argv0} {profile} -x {handle}");
+    let err = std::process::Command::new(&argv0)
+        .arg(profile)
+        .arg("-x")
+        .arg(&handle)
+        .exec();
+    eprintln!("exec failed: {err}");
 }
 
 // ── DB helpers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds `unleash search` — a standalone subcommand that hybrid-searches your past sessions (BM25 + cosine similarity) across all installed CLIs, then hands the picked session off to crossload. Replaces the substring picker behind a real ratatui UI.

- **Storage**: turso 0.6.0 (BETA) — `vector32()` blobs + `vector_distance_cos()` SQL
- **Embeddings + naming**: any OAI-compatible endpoint (llama-server, ollama, vLLM, lmstudio, OpenAI). No ONNX/ort/tokenizers needed in unleash
- **Hybrid scoring**: BM25 in Rust app code (turso 0.6 doesn't expose FTS5) + cosine in SQL, blended with α slider (default 0.4)
- **Sentinel preconfig**: ships `~/.config/unleash/search.toml` defaulting to the cluster's LCO embedding pod via SSH tunnel + `llm.ht.local` chat router
- **Chat-model auto-detect**: GETs `/v1/models`, picks whichever model is already loaded (avoids cold-load 503s on single-slot routers)
- **Naming**: qwen-family thinking-mode disabled via `chat_template_kwargs.enable_thinking=false`

## What's in the branch

| Path | Role |
|---|---|
| `examples/turso_vector_probe.rs` | Step 0 SQL probe — proved `vector32()`/`vector_distance_cos()` work, FTS5 doesn't |
| `examples/poc_search.rs` | End-to-end PoC binary (kept as reference) |
| `src/search.rs` | New module: store, indexer, embedder, namer, ratatui TUI, profile picker, crossload handoff |
| `src/cli.rs` | New `Commands::Search { query, reindex, json, top }` |
| `src/lib.rs` | Routes `Search` → `search::run`; allowlisted in `is_known_subcommand` |
| `Cargo.toml` | Promotes turso/tokio/reqwest from dev-deps to deps |

## Architecture notes

- Tokio runtime is contained inside `search::run` (`current_thread` flavor) — never leaks into the rest of the sync CLI
- `Hit` rows + embeddings are loaded once and rescored in-memory per keystroke (debounced 300ms for re-embedding the query); <50ms for ~1k sessions
- vector32 BLOB decode tries header offsets 8/4/0 to handle turso version drift
- crossload handoff is `execvp` on argv[0] with `<profile> -x <cli>:<id>` — reuses existing inject path, no new code

## Test plan

- [x] `cargo build --profile fast` — clean
- [x] `cargo test --lib` — 492 passing
- [x] Smoke: 863 sessions indexed, 12 named in ~50s, hybrid scored in 49ms (PoC log)
- [ ] Manual TUI exercise in a real terminal (couldn't do in agent shell — flag any UX rough edges)
- [ ] First-run: delete `~/.local/share/unleash/search-index.db` + `~/.config/unleash/search.toml`, confirm fresh bootstrap
- [ ] Tunnel-down case: confirm helpful error message + exit, not crash

## Known open work (deferred to follow-up PRs)

- PR F polish: `unleash sessions reindex` / `unleash sessions name` commands, docs in `docs/`, `--json` non-interactive output
- Re-embed-on-model-change: model id is stored per row but not yet used to invalidate
- Turso BETA — `SearchStore` trait isn't extracted yet; if turso stability bites, the libsql swap is one file