### PR TITLE
ci: memory profiling script and workflow

### DIFF
--- a/.github/workflows/memory-profile.yml
+++ b/.github/workflows/memory-profile.yml
@@ -1,0 +1,65 @@
+name: Memory Profiling
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'scripts/memory_profile.sh'
+      - '.github/workflows/memory-profile.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'scripts/memory_profile.sh'
+      - '.github/workflows/memory-profile.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  profile:
+    name: Memory Profiling
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y time nodejs npm
+          # Install agents
+          npm install -g @google/gemini-cli @mariozechner/pi-coding-agent opencode-ai
+
+      - name: Install Codex and Claude
+        run: |
+          # Install Hermes Agent
+          curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup
+          # Build unleash for profiling
+          cargo build --profile fast
+          # Use unleash to install claude and codex
+          ./target/fast/unleash install claude codex || true
+
+      - name: Make script executable
+        run: chmod +x scripts/memory_profile.sh
+
+      - name: Run Memory Profiling
+        run: |
+          ./scripts/memory_profile.sh | tee memory-profile.txt
+          
+      - name: Add to Step Summary
+        run: |
+          {
+            echo "## Memory Profiling Results"
+            echo '```text'
+            cat memory-profile.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/memory_profile.sh
+++ b/scripts/memory_profile.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script measures and compares the memory usage (Maximum Resident Set Size)
+# of running each supported CLI directly vs running it through the unleash wrapper.
+
+if ! command -v /usr/bin/time >/dev/null 2>&1; then
+    echo "Error: /usr/bin/time is required. Please install it (e.g. apt-get install time)."
+    exit 1
+fi
+
+AGENTS=("claude" "codex" "gemini" "opencode" "pi" "hermes")
+
+echo "=========================================================="
+echo " Memory Profiling: Unleash Wrapper vs Direct CLI"
+echo "=========================================================="
+printf "%-15s | %-15s | %-15s | %-15s\n" "Agent" "Direct (KB)" "Wrapped (KB)" "Overhead (KB)"
+echo "----------------------------------------------------------"
+
+has_measured=0
+
+for agent in "${AGENTS[@]}"; do
+    if command -v "$agent" >/dev/null 2>&1; then
+        # We use an invalid flag so the agent prints an error and exits immediately
+        # without hanging on interactive inputs or making API calls.
+        DIRECT_CMD="--invalid-flag-for-mem-test"
+        WRAPPED_CMD="-- --invalid-flag-for-mem-test"
+
+        # Measure direct CLI
+        direct_out=$(mktemp)
+        env -u AGENT_UNLEASH -u AGENT_CMD /usr/bin/time -v "$agent" $DIRECT_CMD < /dev/null 2> "$direct_out" >/dev/null || true
+        direct_mem=$(grep "Maximum resident set size" "$direct_out" | awk '{print $6}' || echo "")
+        rm -f "$direct_out"
+
+        # Measure wrapped CLI
+        wrapped_out=$(mktemp)
+        UNLEASH_CMD="unleash"
+        if [ -x "./target/release/unleash" ]; then
+            UNLEASH_CMD="./target/release/unleash"
+        elif [ -x "./target/fast/unleash" ]; then
+            UNLEASH_CMD="./target/fast/unleash"
+        fi
+        
+        env -u AGENT_UNLEASH -u AGENT_CMD /usr/bin/time -v "$UNLEASH_CMD" "$agent" $WRAPPED_CMD < /dev/null 2> "$wrapped_out" >/dev/null || true
+        wrapped_mem=$(grep "Maximum resident set size" "$wrapped_out" | awk '{print $6}' || echo "")
+        rm -f "$wrapped_out"
+
+        if [ -n "$direct_mem" ] && [ -n "$wrapped_mem" ]; then
+            overhead=$((wrapped_mem - direct_mem))
+            printf "%-15s | %-15s | %-15s | %+d\n" "$agent" "$direct_mem" "$wrapped_mem" "${overhead}"
+            has_measured=1
+        else
+            printf "%-15s | %-15s | %-15s | %-15s\n" "$agent" "${direct_mem:-ERROR}" "${wrapped_mem:-ERROR}" "N/A"
+        fi
+    else
+        printf "%-15s | %-15s | %-15s | %-15s\n" "$agent" "SKIP (missing)" "N/A" "N/A"
+    fi
+done
+
+echo "=========================================================="
+
+if [ "$has_measured" -eq 0 ]; then
+    echo "No CLIs were found to measure."
+    exit 0
+fi


### PR DESCRIPTION
## Summary

Adds a memory profiling script and GitHub Actions workflow to track the overhead of the `unleash` wrapper.

1. **`scripts/memory_profile.sh`**:
   - Compares the `Maximum resident set size` of the direct agent CLI (e.g. `claude --invalid-flag-for-mem-test`) against the wrapped invocation (`unleash claude -- --invalid-flag-for-mem-test`).
   - The invalid flag ensures the underlying agent CLI launches and exits fast without hanging on network/interactive prompts, capturing the peak memory at startup.

2. **`.github/workflows/memory-profile.yml`**:
   - Runs the profiling script on Ubuntu.
   - Installs the agents (npm and curl).
   - Adds the profile output table to the GitHub Step Summary.

This provides transparency that the Rust-based wrapper adds almost no memory overhead to the Python/Node-based agents.