### PR TITLE
feat(search): unleash sessions reindex + sessions name subcommands

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -105,6 +105,40 @@ Show all agent versions and update status in a single table.
 
 List sessions across all installed CLIs.
 
+```bash
+unleash sessions                              # List all
+unleash sessions --cli claude                 # Filter by CLI
+unleash sessions --find claude:abc1234        # Lookup one
+unleash sessions reindex                      # Rebuild the search index
+unleash sessions name claude:abc "My Title"   # Override the display title
+unleash sessions name claude:abc              # Regenerate via chat model
+```
+
+`sessions reindex` re-embeds every session and refreshes generated titles using
+the configured OpenAI-compatible endpoint (see `unleash search`).
+
+`sessions name <cli>:<source_id> [TITLE]` updates the `generated_title` column
+in the search index. With an explicit `TITLE` it's a direct write; without one
+the configured chat model is asked for a new 3–6 word title. Useful when an
+auto-generated title is wrong or missing.
+
+### `unleash search`
+
+Semantic + BM25 hybrid search across all indexed sessions.
+
+```bash
+unleash search                          # Open the interactive TUI
+unleash search "fix install summary"    # Pre-fill the TUI with a query
+unleash search --json --top 10 "..."    # Non-interactive ranked JSON output
+unleash search --reindex                # Rebuild before searching
+```
+
+Backed by a Turso DB at `~/.local/share/unleash/search-index.db`. Uses an
+OpenAI-compatible local server for embeddings (e.g.
+`llama-server --embeddings -m embed.gguf`). See `unleash search --help` for
+environment variables (`OAI_BASE`, `OAI_EMBED_MODEL`, `OAI_CHAT_MODEL`,
+`ALPHA`).
+
 ### `unleash convert`
 
 Convert between CLI session formats. Use `--from` to specify the source format and

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -656,14 +656,24 @@ pub enum Commands {
     },
 
     /// List conversation sessions across all agent CLIs
+    ///
+    /// Examples:
+    ///   unleash sessions                          # List all sessions
+    ///   unleash sessions --cli claude             # Filter by CLI
+    ///   unleash sessions --find claude:abc1234    # Lookup one
+    ///   unleash sessions reindex                  # Rebuild the search index
+    ///   unleash sessions name claude:abc "Title"  # Set a session title
     Sessions {
         /// Filter by CLI (claude, codex, gemini, opencode)
-        #[arg(short, long)]
+        #[arg(short, long, global = true)]
         cli: Option<String>,
 
         /// Find a specific session by name/ID (supports cli:name format)
         #[arg(short, long)]
         find: Option<String>,
+
+        #[command(subcommand)]
+        action: Option<SessionsAction>,
     },
 
     /// Semantic search across all sessions (hybrid BM25 + cosine over local embeddings).
@@ -755,6 +765,30 @@ pub enum Commands {
     /// Run a profile by name (catches any unknown subcommand as a profile name)
     #[command(external_subcommand)]
     Profile(Vec<String>),
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SessionsAction {
+    /// Rebuild the search index — re-embed every session and refresh titles
+    ///
+    /// Use after switching embedding models, or if the index gets corrupted.
+    /// Runs the same indexer as `unleash search --reindex` but without opening
+    /// the TUI.
+    Reindex,
+
+    /// Set or regenerate the display title for a session
+    ///
+    /// Targets are written as `<cli>:<source_id>` (the format printed by
+    /// `unleash sessions`). When TITLE is supplied it replaces any existing
+    /// generated/native title for that row. When omitted, the configured chat
+    /// model is asked for a new 3–6 word title.
+    Name {
+        /// Session identifier in `<cli>:<source_id>` form
+        target: String,
+
+        /// New title — if omitted, regenerate via the configured chat model
+        title: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1086,8 +1086,13 @@ pub fn run() -> io::Result<()> {
         Some(Commands::Sessions {
             cli: cli_filter,
             find,
+            action,
         }) => {
             let json = cli.json;
+            if let Some(act) = action {
+                return search::run_sessions_action(act, json)
+                    .map_err(|e| io::Error::other(e.to_string()));
+            }
             if let Some(query) = find {
                 match interchange::sessions::find_session(&query) {
                     Some(session) => {

--- a/src/search.rs
+++ b/src/search.rs
@@ -196,6 +196,142 @@ pub fn run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     rt.block_on(run_async(args))
 }
 
+/// Synchronous entry point for `unleash sessions reindex` / `unleash sessions name`.
+/// Same tokio-containment pattern as `run()`.
+pub fn run_sessions_action(
+    action: crate::cli::SessionsAction,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(run_sessions_action_async(action, json))
+}
+
+async fn run_sessions_action_async(
+    action: crate::cli::SessionsAction,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match action {
+        crate::cli::SessionsAction::Reindex => {
+            // Re-use the full search pipeline (probe → schema → discover → upsert
+            // → embed → name) with no query and no TUI. Setting reindex=true
+            // wipes embeddings + generated titles so everything regenerates.
+            run_async(RunArgs {
+                query: Some(String::new()),
+                reindex: true,
+                json,
+                top: 0,
+            })
+            .await
+        }
+        crate::cli::SessionsAction::Name { target, title } => {
+            set_session_title(&target, title.as_deref(), json).await
+        }
+    }
+}
+
+async fn set_session_title(
+    target: &str,
+    title: Option<&str>,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (cli, source_id) = target
+        .split_once(':')
+        .ok_or("target must be in <cli>:<source_id> form (e.g. claude:abc12345)")?;
+    if cli.is_empty() || source_id.is_empty() {
+        return Err("target must be in <cli>:<source_id> form (e.g. claude:abc12345)".into());
+    }
+
+    let db_path = index_db_path();
+    if let Some(parent) = db_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let db = turso::Builder::new_local(db_path.to_string_lossy().as_ref())
+        .build()
+        .await?;
+    let conn = db.connect()?;
+    bootstrap_schema(&conn).await?;
+
+    // Confirm the row exists so we can give a useful error rather than silently
+    // updating zero rows.
+    let mut probe = conn
+        .query(
+            "SELECT pk FROM sessions WHERE cli=?1 AND source_id=?2",
+            turso::params![cli.to_string(), source_id.to_string()],
+        )
+        .await?;
+    if probe.next().await?.is_none() {
+        return Err(format!(
+            "no session indexed for {cli}:{source_id} — run `unleash search` or `unleash sessions reindex` first"
+        )
+        .into());
+    }
+
+    let new_title = match title {
+        Some(t) => {
+            let trimmed = t.trim();
+            if trimmed.is_empty() {
+                return Err("title must not be empty".into());
+            }
+            trimmed.to_string()
+        }
+        None => {
+            // Regenerate via the configured chat model.
+            let cfg = resolve_config();
+            let chat_base = cfg.chat_base.clone();
+            let chat_model = match cfg.chat_model.clone() {
+                Some(m) => m,
+                None => {
+                    let probe_http = reqwest::Client::builder()
+                        .timeout(std::time::Duration::from_secs(3))
+                        .build()?;
+                    detect_loaded_chat_model(&probe_http, &chat_base)
+                        .await
+                        .ok_or("no chat model configured or loaded — set OAI_CHAT_MODEL or pass an explicit TITLE")?
+                }
+            };
+
+            let mut content = conn
+                .query(
+                    "SELECT first_message FROM sessions WHERE cli=?1 AND source_id=?2",
+                    turso::params![cli.to_string(), source_id.to_string()],
+                )
+                .await?;
+            let text: String = match content.next().await? {
+                Some(row) => row.get(0)?,
+                None => String::new(),
+            };
+            if text.is_empty() {
+                return Err("session has no indexed text — run `unleash sessions reindex` first".into());
+            }
+
+            let http = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(NAMING_TIMEOUT_SECS))
+                .build()?;
+            generate_name(&http, &chat_base, &chat_model, &text).await?
+        }
+    };
+
+    conn.execute(
+        "UPDATE sessions SET generated_title=?1 WHERE cli=?2 AND source_id=?3",
+        turso::params![new_title.clone(), cli.to_string(), source_id.to_string()],
+    )
+    .await?;
+
+    if json {
+        let out = serde_json::json!({
+            "cli": cli,
+            "source_id": source_id,
+            "title": new_title,
+        });
+        println!("{}", serde_json::to_string(&out)?);
+    } else {
+        println!("{cli}:{source_id} -> {new_title}");
+    }
+    Ok(())
+}
+
 async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     let cfg = resolve_config();
     let ResolvedConfig {


### PR DESCRIPTION
## Summary

PR F polish from the search-overhaul plan. Adds two discoverable subcommands so reindex and title management don't need the interactive TUI:

- `unleash sessions reindex` — non-TUI rebuild (re-embeds + re-titles every row; same pipeline as `unleash search --reindex` but skips the picker).
- `unleash sessions name <cli>:<source_id> "TITLE"` — directly overwrite \`generated_title\` for one row. Useful when the auto-generated title is wrong/missing.
- `unleash sessions name <cli>:<source_id>` — regenerate via the configured chat model (auto-detects a loaded model if \`OAI_CHAT_MODEL\` is unset).

Backward compatible: \`unleash sessions [--cli X | --find Y]\` still works — \`action\` is \`Option<SessionsAction>\` and the bare-flags path only runs when it's \`None\`.

All wiring routes through a new \`search::run_sessions_action\` entry point that owns its own tokio runtime, keeping the rest of the CLI sync (same containment pattern as \`search::run\`).

## Test plan

- [x] \`cargo build --profile fast\` clean (no new warnings)
- [x] \`cargo test --lib\` — 506 passed
- [x] \`unleash sessions --help\` shows the new subcommands in usage block
- [x] \`unleash sessions reindex --help\` and \`sessions name --help\` render
- [x] Backward compat: \`unleash sessions --cli claude\` still lists
- [x] \`sessions name not-a-format X\` → useful error
- [x] \`sessions name claude:nonexistent X\` → useful "run reindex first" error
- [x] \`sessions name claude:<real-id> "Title"\` writes to DB (verified via sqlite3)
- [x] \`sessions --json name <id> "Title"\` emits JSON

Closes the last open item on the search-overhaul plan (\`/home/me/.claude/plans/glittery-launching-codd.md\`).