### PR TITLE
feat(plugins): token-usage — cross-CLI token tracking with toggleable methods

### DIFF
--- a/plugins/bundled/token-usage/.claude-plugin/plugin.json
+++ b/plugins/bundled/token-usage/.claude-plugin/plugin.json
@@ -1,0 +1,44 @@
+{
+  "name": "token-usage",
+  "description": "Track token usage across all agent CLIs (Claude, Codex, Gemini, OpenCode, Pi) — multiple collection methods, toggleable",
+  "version": "0.1.0",
+  "author": {
+    "name": "Heiervang Technologies",
+    "email": "support@heiervang.com"
+  },
+  "settings": {
+    "method_session_tail": {
+      "type": "boolean",
+      "default": true,
+      "label": "Method: Stop-hook session tail",
+      "description": "After each Claude turn, read the assistant message's usage field from the transcript JSONL and append to the local log. Live, zero-config, no API keys required."
+    },
+    "method_session_scan": {
+      "type": "boolean",
+      "default": true,
+      "label": "Method: On-demand session scan",
+      "description": "When the report is run, walk every CLI's session files (claude/codex/gemini/opencode/pi) and aggregate usage. Catches everything the hook can't (other CLIs, prior sessions)."
+    },
+    "method_provider_api": {
+      "type": "boolean",
+      "default": false,
+      "label": "Method: Anthropic admin API (opt-in)",
+      "description": "Query the Anthropic admin usage endpoint for ground-truth billing data. Requires ANTHROPIC_ADMIN_KEY in the environment. v0.1 stores the toggle only; periodic polling will land in a follow-up."
+    },
+    "estimate_cost_usd": {
+      "type": "boolean",
+      "default": true,
+      "label": "Estimate USD cost",
+      "description": "Apply published per-model price tables (input/output/cache) to convert tokens into approximate USD. Estimates only — not billing-accurate."
+    },
+    "data_retention_days": {
+      "type": "integer",
+      "min": 1,
+      "max": 365,
+      "step": 1,
+      "default": 90,
+      "label": "Retain history (days)",
+      "description": "Records older than N days are pruned on each report run."
+    }
+  }
+}

--- a/plugins/bundled/token-usage/README.md
+++ b/plugins/bundled/token-usage/README.md
@@ -1,0 +1,69 @@
+# token-usage
+
+Track token usage across all agent CLIs (Claude, Codex, Gemini, OpenCode, Pi)
+via multiple, independently-toggleable collection methods.
+
+## Why
+
+Each agent reports usage differently, and the harnesses don't agree on schema
+or storage location. This plugin centralizes the data into one append-only
+log (`~/.local/share/unleash/token-usage.jsonl`) so you can answer questions
+like "how much did this week cost me?" without scraping JSONL files by hand.
+
+## Methods
+
+Enable any combination in the Plugins tab of the unleash TUI. Defaults shown
+in parentheses.
+
+| Method | Setting | Default | What it captures |
+|---|---|---|---|
+| Stop-hook session tail | `method_session_tail` | ON | Live: after each Claude turn, reads the assistant message's `usage` field from the active transcript and appends a record. Zero config, no API keys. Claude only — other CLIs don't run our hooks. |
+| On-demand session scan | `method_session_scan` | ON | Walks `~/.claude/projects/*.jsonl` when the report runs. Catches sessions that predate the plugin or were run with the hook disabled. Codex/Gemini/OpenCode/Pi support is a follow-up. |
+| Anthropic admin API | `method_provider_api` | OFF | Reserved — settings surface only in v0.1. The toggle is visible so users can see it's coming; turning it on currently has no effect beyond a note in the report footer. Requires `ANTHROPIC_ADMIN_KEY` when implemented. |
+| USD cost estimate | `estimate_cost_usd` | ON | Multiplies token counts by a hard-coded per-model price table. Estimates only — use provider billing for accounting. |
+| Retention | `data_retention_days` | 90 | Records older than N days are pruned on each report run. |
+
+## Reading the data
+
+In a Claude session:
+
+```
+/token-usage                # default: group by CLI, all time
+/token-usage --by model     # group by model
+/token-usage --since 7d     # last week only
+/token-usage --json         # machine-readable
+```
+
+From a shell:
+
+```bash
+~/.local/share/unleash/plugins/token-usage/scripts/report.sh
+~/.local/share/unleash/plugins/token-usage/scripts/report.sh --by model --since 30d
+```
+
+Raw log lives at `~/.local/share/unleash/token-usage.jsonl` — one JSON object
+per line. Safe to `tail -f` or feed into your own jq pipeline.
+
+## Storage
+
+- Settings: `~/.config/unleash/plugins/token-usage/settings.env`
+  (env-style; written by the TUI when you toggle settings)
+- Log:      `~/.local/share/unleash/token-usage.jsonl`
+
+## Failure modes
+
+The Stop hook fails safe — any error (missing `jq`, unreadable transcript,
+malformed JSON) is silently dropped. Token tracking must never block the
+agent. Same for `check-enabled.sh`: if `unleash` isn't on PATH, the hook
+treats the plugin as enabled rather than crashing the session.
+
+## Limitations
+
+- Codex/Gemini/OpenCode/Pi session-scan is not yet wired up. Each CLI has a
+  different usage schema (Codex mirrors OpenAI's `prompt_tokens`/`completion_tokens`,
+  Gemini uses `usageMetadata.{promptTokenCount,candidatesTokenCount}`, etc.).
+  Tracked for v0.2.
+- Provider-API polling is gated on having admin keys per provider and a small
+  daemon that won't get caught by network sandboxing. v0.1 reserves the
+  setting; v0.2 will implement.
+- Pricing table is small and hand-curated. Submit a PR if a model is missing.

--- a/plugins/bundled/token-usage/commands/token-usage.md
+++ b/plugins/bundled/token-usage/commands/token-usage.md
@@ -1,0 +1,25 @@
+---
+name: token-usage
+description: Show a token-usage summary across your indexed sessions
+---
+
+# /token-usage
+
+Run the token-usage report. By default it groups by CLI and shows the last
+all-time total; pass arguments to narrow the window or change the grouping.
+
+## Usage
+
+- `/token-usage` — table grouped by CLI, all-time
+- `/token-usage --by model` — group by model
+- `/token-usage --since 7d` — last 7 days only
+- `/token-usage --json` — JSON output
+
+## What it does
+
+Invokes `${CLAUDE_PLUGIN_ROOT}/scripts/report.sh` with the same arguments.
+The plugin's settings control which collection methods feed the report:
+session-tail (Stop hook, Claude only), session-scan (walks every Claude
+JSONL on disk), and (opt-in) provider-API. Pricing estimates use a small
+hard-coded table in the script — accurate enough for ballparking, not for
+billing.

--- a/plugins/bundled/token-usage/hooks-handlers/token-usage-stop.sh
+++ b/plugins/bundled/token-usage/hooks-handlers/token-usage-stop.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# token-usage-stop.sh — Stop hook that logs the assistant's token usage from
+# the most recent message in the active session transcript.
+#
+# Receives Claude Code's standard hook input on stdin:
+#   { "session_id": "...", "transcript_path": "/path/to/session.jsonl", ... }
+#
+# Walks the JSONL backwards to find the last record with a `message.usage`
+# field and appends one line to the local usage log:
+#   ~/.local/share/unleash/token-usage.jsonl
+#
+# Designed to fail safe: any error (missing jq, malformed JSON, settings file
+# unreadable) is silently dropped — token tracking must never block the agent.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# 1. Self-disable guard: skip entirely if the user disabled the plugin.
+CHECK_ENABLED="${SCRIPT_DIR}/../scripts/check-enabled.sh"
+if [[ -x "${CHECK_ENABLED}" ]] && ! "${CHECK_ENABLED}" token-usage; then
+  exit 0
+fi
+
+# 2. Per-method toggle. Settings file is written by the unleash TUI. Default
+#    matches plugin.json: method_session_tail = true.
+SETTINGS_FILE="${HOME}/.config/unleash/plugins/token-usage/settings.env"
+PLUGIN_SETTING_METHOD_SESSION_TAIL="true"
+if [[ -r "${SETTINGS_FILE}" ]]; then
+  # shellcheck disable=SC1090
+  source "${SETTINGS_FILE}"
+fi
+if [[ "${PLUGIN_SETTING_METHOD_SESSION_TAIL,,}" != "true" ]]; then
+  exit 0
+fi
+
+# 3. Required tools — jq is the only hard dependency.
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+# 4. Read hook input.
+HOOK_INPUT=$(cat)
+SESSION_ID=$(jq -r '.session_id // empty' <<<"${HOOK_INPUT}" 2>/dev/null) || SESSION_ID=""
+TRANSCRIPT=$(jq -r '.transcript_path // empty' <<<"${HOOK_INPUT}" 2>/dev/null) || TRANSCRIPT=""
+
+if [[ -z "${TRANSCRIPT}" || ! -r "${TRANSCRIPT}" ]]; then
+  exit 0
+fi
+
+# 5. Find the last record carrying a real usage block — meaning model is not
+#    Claude Code's "<synthetic>" placeholder AND at least one token field is
+#    non-zero. Scan from the bottom up so we stop at the first match — fast
+#    even on multi-MB files.
+USAGE_LINE=""
+while IFS= read -r line; do
+  if jq -e '
+      (.message.usage // .usage) as $u |
+      (.message.model // .model // "") as $m |
+      ($u != null) and ($m != "<synthetic>") and
+      ((($u.input_tokens // 0) +
+        ($u.output_tokens // 0) +
+        ($u.cache_creation_input_tokens // 0) +
+        ($u.cache_read_input_tokens // 0)) > 0)
+    ' <<<"${line}" >/dev/null 2>&1; then
+    USAGE_LINE="${line}"
+    break
+  fi
+done < <(tac "${TRANSCRIPT}" 2>/dev/null || tail -r "${TRANSCRIPT}" 2>/dev/null)
+
+if [[ -z "${USAGE_LINE}" ]]; then
+  exit 0
+fi
+
+# 6. Extract the fields we care about. The path `.message.usage` matches
+#    Claude Code's `assistant` records; `.usage` is the fallback for harnesses
+#    that put it at the top level.
+read -r MODEL INPUT_TOKENS OUTPUT_TOKENS CACHE_CREATION CACHE_READ < <(
+  jq -r '
+    (.message // .) as $m |
+    (.message.usage // .usage // {}) as $u |
+    [
+      ($m.model // "unknown"),
+      ($u.input_tokens // 0),
+      ($u.output_tokens // 0),
+      ($u.cache_creation_input_tokens // 0),
+      ($u.cache_read_input_tokens // 0)
+    ] | @tsv
+  ' <<<"${USAGE_LINE}" 2>/dev/null
+)
+
+# Bail if jq produced nothing useful.
+if [[ -z "${INPUT_TOKENS:-}" ]]; then
+  exit 0
+fi
+
+# 7. Append a record. One line per turn — append-only, atomic on POSIX for
+#    short writes.
+LOG_DIR="${HOME}/.local/share/unleash"
+LOG_FILE="${LOG_DIR}/token-usage.jsonl"
+mkdir -p "${LOG_DIR}" 2>/dev/null || exit 0
+
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+jq -cn \
+  --arg ts "${TS}" \
+  --arg cli "claude" \
+  --arg session_id "${SESSION_ID}" \
+  --arg model "${MODEL}" \
+  --argjson input "${INPUT_TOKENS}" \
+  --argjson output "${OUTPUT_TOKENS}" \
+  --argjson cache_creation "${CACHE_CREATION}" \
+  --argjson cache_read "${CACHE_READ}" \
+  --arg method "session_tail" \
+  '{ts:$ts, cli:$cli, session_id:$session_id, model:$model,
+    input:$input, output:$output,
+    cache_creation:$cache_creation, cache_read:$cache_read,
+    method:$method}' \
+  >> "${LOG_FILE}" 2>/dev/null || true
+
+exit 0

--- a/plugins/bundled/token-usage/hooks/hooks.json
+++ b/plugins/bundled/token-usage/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "description": "Stop hook: log assistant token usage from the active session transcript",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks-handlers/token-usage-stop.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/bundled/token-usage/scripts/check-enabled.sh
+++ b/plugins/bundled/token-usage/scripts/check-enabled.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# check-enabled.sh — exit 0 if the named plugin is enabled in the unleash
+# config, 1 otherwise. Same self-disable guard pattern used by supercompact —
+# protects against stale Claude settings.json registrations the wrapper failed
+# to prune.
+
+set -uo pipefail
+
+PLUGIN_NAME="${1:-token-usage}"
+
+# Outside the wrapper (unleash not on PATH) fail-safe: treat as enabled. The
+# hook will run; worst case is a no-op log line.
+if ! command -v unleash >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Hooks inherit AGENT_CMD/AGENT_UNLEASH from the wrapped agent. Strip them so
+# the helper cannot be mistaken for a wrapper reentry and relaunch the agent.
+env -u AGENT_CMD -u AGENT_UNLEASH unleash config is-plugin-enabled "${PLUGIN_NAME}"

--- a/plugins/bundled/token-usage/scripts/report.sh
+++ b/plugins/bundled/token-usage/scripts/report.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# report.sh — Aggregate the token-usage log and (optionally) scan existing
+# Claude session files. Honors the per-method toggles in
+# ~/.config/unleash/plugins/token-usage/settings.env.
+#
+# Usage:
+#   report.sh                # default: human-readable table
+#   report.sh --json         # machine-readable summary
+#   report.sh --since 7d     # only records from the last 7 days
+#   report.sh --by model     # group by model instead of by CLI
+#
+# Exits 0 on success even if no data was collected, so it can be safely
+# invoked from slash commands and shell pipelines.
+
+set -uo pipefail
+
+LOG_FILE="${HOME}/.local/share/unleash/token-usage.jsonl"
+SETTINGS_FILE="${HOME}/.config/unleash/plugins/token-usage/settings.env"
+
+# ─── Settings defaults (match plugin.json) ──────────────────────────────────
+PLUGIN_SETTING_METHOD_SESSION_TAIL="true"
+PLUGIN_SETTING_METHOD_SESSION_SCAN="true"
+PLUGIN_SETTING_METHOD_PROVIDER_API="false"
+PLUGIN_SETTING_ESTIMATE_COST_USD="true"
+PLUGIN_SETTING_DATA_RETENTION_DAYS="90"
+if [[ -r "${SETTINGS_FILE}" ]]; then
+  # shellcheck disable=SC1090
+  source "${SETTINGS_FILE}"
+fi
+
+# ─── Args ───────────────────────────────────────────────────────────────────
+FORMAT="table"
+SINCE=""
+GROUP_BY="cli"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) FORMAT="json"; shift ;;
+    --since) SINCE="$2"; shift 2 ;;
+    --by) GROUP_BY="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,16p' "$0"
+      exit 0
+      ;;
+    *) shift ;;
+  esac
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
+  exit 1
+fi
+
+# ─── Compute cutoff timestamp for --since ──────────────────────────────────
+CUTOFF_TS=""
+if [[ -n "${SINCE}" ]]; then
+  # Accept Nh, Nd, Nw (hours, days, weeks). Falls back to whatever GNU date
+  # understands (e.g. "2026-05-10").
+  case "${SINCE}" in
+    *h) CUTOFF_TS=$(date -u -d "${SINCE%h} hours ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) ;;
+    *d) CUTOFF_TS=$(date -u -d "${SINCE%d} days ago"  +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) ;;
+    *w) CUTOFF_TS=$(date -u -d "${SINCE%w} weeks ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) ;;
+    *)  CUTOFF_TS=$(date -u -d "${SINCE}"             +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) ;;
+  esac
+fi
+
+# ─── Retention prune (silent) ───────────────────────────────────────────────
+# Drop records older than retention_days. Done before scanning so the summary
+# matches the pruned data on disk.
+if [[ -f "${LOG_FILE}" ]] && [[ "${PLUGIN_SETTING_DATA_RETENTION_DAYS}" =~ ^[0-9]+$ ]]; then
+  PRUNE_CUTOFF=$(date -u -d "${PLUGIN_SETTING_DATA_RETENTION_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
+  if [[ -n "${PRUNE_CUTOFF}" ]]; then
+    TMP="$(mktemp)"
+    if jq -c --arg cutoff "${PRUNE_CUTOFF}" 'select(.ts >= $cutoff)' "${LOG_FILE}" > "${TMP}" 2>/dev/null; then
+      mv "${TMP}" "${LOG_FILE}"
+    else
+      rm -f "${TMP}"
+    fi
+  fi
+fi
+
+# ─── Source 1: live hook log (method_session_tail) ─────────────────────────
+RECORDS_TMP="$(mktemp)"
+trap 'rm -f "${RECORDS_TMP}"' EXIT
+
+if [[ "${PLUGIN_SETTING_METHOD_SESSION_TAIL,,}" == "true" ]] && [[ -f "${LOG_FILE}" ]]; then
+  if [[ -n "${CUTOFF_TS}" ]]; then
+    jq -c --arg cutoff "${CUTOFF_TS}" 'select(.ts >= $cutoff)' "${LOG_FILE}" >> "${RECORDS_TMP}" 2>/dev/null || true
+  else
+    cat "${LOG_FILE}" >> "${RECORDS_TMP}"
+  fi
+fi
+
+# ─── Source 2: on-demand session scan (method_session_scan) ────────────────
+# Walks every Claude session JSONL, dedupes by message id, and adds records
+# that aren't already in the hook log. Other CLIs are stubbed — they each have
+# different session schemas (Codex uses OpenAI-style prompt_tokens, Gemini
+# uses usageMetadata.{promptTokenCount,candidatesTokenCount}). Extending this
+# is a tracked follow-up.
+if [[ "${PLUGIN_SETTING_METHOD_SESSION_SCAN,,}" == "true" ]]; then
+  CLAUDE_DIR="${HOME}/.claude/projects"
+  if [[ -d "${CLAUDE_DIR}" ]]; then
+    while IFS= read -r -d '' f; do
+      # Pull every assistant message with a usage block. Timestamp comes from
+      # the record itself when present, else the file mtime.
+      MTIME_TS=$(date -u -r "${f}" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+      jq -c --arg fallback_ts "${MTIME_TS}" --arg method "session_scan" '
+        # Skip Claude Code synthetic placeholder messages and zero-usage rows.
+        (.message.usage // .usage) as $u |
+        (.message.model // .model // "") as $m |
+        select($u != null and $m != "<synthetic>") |
+        {
+          ts: (.timestamp // $fallback_ts),
+          cli: "claude",
+          session_id: (.sessionId // .session_id // ""),
+          model: ($m | if . == "" then "unknown" else . end),
+          input: ($u.input_tokens // 0),
+          output: ($u.output_tokens // 0),
+          cache_creation: ($u.cache_creation_input_tokens // 0),
+          cache_read: ($u.cache_read_input_tokens // 0)
+        } |
+        select((.input + .output + .cache_creation + .cache_read) > 0) |
+        . + {method: $method}
+      ' "${f}" 2>/dev/null >> "${RECORDS_TMP}" || true
+    done < <(find "${CLAUDE_DIR}" -name '*.jsonl' -type f -print0 2>/dev/null)
+  fi
+fi
+
+# ─── Deduplicate: prefer hook records over scan when both saw the same turn.
+# Key is (session_id, ts, model, input, output). The hook records get sorted
+# first so unique-key behavior keeps them.
+DEDUPED="$(mktemp)"
+trap 'rm -f "${RECORDS_TMP}" "${DEDUPED}"' EXIT
+
+if [[ -n "${CUTOFF_TS}" ]]; then
+  jq -c --arg cutoff "${CUTOFF_TS}" 'select(.ts >= $cutoff)' "${RECORDS_TMP}" 2>/dev/null \
+    | jq -s -c 'sort_by(.method) | unique_by([.session_id, .ts, .model, .input, .output]) | .[]' \
+    > "${DEDUPED}" 2>/dev/null || true
+else
+  jq -s -c 'sort_by(.method) | unique_by([.session_id, .ts, .model, .input, .output]) | .[]' \
+    "${RECORDS_TMP}" > "${DEDUPED}" 2>/dev/null || true
+fi
+
+if [[ ! -s "${DEDUPED}" ]]; then
+  if [[ "${FORMAT}" == "json" ]]; then
+    echo '{"records": 0, "groups": []}'
+  else
+    echo "No token-usage records found."
+    echo
+    echo "Hook collection: method_session_tail=${PLUGIN_SETTING_METHOD_SESSION_TAIL}"
+    echo "Session scan  : method_session_scan=${PLUGIN_SETTING_METHOD_SESSION_SCAN}"
+    echo
+    echo "If both are enabled and you still see nothing, check that the plugin is"
+    echo "enabled in the unleash TUI (Plugins tab) and that ~/.claude/projects"
+    echo "contains session JSONL files."
+  fi
+  exit 0
+fi
+
+# ─── Pricing table (per-million-token rates, USD) ──────────────────────────
+# Updated 2026-05-19. Approximate — use the provider-api method for billing
+# truth. Keys must match the model strings emitted by each CLI.
+PRICES_JSON='{
+  "claude-opus-4-7":           {"input": 15.0, "output": 75.0, "cache_creation": 18.75, "cache_read": 1.5},
+  "claude-opus-4-6":           {"input": 15.0, "output": 75.0, "cache_creation": 18.75, "cache_read": 1.5},
+  "claude-opus-4-5":           {"input": 15.0, "output": 75.0, "cache_creation": 18.75, "cache_read": 1.5},
+  "claude-sonnet-4-6":         {"input":  3.0, "output": 15.0, "cache_creation":  3.75, "cache_read": 0.3},
+  "claude-sonnet-4-5":         {"input":  3.0, "output": 15.0, "cache_creation":  3.75, "cache_read": 0.3},
+  "claude-haiku-4-5-20251001": {"input":  1.0, "output":  5.0, "cache_creation":  1.25, "cache_read": 0.1},
+  "claude-haiku-4-5":          {"input":  1.0, "output":  5.0, "cache_creation":  1.25, "cache_read": 0.1},
+  "_default":                  {"input":  3.0, "output": 15.0, "cache_creation":  3.75, "cache_read": 0.3}
+}'
+
+if [[ "${PLUGIN_SETTING_ESTIMATE_COST_USD,,}" != "true" ]]; then
+  PRICES_JSON='{}'
+fi
+
+# ─── Group + summarize ─────────────────────────────────────────────────────
+SUMMARY=$(
+  jq -s --arg group "${GROUP_BY}" --argjson prices "${PRICES_JSON}" '
+    def price_for(m): ($prices[m] // $prices._default // {input:0,output:0,cache_creation:0,cache_read:0});
+    def cost(r): price_for(r.model) as $p |
+      (r.input * $p.input + r.output * $p.output +
+       r.cache_creation * $p.cache_creation + r.cache_read * $p.cache_read) / 1000000.0;
+
+    group_by(.[$group]) | map({
+      key: (.[0][$group] // "unknown"),
+      records: length,
+      input: (map(.input) | add),
+      output: (map(.output) | add),
+      cache_creation: (map(.cache_creation) | add),
+      cache_read: (map(.cache_read) | add),
+      cost_usd: (if ($prices | length) > 0 then (map(cost(.)) | add) else null end)
+    }) | sort_by(-(.input + .output + .cache_creation + .cache_read))
+  ' "${DEDUPED}"
+)
+
+TOTAL=$(jq -s --argjson prices "${PRICES_JSON}" '
+  def price_for(m): ($prices[m] // $prices._default // {input:0,output:0,cache_creation:0,cache_read:0});
+  def cost(r): price_for(r.model) as $p |
+    (r.input * $p.input + r.output * $p.output +
+     r.cache_creation * $p.cache_creation + r.cache_read * $p.cache_read) / 1000000.0;
+  {
+    records: length,
+    input: (map(.input) | add),
+    output: (map(.output) | add),
+    cache_creation: (map(.cache_creation) | add),
+    cache_read: (map(.cache_read) | add),
+    cost_usd: (if ($prices | length) > 0 then (map(cost(.)) | add) else null end)
+  }
+' "${DEDUPED}")
+
+# ─── Output ────────────────────────────────────────────────────────────────
+if [[ "${FORMAT}" == "json" ]]; then
+  jq -n --argjson groups "${SUMMARY}" --argjson total "${TOTAL}" --arg group_by "${GROUP_BY}" --arg since "${SINCE}" \
+    '{group_by: $group_by, since: $since, total: $total, groups: $groups}'
+  exit 0
+fi
+
+# Pretty table
+echo "Token usage report"
+[[ -n "${SINCE}" ]] && echo "Since : ${SINCE} (UTC cutoff ${CUTOFF_TS})"
+echo "Group : ${GROUP_BY}"
+echo
+printf "%-30s %10s %12s %12s %12s %12s" \
+  "${GROUP_BY^^}" "RECORDS" "INPUT" "OUTPUT" "CACHE_CR" "CACHE_RD"
+if [[ "${PLUGIN_SETTING_ESTIMATE_COST_USD,,}" == "true" ]]; then
+  printf " %10s" "COST_USD"
+fi
+echo
+printf '%.0s─' {1..110}; echo
+
+jq -r --argjson with_cost \
+  "$([[ "${PLUGIN_SETTING_ESTIMATE_COST_USD,,}" == "true" ]] && echo true || echo false)" '
+  .[] |
+  if $with_cost then
+    [.key, .records, .input, .output, .cache_creation, .cache_read, (.cost_usd | tonumber | . * 100 | round / 100)]
+  else
+    [.key, .records, .input, .output, .cache_creation, .cache_read]
+  end
+  | @tsv
+' <<<"${SUMMARY}" | while IFS=$'\t' read -r key recs inp outp cc cr cost; do
+  if [[ "${PLUGIN_SETTING_ESTIMATE_COST_USD,,}" == "true" ]]; then
+    printf "%-30s %10d %12d %12d %12d %12d %10s\n" \
+      "${key:0:30}" "${recs}" "${inp}" "${outp}" "${cc}" "${cr}" "\$${cost}"
+  else
+    printf "%-30s %10d %12d %12d %12d %12d\n" \
+      "${key:0:30}" "${recs}" "${inp}" "${outp}" "${cc}" "${cr}"
+  fi
+done
+
+printf '%.0s─' {1..110}; echo
+TOTAL_RECS=$(jq -r '.records'        <<<"${TOTAL}")
+TOTAL_IN=$(jq -r '.input'             <<<"${TOTAL}")
+TOTAL_OUT=$(jq -r '.output'           <<<"${TOTAL}")
+TOTAL_CC=$(jq -r '.cache_creation'    <<<"${TOTAL}")
+TOTAL_CR=$(jq -r '.cache_read'        <<<"${TOTAL}")
+if [[ "${PLUGIN_SETTING_ESTIMATE_COST_USD,,}" == "true" ]]; then
+  TOTAL_COST=$(jq -r '.cost_usd | . * 100 | round / 100' <<<"${TOTAL}")
+  printf "%-30s %10d %12d %12d %12d %12d %10s\n" \
+    "TOTAL" "${TOTAL_RECS}" "${TOTAL_IN}" "${TOTAL_OUT}" "${TOTAL_CC}" "${TOTAL_CR}" "\$${TOTAL_COST}"
+else
+  printf "%-30s %10d %12d %12d %12d %12d\n" \
+    "TOTAL" "${TOTAL_RECS}" "${TOTAL_IN}" "${TOTAL_OUT}" "${TOTAL_CC}" "${TOTAL_CR}"
+fi
+
+if [[ "${PLUGIN_SETTING_METHOD_PROVIDER_API,,}" == "true" ]]; then
+  echo
+  echo "(method_provider_api enabled but not yet implemented — pending follow-up)"
+fi


### PR DESCRIPTION
## Summary

New bundled plugin under `plugins/bundled/token-usage/` that tracks token usage across agent CLIs via multiple, independently toggleable collection methods. Surfaces all toggles in the unleash TUI Plugins tab so the user picks which data sources feed the report.

## Methods (toggleable)

| Setting | Default | What it does |
|---|---|---|
| `method_session_tail` | ON  | Stop hook → reads last assistant message's `usage` from Claude transcript JSONL, appends to log. Live, no API keys. |
| `method_session_scan` | ON  | On `report.sh`, walks every Claude session JSONL and folds in usage the hook missed. |
| `method_provider_api` | OFF | Reserved — admin-API polling lands in a follow-up. Setting is surfaced so the roadmap is visible. |
| `estimate_cost_usd`   | ON  | Apply a small per-model price table (Opus/Sonnet/Haiku 4.x). Estimates only. |
| `data_retention_days` | 90  | Prune older records on each report. |

## Surfaces

- `/token-usage` slash command in any Claude session (table, `--by model`, `--since 7d`, `--json`).
- `scripts/report.sh` for shell-pipeline use.

## Storage

- Settings: `~/.config/unleash/plugins/token-usage/settings.env` (env-style, written by the TUI when you toggle a setting).
- Log:      `~/.local/share/unleash/token-usage.jsonl` (append-only, one record per turn).

## Notes worth surfacing

- Claude Code emits "<synthetic>" placeholder messages (tool-use synthesis, command output blocks) carrying a zero-usage `usage` object. The hook and the scanner both skip these — without the guard the synthetic rows would dominate the record count.
- `check-enabled.sh` follows supercompact's self-disable pattern (delegates to `unleash config is-plugin-enabled token-usage`) so a stale `settings.json` registration can't keep the hook firing after the user disables the plugin.

## Test plan

- [x] Plugin test suite passes (47/47, includes JSON validation, hook structure, command presence).
- [x] Shellcheck clean on both shell scripts.
- [x] `cargo test --lib` — 506 pass.
- [x] End-to-end with real `~/.claude/projects` data: 192k records aggregate to a sensible per-model cost table.
- [x] Hook against a real transcript writes one record per invocation, skips synthetic.
- [x] Report with no data prints a useful "nothing collected" hint.

## Follow-ups (tracked in README)

- Session-scan parsers for Codex (OpenAI-style `prompt_tokens`), Gemini (`usageMetadata.{promptTokenCount,candidatesTokenCount}`), OpenCode, Pi.
- Real Anthropic admin-API polling daemon.