### PR TITLE
fix(crossload): track source_updated_at in idempotency cache and pi crossload fixes

### DIFF
--- a/src/interchange/crossload_index.rs
+++ b/src/interchange/crossload_index.rs
@@ -27,6 +27,10 @@ pub struct Entry {
     /// Absolute path to the target file/db row we wrote. Empty for DB-backed
     /// targets (OpenCode) where there is no single representative file.
     pub target_path: String,
+    /// The `updated_at` timestamp of the source session at the time of crossload.
+    /// Used to invalidate the cache if the source session receives new messages.
+    #[serde(default)]
+    pub source_updated_at: Option<String>,
 }
 
 fn key(source_cli: &str, source_id: &str, target_cli: &str) -> String {
@@ -80,12 +84,14 @@ impl CrossloadIndex {
         target_cli: &str,
         target_session_id: String,
         target_path: String,
+        source_updated_at: Option<String>,
     ) {
         self.entries.insert(
             key(source_cli, source_id, target_cli),
             Entry {
                 target_session_id,
                 target_path,
+                source_updated_at,
             },
         );
     }
@@ -121,6 +127,7 @@ mod tests {
             "claude",
             "sess-1".into(),
             "/tmp/sess-1.jsonl".into(),
+            None,
         );
         idx.record(
             "pi",
@@ -128,6 +135,7 @@ mod tests {
             "gemini",
             "sess-2".into(),
             "/tmp/chats/sess-2.json".into(),
+            None,
         );
         save_to(&idx, &path).unwrap();
 
@@ -159,22 +167,22 @@ mod tests {
     }
 
     #[test]
-    fn remove_drops_entry() {
+    fn test_remove() {
         let mut idx = CrossloadIndex::default();
-        idx.record("a", "b", "c", "d".into(), String::new());
+        idx.record("a", "b", "c", "d".into(), String::new(), None);
         assert!(idx.lookup("a", "b", "c").is_some());
         idx.remove("a", "b", "c");
         assert!(idx.lookup("a", "b", "c").is_none());
     }
 
     #[test]
-    fn re_record_overwrites_in_place() {
+    fn test_record_overwrites() {
         let mut idx = CrossloadIndex::default();
-        idx.record("a", "b", "c", "first".into(), "/tmp/one".into());
-        idx.record("a", "b", "c", "second".into(), "/tmp/two".into());
-        let e = idx.lookup("a", "b", "c").unwrap();
-        assert_eq!(e.target_session_id, "second");
-        assert_eq!(e.target_path, "/tmp/two");
+        idx.record("a", "b", "c", "first".into(), "/tmp/one".into(), None);
+        idx.record("a", "b", "c", "second".into(), "/tmp/two".into(), None);
+        let entry = idx.lookup("a", "b", "c").unwrap();
+        assert_eq!(entry.target_session_id, "second");
+        assert_eq!(entry.target_path, "/tmp/two");
     }
 
     #[test]
@@ -186,14 +194,17 @@ mod tests {
         let live = Entry {
             target_session_id: "s".into(),
             target_path: real.to_string_lossy().into(),
+            source_updated_at: None,
         };
         let dead = Entry {
             target_session_id: "s".into(),
             target_path: "/nonexistent/ghost.jsonl".into(),
+            source_updated_at: None,
         };
         let db = Entry {
             target_session_id: "s".into(),
             target_path: String::new(),
+            source_updated_at: None,
         };
 
         assert!(entry_is_live(&live));

--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -44,22 +44,31 @@ pub fn inject_session(
     if !force {
         if let Some(entry) = index.lookup(&session.cli, &session.id, canonical_target) {
             if entry_is_live(entry) {
-                eprintln!(
-                    "Already crossloaded; reusing target session '{}' (set UNLEASH_CROSSLOAD_FORCE=1 to re-inject)",
-                    entry.target_session_id
-                );
-                return Ok(InjectionResult {
-                    session_id: entry.target_session_id.clone(),
-                    resume_args: resume_args_for(canonical_target, &entry.target_session_id),
-                    message: format!(
-                        "Reused cached crossload of '{}' from {} into {}",
-                        session.name.as_deref().unwrap_or(&session.id),
-                        session.cli,
-                        canonical_target,
-                    ),
-                });
+                // If the cached entry doesn't record the source updated_at or if it doesn't match the current session's updated_at,
+                // the source session has been updated since the crossload. We need to re-crossload.
+                if entry.source_updated_at.as_deref() == Some(&*session.updated_at) {
+                    eprintln!(
+                        "Already crossloaded; reusing target session '{}' (set UNLEASH_CROSSLOAD_FORCE=1 to re-inject)",
+                        entry.target_session_id
+                    );
+                    return Ok(InjectionResult {
+                        session_id: entry.target_session_id.clone(),
+                        resume_args: resume_args_for(canonical_target, &entry.target_session_id),
+                        message: format!(
+                            "Reused cached crossload of '{}' from {} into {}",
+                            session.name.as_deref().unwrap_or(&session.id),
+                            session.cli,
+                            canonical_target,
+                        ),
+                    });
+                } else {
+                    eprintln!(
+                        "Source session has been updated since last crossload; re-injecting into {}",
+                        canonical_target
+                    );
+                }
             }
-            // Cached target is gone; drop the stale entry and fall through.
+            // Cached target is gone or stale; drop the stale entry and fall through.
             index.remove(&session.cli, &session.id, canonical_target);
         }
     }
@@ -88,6 +97,7 @@ pub fn inject_session(
         canonical_target,
         result.session_id.clone(),
         target_path,
+        Some(session.updated_at.clone()),
     );
     if let Err(e) = crossload_index::save(&index) {
         eprintln!(
@@ -803,6 +813,14 @@ fn inject_into_opencode(
     ))
 }
 
+/// Soft cap on injected pi session size. Pi loads sessions via Node's
+/// `readFileSync(path, "utf8")`, which throws `ERR_STRING_TOO_LONG` past
+/// ~512 MB and OOMs the picker well before that. The cap also keeps
+/// the partial-UUID resolver fast — pi reads every file in the project
+/// dir to match a prefix, so one huge file can starve the rest.
+/// Tunable via `UNLEASH_PI_MAX_BYTES`.
+const PI_MAX_BYTES_DEFAULT: usize = 50 * 1024 * 1024;
+
 fn inject_into_pi(
     source: &SessionInfo,
     hub_records: &[HubRecord],
@@ -842,6 +860,15 @@ fn inject_into_pi(
         first.insert("timestamp".into(), serde_json::Value::String(ts.clone()));
         ts
     };
+
+    // Drop oldest records (after the header) until the serialized output fits
+    // pi's byte budget. Foreign source sessions can be hundreds of MB once
+    // converted — far past what pi can readFileSync at startup.
+    let max_bytes = std::env::var("UNLEASH_PI_MAX_BYTES")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(PI_MAX_BYTES_DEFAULT);
+    let dropped = trim_pi_lines_to_byte_budget(&mut pi_lines, max_bytes);
 
     // Regenerate the parentId chain: each non-session record gets a fresh id,
     // parentId links to the previous record's id (or null for the first).
@@ -890,18 +917,90 @@ fn inject_into_pi(
     );
 
     let target_path = output_path.to_string_lossy().to_string();
+    // Pass the full path as the resume handle. `pi --session <path|id>` accepts
+    // either, but pi's UUID resolver walks every file in the cwd's project dir
+    // to match a prefix — and any one outsized file crashes that walk with
+    // ERR_STRING_TOO_LONG, leaving freshly-injected sessions invisible. The
+    // path bypasses the walk entirely.
     Ok((
         InjectionResult {
-            session_id: session_id.clone(),
-            resume_args: vec!["--session".into(), session_id],
-            message: format!(
-                "Session '{}' from {} injected into Pi",
-                source.name.as_deref().unwrap_or(&source.id),
-                source.cli,
-            ),
+            session_id: target_path.clone(),
+            resume_args: vec!["--session".into(), target_path.clone()],
+            message: if dropped > 0 {
+                format!(
+                    "Session '{}' from {} injected into Pi ({} oldest records trimmed to fit {})",
+                    source.name.as_deref().unwrap_or(&source.id),
+                    source.cli,
+                    dropped,
+                    format_byte_budget(max_bytes),
+                )
+            } else {
+                format!(
+                    "Session '{}' from {} injected into Pi",
+                    source.name.as_deref().unwrap_or(&source.id),
+                    source.cli,
+                )
+            },
         },
         target_path,
     ))
+}
+
+fn format_byte_budget(bytes: usize) -> String {
+    const KB: usize = 1024;
+    const MB: usize = 1024 * KB;
+    if bytes >= MB {
+        format!("~{} MB", bytes / MB)
+    } else if bytes >= KB {
+        format!("~{} KB", bytes / KB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+/// Drop oldest non-header records until the serialized output fits `max_bytes`.
+/// Always preserves index 0 (the session header). Returns the number of
+/// records removed from the middle of the list.
+fn trim_pi_lines_to_byte_budget(
+    lines: &mut Vec<serde_json::Value>,
+    max_bytes: usize,
+) -> usize {
+    if lines.len() < 2 {
+        return 0;
+    }
+
+    let sizes: Vec<usize> = lines
+        .iter()
+        .map(|v| serde_json::to_string(v).map(|s| s.len() + 1).unwrap_or(0))
+        .collect();
+    let total: usize = sizes.iter().sum();
+    if total <= max_bytes {
+        return 0;
+    }
+
+    let header_size = sizes[0];
+    let available = max_bytes.saturating_sub(header_size);
+
+    let mut acc = 0usize;
+    let mut keep_from = lines.len();
+    for i in (1..lines.len()).rev() {
+        let next = acc.saturating_add(sizes[i]);
+        if next > available {
+            break;
+        }
+        acc = next;
+        keep_from = i;
+    }
+
+    let dropped = keep_from.saturating_sub(1);
+    if dropped == 0 {
+        return 0;
+    }
+
+    let suffix: Vec<serde_json::Value> = lines.drain(keep_from..).collect();
+    lines.truncate(1);
+    lines.extend(suffix);
+    dropped
 }
 
 /// Read a usable session timestamp from a Pi session header, falling back to
@@ -1698,6 +1797,60 @@ mod tests {
             "2026-04-27T19:00:00.000Z",
             "populated timestamp must be preserved as-is"
         );
+    }
+
+    #[test]
+    fn test_trim_pi_lines_under_budget_keeps_everything() {
+        let mut lines: Vec<serde_json::Value> = (0..10)
+            .map(|i| serde_json::json!({"type": "message", "n": i}))
+            .collect();
+        lines.insert(0, serde_json::json!({"type": "session", "id": "h"}));
+        let before = lines.len();
+        let dropped = trim_pi_lines_to_byte_budget(&mut lines, 10 * 1024 * 1024);
+        assert_eq!(dropped, 0);
+        assert_eq!(lines.len(), before);
+    }
+
+    #[test]
+    fn test_trim_pi_lines_over_budget_drops_oldest_keeps_header_and_tail() {
+        // Header + 50 message records, each ~50 bytes serialized. Budget of
+        // ~600 bytes after the header should keep roughly the last 10 records.
+        let header = serde_json::json!({"type": "session", "id": "h"});
+        let mut lines = vec![header.clone()];
+        for i in 0..50 {
+            lines.push(serde_json::json!({
+                "type": "message",
+                "id": format!("rec-{i:05}"),
+                "parentId": null,
+                "message": {"role": "user", "content": [{"type":"text","text":"x"}]}
+            }));
+        }
+        let total: usize = lines
+            .iter()
+            .map(|v| serde_json::to_string(v).unwrap().len() + 1)
+            .sum();
+        let budget = total / 5; // keep roughly the last 20%
+        let dropped = trim_pi_lines_to_byte_budget(&mut lines, budget);
+        assert!(dropped > 0, "expected some records to be dropped");
+        // Header still present and unchanged
+        assert_eq!(lines[0], header, "header must be preserved as first line");
+        // Tail order preserved
+        let last = lines.last().unwrap();
+        assert_eq!(last["id"], "rec-00049");
+        // Total bytes now under budget
+        let new_total: usize = lines
+            .iter()
+            .map(|v| serde_json::to_string(v).unwrap().len() + 1)
+            .sum();
+        assert!(new_total <= budget, "post-trim {new_total} > budget {budget}");
+    }
+
+    #[test]
+    fn test_trim_pi_lines_single_line_no_op() {
+        let mut lines = vec![serde_json::json!({"type": "session"})];
+        let dropped = trim_pi_lines_to_byte_budget(&mut lines, 1);
+        assert_eq!(dropped, 0);
+        assert_eq!(lines.len(), 1);
     }
 
     #[test]

--- a/src/interchange/sessions.rs
+++ b/src/interchange/sessions.rs
@@ -62,14 +62,24 @@ pub fn find_session(query: &str) -> Option<SessionInfo> {
         discover_all()
     };
 
-    // Match by ID, name, slug, or title (case-insensitive partial match)
+    // Match precedence: exact id > id prefix > exact name > substring of id/title.
+    // Two-pass so an exact match in one CLI beats a fuzzy title-contains match
+    // in another — important for pi, whose discovered ids are <TIMESTAMP>_<UUID>
+    // and need substring matching to be resolvable by the UUID alone.
     let name_lower = name.to_lowercase();
-    sessions.into_iter().find(|s| {
+
+    if let Some(s) = sessions.iter().find(|s| {
         s.id.to_lowercase() == name_lower
             || s.id.to_lowercase().starts_with(&name_lower)
             || s.name
                 .as_ref()
                 .is_some_and(|n| n.to_lowercase() == name_lower)
+    }) {
+        return Some(s.clone());
+    }
+
+    sessions.into_iter().find(|s| {
+        s.id.to_lowercase().contains(&name_lower)
             || s.title
                 .as_ref()
                 .is_some_and(|t| t.to_lowercase().contains(&name_lower))
@@ -77,6 +87,16 @@ pub fn find_session(query: &str) -> Option<SessionInfo> {
 }
 
 // === Claude Code discovery ===
+
+/// True if a claude session file's stem identifies a rotated/backup variant
+/// rather than a live session. These appear under `.jsonl` extension but the
+/// stem retains the suffix, e.g. `<uuid>.archive`. Picking them up dumps stale
+/// (often hundreds of MB) history into the picker — and into pi if crossloaded.
+fn is_claude_backup_stem(stem: &str) -> bool {
+    stem.ends_with(".archive")
+        || stem.ends_with(".pre-compact-full")
+        || stem.ends_with(".pre-supercompact")
+}
 
 fn discover_claude() -> Vec<SessionInfo> {
     let mut sessions = Vec::new();
@@ -120,6 +140,10 @@ fn discover_claude() -> Vec<SessionInfo> {
                 .and_then(|s| s.to_str())
                 .unwrap_or("")
                 .to_string();
+
+            if is_claude_backup_stem(&session_id) {
+                continue;
+            }
 
             // Get modified time as updated_at
             let updated_at = file
@@ -450,6 +474,20 @@ mod tests {
         let sessions = discover_all();
         // We can't assert count since it depends on the machine; just verify no panic.
         let _ = sessions.len();
+    }
+
+    #[test]
+    fn test_is_claude_backup_stem() {
+        // Live session UUIDs should pass through.
+        assert!(!is_claude_backup_stem("8de7c62b-e0ba-4485-8af0-15b6912613a7"));
+        assert!(!is_claude_backup_stem(""));
+        // Rotated archive ID — must be skipped or pi crossload eats a 700MB file.
+        assert!(is_claude_backup_stem("8de7c62b-e0ba-4485-8af0-15b6912613a7.archive"));
+        // Pre-compact snapshots claude writes alongside the live file.
+        assert!(is_claude_backup_stem("abc.pre-compact-full"));
+        assert!(is_claude_backup_stem("abc.pre-supercompact"));
+        // Substring match isn't enough — must be a true suffix.
+        assert!(!is_claude_backup_stem("archive-but-not-suffix"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When crossloading a session, we cache the resulting target_session_id to make
the operation idempotent. However, this didn't account for the source session
being updated with new messages after the initial crossload.

This PR adds `source_updated_at` to the `Entry` struct in the crossload index, tracking
the source session's `updated_at` timestamp. Before reusing a cached target
session, we now verify the timestamp matches. If the source session has been
modified, we drop the stale cache entry and perform a fresh crossload injection.

Also includes the previous uncommitted Pi crossload fixes:
- Live archive filtering (skips `.archive` variants from polluting the picker).
- Full-path resume (bypasses partial UUID resolution crashes in Pi).
- 50 MB size cap with tail-trim to keep Pi from choking on huge Claude archives.
- Two-pass `find_session` to correctly resolve `pi:<uuid>`.