### PR TITLE
fix(sandbox): align image tag with Docker Hub repo (marksverdhei/unleash)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-    image: unleash:latest
+    image: marksverdhei/unleash:latest
     entrypoint: ["entrypoint.sh", "/bin/bash"]
     runtime: runsc
     stdin_open: true
@@ -43,7 +43,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-    image: unleash:latest
+    image: marksverdhei/unleash:latest
     runtime: runsc
     stdin_open: true
     tty: true

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -226,37 +226,19 @@ pub fn iptables_rules_active() -> bool {
 /// Check if the unleash Docker image exists (either local or pulled)
 pub fn image_exists() -> bool {
     let full_image = format!("{}:{}", DOCKER_IMAGE, DOCKER_TAG);
-    // Check for both the pulled name and a local "unleash:latest" alias
-    for name in &[full_image.as_str(), "unleash:latest"] {
-        if Command::new("docker")
-            .args(["image", "inspect", name])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
-        {
-            return true;
-        }
-    }
-    false
-}
-
-/// Get the image name to use (prefer pulled image, fall back to local)
-fn image_name() -> String {
-    let full_image = format!("{}:{}", DOCKER_IMAGE, DOCKER_TAG);
-    if Command::new("docker")
+    Command::new("docker")
         .args(["image", "inspect", &full_image])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
-    {
-        full_image
-    } else {
-        "unleash:latest".to_string()
-    }
+}
+
+/// Get the canonical Docker Hub image name (`marksverdhei/unleash:latest`).
+/// Both the pulled image and a `docker compose build` produce this tag.
+fn image_name() -> String {
+    format!("{}:{}", DOCKER_IMAGE, DOCKER_TAG)
 }
 
 /// Check if the .env file exists in the docker directory

--- a/tests/test_sandbox_network.sh
+++ b/tests/test_sandbox_network.sh
@@ -18,7 +18,7 @@
 
 set -euo pipefail
 
-IMAGE="unleash:latest"
+IMAGE="marksverdhei/unleash:latest"
 NETWORK="unleash-sandbox"
 PASS=0
 FAIL=0


### PR DESCRIPTION
## Summary

`unleash sandbox` was printing/checking a bare `unleash:latest` tag in a couple of fallback paths — that name doesn't exist on Docker Hub. The repo is `marksverdhei/unleash`, so the only pullable tag is `marksverdhei/unleash:latest`. Status output now matches what `docker pull` would actually fetch.

## Changes

- `src/sandbox.rs` — `image_exists()` and `image_name()` collapse to the single canonical `marksverdhei/unleash:latest`. Dropped the local alias check that could mask the canonical name in status output.
- `docker/docker-compose.yml` — `bash` and `unleash` services now build/tag as `marksverdhei/unleash:latest` so the local build matches the published tag.
- `tests/test_sandbox_network.sh` — `IMAGE` constant updated.

## Test plan

- [x] `cargo build --profile fast` — clean
- [x] `cargo test --lib sandbox` — 19/19 passing (the wizard state-machine tests)
- [ ] Manual: `unleash sandbox status` prints `marksverdhei/unleash:latest`
- [ ] Manual: `unleash sandbox setup` on a clean machine pulls successfully
- [ ] Manual: `docker compose -f docker/docker-compose.yml run --rm claude` builds with the new tag