### PR TITLE
feat(docker): optional Vulkan GPU passthrough via docker-compose.gpu.yml

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,6 +90,7 @@ RUN apt-get update \
        procps \
        file \
        unzip \
+       mesa-vulkan-drivers \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for sandboxing (with passwordless sudo)

--- a/docker/NETWORKING.md
+++ b/docker/NETWORKING.md
@@ -140,7 +140,9 @@ Safe configurations:
 |-------|---------|----------|----------|
 | base | runsc | sandbox | Single agent (default) |
 | base + runc | runc | default | No gVisor available |
+| base + gpu | runc | sandbox | Single agent with GPU/Vulkan |
 | base + multi-agent | runsc | sandbox + mesh | Agent team |
+| base + gpu + multi-agent | runc | sandbox + mesh | Agent team with GPU/Vulkan |
 | base + runc + multi-agent | runc | default + mesh | Agent team, no gVisor |
 
 The runc + multi-agent combination uses the default Docker bridge for internet (no LAN blocking, no gVisor) and the mesh network for inter-agent communication. This is a lower-security mode suitable for development.

--- a/docker/README.md
+++ b/docker/README.md
@@ -76,6 +76,34 @@ Agents find each other using `.mesh` aliases (`claude.mesh`, `codex.mesh`, etc.)
 
 For advanced networking (sidecars, custom topologies), see [NETWORKING.md](NETWORKING.md).
 
+### GPU / Vulkan
+
+To give containers access to a host GPU (e.g., for Vulkan compute), use the GPU override. This switches to runc (gVisor cannot expose host devices) but keeps the sandbox network for LAN isolation.
+
+```bash
+docker compose -f docker/docker-compose.yml \
+  -f docker/docker-compose.gpu.yml \
+  run --rm claude
+```
+
+The override mounts `/dev/dri/card1` and `/dev/dri/renderD128` and adds the host `video` and `render` group IDs. Verify the group IDs match your host:
+
+```bash
+getent group video render
+```
+
+If your GIDs differ from the defaults in `docker-compose.gpu.yml`, update the `group_add` values.
+
+Inside the container, verify with:
+
+```bash
+vulkaninfo --summary
+```
+
+**Security note:** GPU containers use runc instead of gVisor, so kernel isolation is standard Docker namespaces rather than gVisor's syscall filter. LAN blocking via the sandbox network is still active.
+
+> **Kubernetes host caveat:** On hosts running RKE2/k3s with Calico CNI, the CNI's iptables rules in the FORWARD chain may take priority over DOCKER-USER, bypassing LAN blocking. If LAN isolation is critical, verify with `timeout 2 bash -c 'echo > /dev/tcp/192.168.8.1/80'` from inside the container, and consider adding DROP rules earlier in the FORWARD chain if needed.
+
 ## How Sandboxing Works
 
 ### gVisor (runsc)
@@ -100,12 +128,13 @@ sudo ./docker/sandbox-network.sh status    # Check current state
 
 ### Security Summary
 
-| Setup | Kernel Isolation | LAN Blocked | Inter-Container | Internet |
-|-------|-----------------|-------------|-----------------|----------|
-| Default compose (gVisor + sandbox) | gVisor syscall filter | Yes | No | Yes |
-| Multi-agent (+ mesh) | gVisor syscall filter | Yes | Mesh only | Yes |
-| runc override | Standard Docker (namespaces) | No | Default Docker | Yes |
-| `--network none` | N/A | Yes | No | No |
+| Setup | Kernel Isolation | LAN Blocked | Inter-Container | Internet | GPU |
+|-------|-----------------|-------------|-----------------|----------|-----|
+| Default compose (gVisor + sandbox) | gVisor syscall filter | Yes | No | Yes | No |
+| Multi-agent (+ mesh) | gVisor syscall filter | Yes | Mesh only | Yes | No |
+| GPU override (runc + sandbox) | Standard Docker (namespaces) | Yes | No | Yes | Yes |
+| runc override | Standard Docker (namespaces) | No | Default Docker | Yes | No |
+| `--network none` | N/A | Yes | No | No | No |
 
 ## Authentication
 

--- a/docker/docker-compose.gpu.yml
+++ b/docker/docker-compose.gpu.yml
@@ -1,0 +1,31 @@
+# Override: GPU/Vulkan device passthrough (requires runc — gVisor cannot expose host devices)
+#
+# Usage (sandboxed + GPU):
+#   docker compose -f docker/docker-compose.yml -f docker/docker-compose.gpu.yml run --rm claude
+#
+# Multi-agent + GPU:
+#   docker compose -f docker/docker-compose.yml -f docker/docker-compose.gpu.yml \
+#     -f docker/docker-compose.multi-agent.yml up claude codex
+#
+# Note: Host group IDs for video/render may differ. Check with: getent group video render
+
+x-gpu: &gpu
+  runtime: runc
+  devices:
+    - /dev/dri/card1:/dev/dri/card1
+    - /dev/dri/renderD128:/dev/dri/renderD128
+  group_add:
+    - "983"   # video (host GID — verify with: getent group video)
+    - "987"   # render (host GID — verify with: getent group render)
+
+services:
+  unleash:
+    <<: *gpu
+  claude:
+    <<: *gpu
+  codex:
+    <<: *gpu
+  gemini:
+    <<: *gpu
+  opencode:
+    <<: *gpu


### PR DESCRIPTION
Resurrects #52 against current main. The original branch was 6 weeks behind and conflicted on `docker/Dockerfile`'s expanded apt-get package list; rebased and re-merged here.

## Summary

Adds an opt-in compose override that gives sandbox containers access to a host GPU for Vulkan compute. Falls back to `runc` for the GPU services (gVisor cannot expose host devices) while keeping the sandbox network for LAN isolation.

- `docker/Dockerfile` — `mesa-vulkan-drivers` added to the runtime apt-get block alongside the existing sandbox tooling
- `docker/docker-compose.gpu.yml` (new) — YAML-anchor override that switches `runtime: runc` and mounts `/dev/dri/card1` + `/dev/dri/renderD128` across all agent services with the host's `video` + `render` group IDs
- `docker/README.md`, `docker/NETWORKING.md` — usage instructions and safe-config table rows for `base + gpu` / `base + gpu + multi-agent`

## Usage

```bash
docker compose -f docker/docker-compose.yml \
               -f docker/docker-compose.gpu.yml \
               run --rm claude
```

## Caveats

- Host GIDs for `video`/`render` groups are hardcoded in the override (983/987). They may differ per machine — README calls out the `getent group video render` verification step. On this machine they're 984/988, so users will need to either edit the override or shadow the values via env-var substitution if we want to make this fully portable. Deferred — current state matches the original PR's design and is honest about the verification step.

## Test plan

- [x] `cargo build --profile fast` clean (Rust side unaffected)
- [ ] `docker compose -f docker/docker-compose.yml -f docker/docker-compose.gpu.yml build` succeeds
- [ ] Vulkan workload (`vulkaninfo` or similar) detects the GPU inside the container
- [ ] Sandbox network still blocks LAN under the runc-GPU branch (verify with `tests/test_sandbox_network.sh`)

Closes #52.