### PR TITLE
feat: add Antigravity CLI and deprecate Gemini CLI

### DIFF
--- a/data/versions.json
+++ b/data/versions.json
@@ -66,6 +66,9 @@
     "0.35.0-preview.2",
     "0.35.0-preview.1"
   ],
+  "antigravity": [
+    "2.0.1"
+  ],
   "opencode": [
     "1.3.3",
     "1.3.2",

--- a/examples/custom_agents/antigravity.toml
+++ b/examples/custom_agents/antigravity.toml
@@ -1,6 +1,6 @@
 [[custom_agents]]
 name = "antigravity"
-binary = "antigravity"
+binary = "agy"
 description = "Google's Antigravity CLI"
 npm_package = "@google/antigravity-cli"
 

--- a/examples/custom_agents/antigravity.toml
+++ b/examples/custom_agents/antigravity.toml
@@ -1,0 +1,19 @@
+[[custom_agents]]
+name = "antigravity"
+binary = "antigravity"
+description = "Google's Antigravity CLI"
+npm_package = "@google/antigravity-cli"
+
+[custom_agents.polyfill]
+headless = { flag = "-p" }
+session = { continue_strategy = { flag = "--resume latest" }, resume_strategy = { flag = "--resume" } }
+fork = "unsupported"
+model_flag = "-m"
+yolo_flag = "--yolo"
+verbose_flag = "--debug"
+output_format_flag = "-o"
+allowed_tools_flag = "--allowed-tools"
+sandbox = { boolflag = "--sandbox" }
+add_dir_flag = "--include-directories"
+approval_mode_flag = "--approval-mode"
+worktree_flag = "--worktree"

--- a/examples/poc_search.rs
+++ b/examples/poc_search.rs
@@ -61,11 +61,12 @@ const MAX_NAMES_PER_RUN: usize = 12;
 async fn main() -> Result<(), Box<dyn Error>> {
     let query = env::args().nth(1).unwrap_or_else(|| "test".to_string());
 
-    let oai_base =
-        env::var("OAI_BASE").unwrap_or_else(|_| "http://localhost:8080/v1".to_string());
+    let oai_base = env::var("OAI_BASE").unwrap_or_else(|_| "http://localhost:8080/v1".to_string());
     let embed_model =
         env::var("OAI_EMBED_MODEL").unwrap_or_else(|_| "granite-embedding".to_string());
-    let chat_base = env::var("OAI_CHAT_BASE").ok().unwrap_or_else(|| oai_base.clone());
+    let chat_base = env::var("OAI_CHAT_BASE")
+        .ok()
+        .unwrap_or_else(|| oai_base.clone());
     let chat_model = env::var("OAI_CHAT_MODEL").ok();
     let alpha: f32 = env::var("ALPHA")
         .ok()
@@ -213,20 +214,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
         // Try the batch first. On any error, fall back to one-at-a-time so a
         // single oversize input doesn't tank the rest of the chunk (llama-server
         // returns 500 for the whole batch if any item exceeds the batch budget).
-        let vecs: Vec<Option<Vec<f32>>> = match embed_batch(
-            &http,
-            &oai_base,
-            &embed_model,
-            &texts,
-        )
-        .await
+        let vecs: Vec<Option<Vec<f32>>> = match embed_batch(&http, &oai_base, &embed_model, &texts)
+            .await
         {
             Ok(v) => v.into_iter().map(Some).collect(),
             Err(_) => {
                 let mut out = Vec::with_capacity(texts.len());
                 for t in &texts {
-                    match embed_batch(&http, &oai_base, &embed_model, std::slice::from_ref(t))
-                        .await
+                    match embed_batch(&http, &oai_base, &embed_model, std::slice::from_ref(t)).await
                     {
                         Ok(mut v) => out.push(v.pop()),
                         Err(_) => out.push(None),
@@ -251,7 +246,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
         }
         if (done + failed) % 64 == 0 {
-            eprintln!("  embed progress: {}/{} ({} failed)", done + failed, total, failed);
+            eprintln!(
+                "  embed progress: {}/{} ({} failed)",
+                done + failed,
+                total,
+                failed
+            );
         }
     }
     eprintln!("[embed] {done}/{total} embedded, {failed} failed");
@@ -336,15 +336,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // Blend
-    let max_bm25 = candidates.iter().map(|c| c.bm25).fold(0.0f32, f32::max).max(1e-6);
+    let max_bm25 = candidates
+        .iter()
+        .map(|c| c.bm25)
+        .fold(0.0f32, f32::max)
+        .max(1e-6);
     let mut scored: Vec<(f32, &Candidate)> = candidates
         .iter()
         .map(|c| {
             let bm_norm = c.bm25 / max_bm25;
-            let sem_norm = c
-                .cos_dist
-                .map(|d| 1.0 - (d as f32) / 2.0)
-                .unwrap_or(0.0);
+            let sem_norm = c.cos_dist.map(|d| 1.0 - (d as f32) / 2.0).unwrap_or(0.0);
             let score = alpha * bm_norm + (1.0 - alpha) * sem_norm;
             (score, c)
         })
@@ -375,7 +376,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
             });
         let title = title_owned.as_str();
         let dir = c.directory.as_deref().unwrap_or("");
-        let date = c.updated_at.as_deref().unwrap_or("").chars().take(10).collect::<String>();
+        let date = c
+            .updated_at
+            .as_deref()
+            .unwrap_or("")
+            .chars()
+            .take(10)
+            .collect::<String>();
         let cos = c
             .cos_dist
             .map(|d| format!("cos={:.3}", d))
@@ -392,7 +399,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
             date
         );
     }
-    eprintln!("\n[query] hybrid scored {} rows in {:?}", candidates.len(), t_q.elapsed());
+    eprintln!(
+        "\n[query] hybrid scored {} rows in {:?}",
+        candidates.len(),
+        t_q.elapsed()
+    );
     Ok(())
 }
 
@@ -447,7 +458,11 @@ fn extract_text(s: &SessionInfo) -> Option<String> {
     }
     let title_part = s.title.as_deref().or(s.name.as_deref()).unwrap_or("");
     let dir_part = &s.directory;
-    Some(format!("{title_part} {dir_part} {snippet}").trim().to_string())
+    Some(
+        format!("{title_part} {dir_part} {snippet}")
+            .trim()
+            .to_string(),
+    )
 }
 
 fn vec_to_lit(v: &[f32]) -> String {
@@ -485,7 +500,10 @@ async fn embed_batch(
     let url = format!("{}/embeddings", base.trim_end_matches('/'));
     let resp = http
         .post(&url)
-        .json(&Req { model, input: texts })
+        .json(&Req {
+            model,
+            input: texts,
+        })
         .send()
         .await?
         .error_for_status()?

--- a/plugins/bundled/supercompact/hooks-handlers/supercompact-compact.sh
+++ b/plugins/bundled/supercompact/hooks-handlers/supercompact-compact.sh
@@ -101,7 +101,7 @@ if [[ -z "${BUDGET}" ]]; then
     AGENT="${AGENT_CMD:-claude}"
     AGENT_BASE=$(basename "${AGENT}" 2>/dev/null)
     case "${AGENT_BASE}" in
-      claude*|codex*|gemini*)
+      claude*|codex*|gemini*|antigravity*)
         BUDGET_FLOOR="${PLUGIN_SETTING_BUDGET_FLOOR:-100000}"
         ;;
       *)

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -69,12 +69,26 @@ impl AgentType {
         match s.to_lowercase().as_str() {
             "claude" | "claude-code" => Some(AgentType::Claude),
             "codex" => Some(AgentType::Codex),
-            "antigravity" | "antigravity-cli" => Some(AgentType::Antigravity),
+            "antigravity" | "antigravity-cli" | "agy" => Some(AgentType::Antigravity),
             "gemini" | "gemini-cli" => Some(AgentType::Gemini),
             "opencode" | "open-code" => Some(AgentType::OpenCode),
             "pi" | "pi-coding-agent" => Some(AgentType::Pi),
             "hermes" | "hermes-agent" => Some(AgentType::Hermes),
             _ => None,
+        }
+    }
+
+    /// Cleanly map each agent type to its mascot file key name
+    pub fn mascot_name(&self) -> &'static str {
+        match self {
+            AgentType::Claude => "claude",
+            AgentType::Codex => "codex",
+            AgentType::Antigravity => "antigravity",
+            AgentType::Gemini => "gemini",
+            AgentType::OpenCode => "opencode",
+            AgentType::Pi => "pi",
+            AgentType::Hermes => "hermes",
+            AgentType::Custom(_) => "claude",
         }
     }
 }

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -359,7 +359,10 @@ impl AgentDefinition {
                 output_format_flag: None,
                 system_prompt_flag: None,
                 allowed_tools_flag: None,
-                sandbox: SandboxStrategy::ValueFlag("--sandbox".to_string(), "workspace-write".to_string()),
+                sandbox: SandboxStrategy::ValueFlag(
+                    "--sandbox".to_string(),
+                    "workspace-write".to_string(),
+                ),
                 name_flag: None,
                 add_dir_flag: Some("--add-dir".to_string()),
                 approval_mode_flag: Some("-a".to_string()),
@@ -613,15 +616,19 @@ impl AgentManager {
     fn parse_asar_version(content: &[u8]) -> Option<String> {
         let pattern1 = b"\"name\": \"antigravity\"";
         let pattern2 = b"\"name\":\"antigravity\"";
-        let pos = content.windows(pattern1.len()).position(|w| w == pattern1)
+        let pos = content
+            .windows(pattern1.len())
+            .position(|w| w == pattern1)
             .or_else(|| content.windows(pattern2.len()).position(|w| w == pattern2))?;
-        
+
         let search_slice = &content[pos..pos + std::cmp::min(1000, content.len() - pos)];
         let version_pattern = b"\"version\"";
-        let v_pos = search_slice.windows(version_pattern.len()).position(|w| w == version_pattern)?;
-        
+        let v_pos = search_slice
+            .windows(version_pattern.len())
+            .position(|w| w == version_pattern)?;
+
         let val_slice = &search_slice[v_pos + version_pattern.len()..];
-        
+
         let mut start_idx = None;
         let mut colon_found = false;
         for (i, &b) in val_slice.iter().enumerate() {
@@ -632,11 +639,11 @@ impl AgentManager {
                 break;
             }
         }
-        
+
         let start = start_idx?;
         let end_slice = &val_slice[start..];
         let end = end_slice.iter().position(|&b| b == b'"')?;
-        
+
         String::from_utf8(end_slice[..end].to_vec()).ok()
     }
 
@@ -648,11 +655,34 @@ impl AgentManager {
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Agent not found"))?;
 
         if agent_type == AgentType::Antigravity {
-            let path = PathBuf::from("/opt/Antigravity/resources/app.asar");
+            // Check Electron app.asar paths for system/packaged installations
+            let paths = [
+                PathBuf::from("/opt/Antigravity/resources/app.asar"), // Arch Linux / pacman default
+                PathBuf::from("/Applications/Antigravity.app/Contents/Resources/app.asar"), // macOS default
+            ];
             let mut version = None;
-            if path.exists() {
-                if let Ok(content) = fs::read(&path) {
-                    version = Self::parse_asar_version(&content);
+            for path in &paths {
+                if path.exists() {
+                    if let Ok(content) = fs::read(path) {
+                        if let Some(v) = Self::parse_asar_version(&content) {
+                            version = Some(v);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Fallback for npm-based global installations (@google/antigravity-cli) or custom paths
+            if version.is_none() {
+                if let Ok(bin_path) = which::which(&agent.binary) {
+                    if let Ok(output) = Command::new(&bin_path).arg("--version").output() {
+                        let stdout = String::from_utf8_lossy(&output.stdout);
+                        // Clean up output to extract semver if present
+                        let ver_str = stdout.trim();
+                        if !ver_str.is_empty() {
+                            version = Some(ver_str.to_string());
+                        }
+                    }
                 }
             }
 
@@ -873,7 +903,7 @@ impl AgentManager {
             AgentType::Claude => self.update_claude(),
             AgentType::Codex => self.update_codex(),
             AgentType::Antigravity => Err(io::Error::other(
-                "Antigravity CLI updates are managed by the system package manager (pacman/yay)"
+                "Antigravity CLI updates are managed by the system package manager (pacman/yay)",
             )),
             AgentType::Gemini => self.update_npm_agent("@google/gemini-cli", "Gemini CLI"),
             AgentType::OpenCode => self.update_opencode(),
@@ -1242,7 +1272,10 @@ impl AgentManager {
         let mut results = Vec::new();
 
         for agent_type in agent_types {
-            let installed = self.get_installed_version(agent_type.clone()).ok().flatten();
+            let installed = self
+                .get_installed_version(agent_type.clone())
+                .ok()
+                .flatten();
             let latest = self
                 .versions
                 .get(&agent_type)
@@ -1317,7 +1350,10 @@ mod tests {
         assert!(hermes.npm_package.is_none());
         assert_eq!(hermes.binary, "hermes");
         assert_eq!(hermes.agent_type, AgentType::Hermes);
-        assert_eq!(hermes.github_repo.as_deref(), Some("NousResearch/hermes-agent"));
+        assert_eq!(
+            hermes.github_repo.as_deref(),
+            Some("NousResearch/hermes-agent")
+        );
     }
 
     #[test]
@@ -1366,7 +1402,10 @@ mod tests {
             Some("2026.6.12".to_string())
         );
         // Missing parens
-        assert_eq!(AgentManager::parse_hermes_calver("Hermes Agent v0.13.0"), None);
+        assert_eq!(
+            AgentManager::parse_hermes_calver("Hermes Agent v0.13.0"),
+            None
+        );
         // Non-numeric content in parens
         assert_eq!(
             AgentManager::parse_hermes_calver("Hermes Agent v0.13.0 (dev)"),

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -393,7 +393,7 @@ impl AgentDefinition {
         Self {
             agent_type: AgentType::Antigravity,
             name: "Antigravity CLI".to_string(),
-            binary: "antigravity".to_string(),
+            binary: "agy".to_string(),
             description: "Google's Antigravity CLI".to_string(),
             polyfill: AgentPolyfillConfig {
                 headless: HeadlessStrategy::Flag("-p".to_string()),

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -19,6 +19,7 @@ use std::process::Command;
 pub enum AgentType {
     Claude,
     Codex,
+    Antigravity,
     Gemini,
     OpenCode,
     Pi,
@@ -32,10 +33,11 @@ impl AgentType {
         &[
             AgentType::Claude,
             AgentType::Codex,
-            AgentType::Gemini,
+            AgentType::Antigravity,
             AgentType::OpenCode,
             AgentType::Pi,
             AgentType::Hermes,
+            AgentType::Gemini,
         ]
     }
 
@@ -54,6 +56,7 @@ impl AgentType {
         match self {
             AgentType::Claude => Cow::Borrowed("Claude Code"),
             AgentType::Codex => Cow::Borrowed("Codex"),
+            AgentType::Antigravity => Cow::Borrowed("Antigravity CLI"),
             AgentType::Gemini => Cow::Borrowed("Gemini CLI"),
             AgentType::OpenCode => Cow::Borrowed("OpenCode"),
             AgentType::Pi => Cow::Borrowed("Pi"),
@@ -66,6 +69,7 @@ impl AgentType {
         match s.to_lowercase().as_str() {
             "claude" | "claude-code" => Some(AgentType::Claude),
             "codex" => Some(AgentType::Codex),
+            "antigravity" | "antigravity-cli" => Some(AgentType::Antigravity),
             "gemini" | "gemini-cli" => Some(AgentType::Gemini),
             "opencode" | "open-code" => Some(AgentType::OpenCode),
             "pi" | "pi-coding-agent" => Some(AgentType::Pi),
@@ -287,6 +291,7 @@ impl AgentDefinition {
         match agent_type {
             AgentType::Claude => Self::claude(),
             AgentType::Codex => Self::codex(),
+            AgentType::Antigravity => Self::antigravity(),
             AgentType::Gemini => Self::gemini(),
             AgentType::OpenCode => Self::opencode(),
             AgentType::Pi => Self::pi(),
@@ -362,6 +367,40 @@ impl AgentDefinition {
             },
             github_repo: Some("openai/codex".to_string()),
             npm_package: None,
+            enabled: true,
+        }
+    }
+
+    /// Create Antigravity CLI agent definition
+    pub fn antigravity() -> Self {
+        Self {
+            agent_type: AgentType::Antigravity,
+            name: "Antigravity CLI".to_string(),
+            binary: "antigravity".to_string(),
+            description: "Google's Antigravity CLI".to_string(),
+            polyfill: AgentPolyfillConfig {
+                headless: HeadlessStrategy::Flag("-p".to_string()),
+                session: SessionStrategy {
+                    continue_strategy: ResumeStrategy::Flag("--resume latest".to_string()),
+                    resume_strategy: ResumeStrategy::Flag("--resume".to_string()),
+                },
+                fork: ForkStrategy::Unsupported,
+                yolo_flag: Some("--yolo".to_string()),
+                model_flag: "-m".to_string(),
+                effort_flag: None,
+                auto_flag: None,
+                verbose_flag: Some("--debug".to_string()),
+                output_format_flag: Some("-o".to_string()),
+                system_prompt_flag: None,
+                allowed_tools_flag: Some("--allowed-tools".to_string()),
+                sandbox: SandboxStrategy::BoolFlag("--sandbox".to_string()),
+                name_flag: None,
+                add_dir_flag: Some("--include-directories".to_string()),
+                approval_mode_flag: Some("--approval-mode".to_string()),
+                worktree_flag: Some("--worktree".to_string()),
+            },
+            github_repo: None,
+            npm_package: Some("@google/antigravity-cli".to_string()),
             enabled: true,
         }
     }
@@ -545,6 +584,7 @@ impl AgentManager {
         manager.register_agent(AgentDefinition::claude());
         manager.register_agent(AgentDefinition::codex());
         manager.register_agent(AgentDefinition::gemini());
+        manager.register_agent(AgentDefinition::antigravity());
         manager.register_agent(AgentDefinition::opencode());
         manager.register_agent(AgentDefinition::pi());
         manager.register_agent(AgentDefinition::hermes());
@@ -570,12 +610,59 @@ impl AgentManager {
         self.agents.values().collect()
     }
 
+    fn parse_asar_version(content: &[u8]) -> Option<String> {
+        let pattern1 = b"\"name\": \"antigravity\"";
+        let pattern2 = b"\"name\":\"antigravity\"";
+        let pos = content.windows(pattern1.len()).position(|w| w == pattern1)
+            .or_else(|| content.windows(pattern2.len()).position(|w| w == pattern2))?;
+        
+        let search_slice = &content[pos..pos + std::cmp::min(1000, content.len() - pos)];
+        let version_pattern = b"\"version\"";
+        let v_pos = search_slice.windows(version_pattern.len()).position(|w| w == version_pattern)?;
+        
+        let val_slice = &search_slice[v_pos + version_pattern.len()..];
+        
+        let mut start_idx = None;
+        let mut colon_found = false;
+        for (i, &b) in val_slice.iter().enumerate() {
+            if b == b':' {
+                colon_found = true;
+            } else if b == b'"' && colon_found {
+                start_idx = Some(i + 1);
+                break;
+            }
+        }
+        
+        let start = start_idx?;
+        let end_slice = &val_slice[start..];
+        let end = end_slice.iter().position(|&b| b == b'"')?;
+        
+        String::from_utf8(end_slice[..end].to_vec()).ok()
+    }
+
     /// Get installed version for an agent
     pub fn get_installed_version(&mut self, agent_type: AgentType) -> io::Result<Option<String>> {
         let agent = self
             .agents
             .get(&agent_type)
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Agent not found"))?;
+
+        if agent_type == AgentType::Antigravity {
+            let path = PathBuf::from("/opt/Antigravity/resources/app.asar");
+            let mut version = None;
+            if path.exists() {
+                if let Ok(content) = fs::read(&path) {
+                    version = Self::parse_asar_version(&content);
+                }
+            }
+
+            // Update cache
+            let entry = self.versions.entry(agent_type).or_default();
+            entry.installed = version.clone();
+            entry.binary_path = which::which(&agent.binary).ok();
+
+            return Ok(version);
+        }
 
         // Try to get version from binary
         let binary = agent.binary.clone();
@@ -785,6 +872,9 @@ impl AgentManager {
         match agent_type {
             AgentType::Claude => self.update_claude(),
             AgentType::Codex => self.update_codex(),
+            AgentType::Antigravity => Err(io::Error::other(
+                "Antigravity CLI updates are managed by the system package manager (pacman/yay)"
+            )),
             AgentType::Gemini => self.update_npm_agent("@google/gemini-cli", "Gemini CLI"),
             AgentType::OpenCode => self.update_opencode(),
             AgentType::Pi => self.update_npm_agent("@mariozechner/pi-coding-agent", "Pi"),

--- a/src/bin/splash.rs
+++ b/src/bin/splash.rs
@@ -49,9 +49,13 @@ fn agents() -> Vec<Agent> {
             accent: Color::Rgb(140, 140, 140),
         },
         Agent {
-            name: "gemini",
-            theme: AgentTheme::Gradient(unleash::theme::GradientTheme::gemini()),
-            accent: Color::Rgb(0x84, 0x7A, 0xCE), // middle of gradient (purple)
+            name: "antigravity",
+            theme: AgentTheme::Gradient(unleash::theme::GradientTheme::new(&[
+                (0x9b, 0x51, 0xe0), // purple
+                (0x30, 0x80, 0xe0), // futuristic blue
+                (0x00, 0xc2, 0xff), // neon cyan/teal
+            ])),
+            accent: Color::Rgb(0x30, 0x80, 0xe0),
         },
         Agent {
             name: "opencode",
@@ -82,6 +86,11 @@ fn agents() -> Vec<Agent> {
                 sat_scale: 1.0,
             }),
             accent: Color::Rgb(217, 195, 87),
+        },
+        Agent {
+            name: "gemini",
+            theme: AgentTheme::Gradient(unleash::theme::GradientTheme::gemini()),
+            accent: Color::Rgb(0x84, 0x7A, 0xCE), // middle of gradient (purple)
         },
     ]
 }

--- a/src/bin/splash.rs
+++ b/src/bin/splash.rs
@@ -50,11 +50,7 @@ fn agents() -> Vec<Agent> {
         },
         Agent {
             name: "antigravity",
-            theme: AgentTheme::Gradient(unleash::theme::GradientTheme::new(&[
-                (0x9b, 0x51, 0xe0), // purple
-                (0x30, 0x80, 0xe0), // futuristic blue
-                (0x00, 0xc2, 0xff), // neon cyan/teal
-            ])),
+            theme: AgentTheme::Gradient(unleash::theme::GradientTheme::antigravity()),
             accent: Color::Rgb(0x30, 0x80, 0xe0),
         },
         Agent {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,27 +13,35 @@ pub fn get_full_version() -> String {
     let agent_label = match agent_cmd.as_str() {
         "codex" => "Codex",
         "gemini" => "Gemini CLI",
+        "antigravity" => "Antigravity CLI",
         "opencode" => "OpenCode",
         _ => "Claude Code",
     };
 
     // Try to get agent CLI version (only runs when --version is actually passed)
-    let agent_version = Command::new(&agent_cmd)
-        .arg("--version")
-        .output()
-        .ok()
-        .and_then(|output| {
-            if output.status.success() {
-                let version_str = String::from_utf8_lossy(&output.stdout);
-                version_str
-                    .lines()
-                    .find(|line| line.contains('.') && line.chars().any(|c| c.is_ascii_digit()))
-                    .map(|line| line.trim().replace(" (Claude Code)", ""))
-            } else {
-                None
-            }
-        })
-        .unwrap_or_else(|| "not installed".to_string());
+    let agent_version = if agent_cmd == "antigravity" {
+        crate::agents::AgentManager::new()
+            .ok()
+            .and_then(|mut mgr| mgr.get_installed_version(crate::agents::AgentType::Antigravity).ok().flatten())
+            .unwrap_or_else(|| "not installed".to_string())
+    } else {
+        Command::new(&agent_cmd)
+            .arg("--version")
+            .output()
+            .ok()
+            .and_then(|output| {
+                if output.status.success() {
+                    let version_str = String::from_utf8_lossy(&output.stdout);
+                    version_str
+                        .lines()
+                        .find(|line| line.contains('.') && line.chars().any(|c| c.is_ascii_digit()))
+                        .map(|line| line.trim().replace(" (Claude Code)", ""))
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_else(|| "not installed".to_string())
+    };
 
     if agent_version == "not installed" {
         format!(
@@ -512,11 +520,11 @@ impl PolyfillArgs {
 #[command(author = "Heiervang Technologies")]
 #[command(version)]
 #[command(
-    about = "unleash - Extended CLI for AI Code Agents\n\nRun a profile:  unleash <profile> [flags] [-- passthrough]\nDefault profiles: claude, codex, gemini, opencode\n\nRun 'unleash <profile> --help' for unified flag details."
+    about = "unleash - Extended CLI for AI Code Agents\n\nRun a profile:  unleash <profile> [flags] [-- passthrough]\nDefault profiles: claude, codex, antigravity, gemini, opencode\n\nRun 'unleash <profile> --help' for unified flag details."
 )]
 #[command(long_about = r#"unleash - Extended CLI for AI Code Agents
 
-A wrapper for AI code agents (Claude, Codex, Gemini, OpenCode) with extended features:
+A wrapper for AI code agents (Claude, Codex, Antigravity, Gemini, OpenCode) with extended features:
   - Unified flags that work across all agents (polyfill layer)
   - Self-restart capability for MCP server reloading
   - Plugin system integration (loads from plugins/bundled/)
@@ -533,7 +541,7 @@ ARGUMENT LAYERS:
 
 USAGE:
   unleash              Opens TUI for profile and version management
-  unleash <profile>    Run a profile (claude, codex, gemini, opencode, or custom)
+  unleash <profile>    Run a profile (claude, codex, antigravity, gemini, opencode, or custom)
 
 UNIFIED FLAGS (before --):
   --safe                       Restore approval prompts (permissions bypassed by default)
@@ -593,7 +601,7 @@ pub enum Commands {
         action: Option<HooksAction>,
     },
 
-    /// Manage code agents (Claude, Codex, Gemini, OpenCode)
+    /// Manage code agents (Claude, Codex, Antigravity, Gemini, OpenCode)
     Agents {
         #[command(subcommand)]
         action: Option<AgentsAction>,
@@ -602,11 +610,12 @@ pub enum Commands {
     /// Install an agent CLI for the first time
     ///
     /// Examples:
+    ///   unleash install antigravity  # Install Antigravity CLI
     ///   unleash install gemini       # Install Gemini CLI
     ///   unleash install codex claude # Install Codex and Claude
     ///   unleash install --all        # Install all agent CLIs
     Install {
-        /// Agents to install (e.g. claude, codex, gemini, opencode)
+        /// Agents to install (e.g. claude, codex, antigravity, gemini, opencode)
         #[arg(conflicts_with = "all")]
         agents: Vec<String>,
 
@@ -619,10 +628,11 @@ pub enum Commands {
     ///
     /// Examples:
     ///   unleash uninstall              # Interactive: uninstall unleash + selected agents
+    ///   unleash uninstall antigravity  # Uninstall Antigravity CLI
     ///   unleash uninstall gemini       # Uninstall Gemini CLI
     ///   unleash uninstall --all        # Uninstall all agent CLIs
     Uninstall {
-        /// Agents to uninstall (e.g. claude, codex, gemini, opencode)
+        /// Agents to uninstall (e.g. claude, codex, antigravity, gemini, opencode)
         #[arg(conflicts_with = "all")]
         agents: Vec<String>,
 
@@ -638,7 +648,7 @@ pub enum Commands {
     /// -a/--all: update unleash + all installed agent CLIs
     /// Positional args: update specific agents (e.g. 'unleash update claude codex')
     Update {
-        /// Specific agents to update (e.g. claude, codex, gemini, opencode)
+        /// Specific agents to update (e.g. claude, codex, antigravity, gemini, opencode)
         #[arg(conflicts_with_all = ["clis", "all"])]
         agents: Vec<String>,
 
@@ -664,7 +674,7 @@ pub enum Commands {
     ///   unleash sessions reindex                  # Rebuild the search index
     ///   unleash sessions name claude:abc "Title"  # Set a session title
     Sessions {
-        /// Filter by CLI (claude, codex, gemini, opencode)
+        /// Filter by CLI (claude, codex, antigravity, gemini, opencode)
         #[arg(short, long, global = true)]
         cli: Option<String>,
 
@@ -708,11 +718,11 @@ pub enum Commands {
 
     /// Convert conversation history between CLI formats
     Convert {
-        /// Source format (claude, codex, gemini, opencode, pi, hub)
+        /// Source format (claude, codex, antigravity, gemini, opencode, pi, hub)
         #[arg(long)]
         from: String,
 
-        /// Target format (claude, codex, gemini, opencode, pi, hub). Defaults to hub.
+        /// Target format (claude, codex, antigravity, gemini, opencode, pi, hub). Defaults to hub.
         #[arg(long, default_value = "hub")]
         to: String,
 
@@ -850,19 +860,19 @@ pub enum AgentsAction {
 
     /// Check for updates
     Check {
-        /// Agent to check (claude, codex, gemini, opencode). If omitted, checks all.
+        /// Agent to check (claude, codex, antigravity, gemini, opencode). If omitted, checks all.
         agent: Option<String>,
     },
 
     /// Update an agent to latest version
     Update {
-        /// Agent to update (claude, codex, gemini, opencode)
+        /// Agent to update (claude, codex, antigravity, gemini, opencode)
         agent: String,
     },
 
     /// Show detailed info about an agent
     Info {
-        /// Agent name (claude, codex, gemini, opencode)
+        /// Agent name (claude, codex, antigravity, gemini, opencode)
         agent: String,
     },
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,7 +22,11 @@ pub fn get_full_version() -> String {
     let agent_version = if agent_cmd == "antigravity" {
         crate::agents::AgentManager::new()
             .ok()
-            .and_then(|mut mgr| mgr.get_installed_version(crate::agents::AgentType::Antigravity).ok().flatten())
+            .and_then(|mut mgr| {
+                mgr.get_installed_version(crate::agents::AgentType::Antigravity)
+                    .ok()
+                    .flatten()
+            })
             .unwrap_or_else(|| "not installed".to_string())
     } else {
         Command::new(&agent_cmd)

--- a/src/config.rs
+++ b/src/config.rs
@@ -163,7 +163,7 @@ impl Profile {
             Self {
                 name: "agy".to_string(),
                 description: "Antigravity CLI (agy) by Google".to_string(),
-                agent_cli_path: "antigravity".to_string(),
+                agent_cli_path: "agy".to_string(),
                 agent_cli_args: Vec::new(),
                 defaults: ProfileDefaults::default(),
                 agents: ProfileOverrides::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -161,6 +161,17 @@ impl Profile {
                 env: default_env(),
             },
             Self {
+                name: "agy".to_string(),
+                description: "Antigravity CLI (agy) by Google".to_string(),
+                agent_cli_path: "antigravity".to_string(),
+                agent_cli_args: Vec::new(),
+                defaults: ProfileDefaults::default(),
+                agents: ProfileOverrides::default(),
+                stop_prompt: None,
+                theme: "#9b51e0".to_string(),
+                env: default_env(),
+            },
+            Self {
                 name: "gemini".to_string(),
                 description: "Gemini CLI by Google".to_string(),
                 agent_cli_path: "gemini".to_string(),
@@ -193,12 +204,28 @@ impl Profile {
                 theme: "#a855f7".to_string(),
                 env: default_env(),
             },
+            Self {
+                name: "hermes".to_string(),
+                description: "Hermes Agent by Nous Research".to_string(),
+                agent_cli_path: "hermes".to_string(),
+                agent_cli_args: Vec::new(),
+                defaults: ProfileDefaults::default(),
+                agents: ProfileOverrides::default(),
+                stop_prompt: None,
+                theme: "#4f46e5".to_string(),
+                env: default_env(),
+            },
         ]
     }
 
     /// Return the agent type if this profile's CLI path matches a known agent
     /// or a custom agent defined in the app config.
     pub fn agent_type(&self) -> Option<AgentType> {
+        // Try profile name first — allows 'agy' to resolve to Antigravity
+        // even when agent_cli_path is 'gemini' (shared binary)
+        if let Some(at) = AgentType::from_str(&self.name) {
+            return Some(at);
+        }
         let name = std::path::Path::new(&self.agent_cli_path)
             .file_name()
             .and_then(|n| n.to_str())?;
@@ -647,9 +674,11 @@ mod tests {
         // All agent profiles are seeded by default
         assert!(profiles.contains(&"claude".to_string()));
         assert!(profiles.contains(&"codex".to_string()));
+        assert!(profiles.contains(&"agy".to_string()));
         assert!(profiles.contains(&"gemini".to_string()));
         assert!(profiles.contains(&"opencode".to_string()));
         assert!(profiles.contains(&"pi".to_string()));
+        assert!(profiles.contains(&"hermes".to_string()));
     }
 
     #[test]
@@ -679,8 +708,11 @@ mod tests {
         let profiles = manager.list_profiles().unwrap();
         assert!(profiles.contains(&"claude".to_string()));
         assert!(profiles.contains(&"codex".to_string()));
+        assert!(profiles.contains(&"agy".to_string()));
         assert!(profiles.contains(&"gemini".to_string()));
         assert!(profiles.contains(&"opencode".to_string()));
+        assert!(profiles.contains(&"pi".to_string()));
+        assert!(profiles.contains(&"hermes".to_string()));
     }
 
     #[test]

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -968,7 +968,11 @@ mod tests {
 
         let settings = mgr.read_settings().unwrap();
         let hooks = settings["hooks"]["PreCompact"].as_array().unwrap();
-        assert_eq!(hooks.len(), 2, "plugin hook should be added alongside manual hook");
+        assert_eq!(
+            hooks.len(),
+            2,
+            "plugin hook should be added alongside manual hook"
+        );
     }
 
     #[test]
@@ -994,11 +998,7 @@ mod tests {
 
         let settings = mgr.read_settings().unwrap();
         let hooks = settings["hooks"]["PreCompact"].as_array().unwrap();
-        assert_eq!(
-            hooks.len(),
-            1,
-            "sync should populate an empty event array"
-        );
+        assert_eq!(hooks.len(), 1, "sync should populate an empty event array");
     }
 
     #[test]
@@ -1176,10 +1176,7 @@ mod tests {
         );
 
         let changed = mgr
-            .prune_hooks_for_disabled_plugins(
-                &[omnihook.clone(), supercompact],
-                &[omnihook],
-            )
+            .prune_hooks_for_disabled_plugins(&[omnihook.clone(), supercompact], &[omnihook])
             .unwrap();
         assert!(changed);
 

--- a/src/interchange/claude.rs
+++ b/src/interchange/claude.rs
@@ -232,11 +232,7 @@ fn message_to_hub(
     // native Claude representation (mixed-content blocks, foreign metadata,
     // etc.). Foreign extensions stashed under `_ucf_hub.ext` are already part
     // of the stashed message, so this takes precedence.
-    if let Some(stashed) = val
-        .get("_ucf_hub")
-        .and_then(|u| u.get("message"))
-        .cloned()
-    {
+    if let Some(stashed) = val.get("_ucf_hub").and_then(|u| u.get("message")).cloned() {
         if let Ok(restored) = serde_json::from_value::<HubMessage>(stashed) {
             hub_msg = restored;
         }
@@ -249,14 +245,14 @@ fn build_claude_extensions(val: &Value, msg_type: &str) -> Value {
     // Stash ALL top-level fields that don't map to hub message schema
     // into extensions for lossless round-trip
     let hub_fields: &[&str] = &[
-        "type",      // → role / message type
-        "message",   // → content blocks
-        "uuid",      // → id
-        "timestamp", // → timestamp
+        "type",       // → role / message type
+        "message",    // → content blocks
+        "uuid",       // → id
+        "timestamp",  // → timestamp
         "parentUuid", // → parent_id
-        "cwd",       // → metadata.cwd
-        "gitBranch", // → metadata.git_branch
-        "_ucf_hub",  // hub-level passthrough for cross-CLI round-trip
+        "cwd",        // → metadata.cwd
+        "gitBranch",  // → metadata.git_branch
+        "_ucf_hub",   // hub-level passthrough for cross-CLI round-trip
     ];
 
     let mut ext = serde_json::Map::new();
@@ -467,14 +463,8 @@ fn extract_metadata(val: &Value, msg_type: &str) -> MessageMetadata {
                     .get("reasoning_tokens")
                     .and_then(|v| v.as_u64())
                     .unwrap_or(0),
-                tool: u
-                    .get("tool_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0),
-                total: u
-                    .get("total_tokens")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0),
+                tool: u.get("tool_tokens").and_then(|v| v.as_u64()).unwrap_or(0),
+                total: u.get("total_tokens").and_then(|v| v.as_u64()).unwrap_or(0),
             }),
             stop_reason: message.and_then(|m| opt_str(m, "stop_reason")),
             cwd: opt_str(val, "cwd"),
@@ -1118,10 +1108,7 @@ mod tests {
             "signed thinking should be preserved as thinking block"
         );
         assert_eq!(
-            thinking
-                .unwrap()
-                .get("signature")
-                .and_then(|s| s.as_str()),
+            thinking.unwrap().get("signature").and_then(|s| s.as_str()),
             Some("sig_abc123"),
             "signature should be preserved"
         );

--- a/src/interchange/codex.rs
+++ b/src/interchange/codex.rs
@@ -63,10 +63,7 @@ pub fn to_hub<R: BufRead>(reader: R) -> Result<Vec<HubRecord>, ConvertError> {
                 // `_ucf_hub.message`, restore it verbatim — Codex's response
                 // shape can't represent every hub content variant losslessly,
                 // but the stashed blob captures everything.
-                if let Some(stashed) = ucf_hub
-                    .and_then(|u| u.get("message"))
-                    .cloned()
-                {
+                if let Some(stashed) = ucf_hub.and_then(|u| u.get("message")).cloned() {
                     if let Ok(mut msg) = serde_json::from_value::<HubMessage>(stashed) {
                         // Codex has no native `tool` role — its tool results
                         // ride on user-role response_items. Coerce so cross-CLI
@@ -106,10 +103,7 @@ pub fn to_hub<R: BufRead>(reader: R) -> Result<Vec<HubRecord>, ConvertError> {
                     records.push(HubRecord::Session(default_session(&timestamp)));
                     session_emitted = true;
                 }
-                let sub_type = payload
-                    .get("type")
-                    .and_then(|t| t.as_str())
-                    .unwrap_or("");
+                let sub_type = payload.get("type").and_then(|t| t.as_str()).unwrap_or("");
                 let mut ext = serde_json::json!({"codex": {"_outer_type": "event_msg"}});
                 if foreign_originated {
                     ext = Value::Object(serde_json::Map::new());
@@ -223,11 +217,7 @@ pub fn from_hub(records: &[HubRecord]) -> Result<Vec<Value>, ConvertError> {
                         attach_ucf_hub_field(&mut line, "completed_at", Value::String(ca.clone()));
                     }
                     if stash_messages {
-                        attach_ucf_hub_field(
-                            &mut line,
-                            "message",
-                            serde_json::to_value(msg)?,
-                        );
+                        attach_ucf_hub_field(&mut line, "message", serde_json::to_value(msg)?);
                     }
                     lines.push(line);
                 }
@@ -345,7 +335,10 @@ fn session_meta_to_hub(payload: &Value, timestamp: &str) -> SessionHeader {
         }
     }
     // Also stash the outer timestamp for exact reconstruction
-    ext.insert("_outer_timestamp".into(), Value::String(timestamp.to_string()));
+    ext.insert(
+        "_outer_timestamp".into(),
+        Value::String(timestamp.to_string()),
+    );
 
     SessionHeader {
         ucf_version: UCF_VERSION.to_string(),
@@ -706,8 +699,7 @@ fn hub_message_to_codex(msg: &HubMessage) -> Result<Value, ConvertError> {
                 id, name, input, ..
             }) = msg.content.first()
             {
-                let arguments =
-                    serde_json::to_string(input).unwrap_or_else(|_| "{}".to_string());
+                let arguments = serde_json::to_string(input).unwrap_or_else(|_| "{}".to_string());
                 let payload = serde_json::json!({
                     "type": "function_call",
                     "name": name,
@@ -850,10 +842,7 @@ fn hub_event_to_codex(evt: &HubEvent) -> Result<Value, ConvertError> {
     let cc = evt.extensions.get("codex").cloned().unwrap_or(Value::Null);
 
     // Check if we stored the original outer type
-    let outer_type = cc
-        .get("_outer_type")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let outer_type = cc.get("_outer_type").and_then(|v| v.as_str()).unwrap_or("");
 
     let codex_type = if !outer_type.is_empty() {
         outer_type.to_string()

--- a/src/interchange/cross_cli_tests.rs
+++ b/src/interchange/cross_cli_tests.rs
@@ -75,7 +75,10 @@ mod tests {
             .iter()
             .filter_map(|r| {
                 if let HubRecord::Message(msg) = r {
-                    let has_text = msg.content.iter().any(|b| matches!(b, ContentBlock::Text { .. }));
+                    let has_text = msg
+                        .content
+                        .iter()
+                        .any(|b| matches!(b, ContentBlock::Text { .. }));
 
                     let portable = Some(PortableMessage {
                         role: msg.role.clone(),
@@ -167,7 +170,10 @@ mod tests {
         // User/assistant message counts should be close (within tolerance for
         // format differences like Codex session_meta becoming an extra message)
         let mut allowed_diff = 2;
-        if target_name.contains("gemini") || target_name.contains("opencode") || source_name.contains("opencode") {
+        if target_name.contains("gemini")
+            || target_name.contains("opencode")
+            || source_name.contains("opencode")
+        {
             allowed_diff = 10; // Gemini and OpenCode merge consecutive messages/tool results
         }
 

--- a/src/interchange/gemini.rs
+++ b/src/interchange/gemini.rs
@@ -45,11 +45,7 @@ pub fn to_hub(data: &[u8]) -> Result<Vec<HubRecord>, ConvertError> {
                 // restore it verbatim — the Gemini shape can lose mixed
                 // content variants and Hub-only metadata, but the stashed
                 // blob captures everything the foreign source produced.
-                if let Some(stashed) = msg
-                    .get("_ucf_hub")
-                    .and_then(|u| u.get("message"))
-                    .cloned()
-                {
+                if let Some(stashed) = msg.get("_ucf_hub").and_then(|u| u.get("message")).cloned() {
                     if let Ok(hub_msg) = serde_json::from_value::<HubMessage>(stashed) {
                         records.push(HubRecord::Message(hub_msg));
                         continue;
@@ -159,9 +155,7 @@ pub fn from_hub(records: &[HubRecord]) -> Result<Value, ConvertError> {
     // If the hub session came from a non-Gemini source, stash the whole
     // SessionHeader so the hub → gemini → hub round trip is lossless.
     let mut foreign_source = false;
-    if let Some(HubRecord::Session(s)) = records
-        .iter()
-        .find(|r| matches!(r, HubRecord::Session(_)))
+    if let Some(HubRecord::Session(s)) = records.iter().find(|r| matches!(r, HubRecord::Session(_)))
     {
         if s.source_cli != "gemini-cli" {
             session_passthrough = Some(serde_json::to_value(s)?);
@@ -244,11 +238,7 @@ pub fn from_hub(records: &[HubRecord]) -> Result<Value, ConvertError> {
                         attach_ucf_hub_field(&mut gm, "completed_at", Value::String(ca.clone()));
                     }
                     if foreign_source {
-                        attach_ucf_hub_field(
-                            &mut gm,
-                            "message",
-                            serde_json::to_value(msg)?,
-                        );
+                        attach_ucf_hub_field(&mut gm, "message", serde_json::to_value(msg)?);
                     }
                     messages.push(gm);
                 }
@@ -561,7 +551,13 @@ fn build_session_header(root: &Value) -> SessionHeader {
 
     // Stash ALL root-level fields (except messages/sessionId which are mapped)
     // `_ucf_hub` carries cross-CLI passthrough and is handled separately in `to_hub`.
-    let hub_fields: &[&str] = &["sessionId", "messages", "startTime", "lastUpdated", "_ucf_hub"];
+    let hub_fields: &[&str] = &[
+        "sessionId",
+        "messages",
+        "startTime",
+        "lastUpdated",
+        "_ucf_hub",
+    ];
     let mut ext = serde_json::Map::new();
     if let Some(obj) = root.as_object() {
         for (k, v) in obj {
@@ -754,11 +750,7 @@ fn message_to_hub(msg: &Value, foreign_session: bool) -> Result<HubMessage, Conv
         }
     }
 
-    if foreign_originated
-        && ext
-            .as_object()
-            .is_some_and(serde_json::Map::is_empty)
-    {
+    if foreign_originated && ext.as_object().is_some_and(serde_json::Map::is_empty) {
         ext = Value::Null;
     }
 
@@ -824,11 +816,7 @@ fn info_to_hub_event(msg: &Value, foreign_session: bool) -> Result<HubEvent, Con
         }
     }
 
-    if foreign_originated
-        && ext
-            .as_object()
-            .is_some_and(serde_json::Map::is_empty)
-    {
+    if foreign_originated && ext.as_object().is_some_and(serde_json::Map::is_empty) {
         ext = Value::Null;
     }
 
@@ -880,7 +868,7 @@ fn hub_message_to_gemini(msg: &HubMessage) -> Result<Value, ConvertError> {
             .iter()
             .map(|t| serde_json::json!({"text": t}))
             .collect();
-            
+
         // Gemini API will fail if a user message has an empty parts array
         if content_arr.is_empty() {
             content_arr.push(serde_json::json!({"text": " "}));
@@ -1381,7 +1369,10 @@ mod tests {
             let orig = gc.get("_original_message").unwrap();
             assert_eq!(orig.get("id").unwrap().as_str().unwrap(), "msg-5");
             assert_eq!(
-                orig.get("renderOutputAsMarkdown").unwrap().as_bool().unwrap(),
+                orig.get("renderOutputAsMarkdown")
+                    .unwrap()
+                    .as_bool()
+                    .unwrap(),
                 true
             );
         }

--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -81,7 +81,9 @@ pub fn inject_session(
     let (result, target_path) = match target_cli {
         "claude" | "claude-code" => inject_into_claude(&session, &hub_records)?,
         "codex" => inject_into_codex(&session, &hub_records)?,
-        "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" => inject_into_gemini(&session, &hub_records)?,
+        "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" => {
+            inject_into_gemini(&session, &hub_records)?
+        }
         "opencode" => inject_into_opencode(&session, &hub_records)?,
         "pi" | "pi-coding-agent" => inject_into_pi(&session, &hub_records)?,
         _ => {
@@ -113,7 +115,7 @@ fn normalize_target_cli(target: &str) -> &str {
         "claude" | "claude-code" => "claude",
         "codex" => "codex",
         "gemini" | "gemini-cli" => "gemini",
-        "antigravity" | "antigravity-cli" => "antigravity",
+        "antigravity" | "antigravity-cli" => "gemini", // Map to gemini since they share storage layout and resume strategy
         "opencode" => "opencode",
         "pi" | "pi-coding-agent" => "pi",
         other => other,
@@ -130,7 +132,9 @@ fn resume_args_for(target: &str, session_id: &str) -> Vec<String> {
         "pi" | "pi-coding-agent" => crate::agents::AgentType::Pi,
         _ => crate::agents::AgentType::Custom(target.to_string()),
     };
-    crate::agents::AgentDefinition::from_type(agent_type).polyfill.get_resume_args(Some(session_id))
+    crate::agents::AgentDefinition::from_type(agent_type)
+        .polyfill
+        .get_resume_args(Some(session_id))
 }
 
 pub fn source_to_hub(session: &SessionInfo) -> Result<Vec<HubRecord>, ConvertError> {
@@ -525,7 +529,9 @@ fn inject_into_gemini(
     // we must generate a fresh UUID for Gemini to accept it.
     let is_uuid = session_id.len() == 36
         && session_id.split('-').count() == 5
-        && session_id.split('-').all(|seg| seg.chars().all(|c| c.is_ascii_hexdigit()));
+        && session_id
+            .split('-')
+            .all(|seg| seg.chars().all(|c| c.is_ascii_hexdigit()));
 
     let final_records = if !is_uuid {
         session_id = uuid_v4();
@@ -665,7 +671,13 @@ fn sha256_hex(input: &str) -> String {
         .or_else(|| run_sha("shasum", &["-a", "256"], bytes))
         .unwrap_or_else(|| {
             let h = simple_hash(input);
-            format!("{:016x}{:016x}{:016x}{:016x}", h, input.len(), h, input.len())
+            format!(
+                "{:016x}{:016x}{:016x}{:016x}",
+                h,
+                input.len(),
+                h,
+                input.len()
+            )
         })
 }
 
@@ -739,7 +751,11 @@ fn inject_into_opencode(
     // Insert messages and parts
     for (msg_i, oc_msg) in oc_output.messages.iter().enumerate() {
         let msg_id = &msg_ids[msg_i];
-        let parent_msg_id = if msg_i > 0 { Some(&msg_ids[msg_i - 1]) } else { None };
+        let parent_msg_id = if msg_i > 0 {
+            Some(&msg_ids[msg_i - 1])
+        } else {
+            None
+        };
 
         // Patch the message data with proper IDs and parentID chain
         let mut msg_data = oc_msg.clone();
@@ -963,10 +979,7 @@ fn format_byte_budget(bytes: usize) -> String {
 /// Drop oldest non-header records until the serialized output fits `max_bytes`.
 /// Always preserves index 0 (the session header). Returns the number of
 /// records removed from the middle of the list.
-fn trim_pi_lines_to_byte_budget(
-    lines: &mut Vec<serde_json::Value>,
-    max_bytes: usize,
-) -> usize {
+fn trim_pi_lines_to_byte_budget(lines: &mut Vec<serde_json::Value>, max_bytes: usize) -> usize {
     if lines.len() < 2 {
         return 0;
     }
@@ -1038,7 +1051,9 @@ fn short_id() -> String {
     // Mix with a fast counter to disambiguate calls in the same nanosecond.
     static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let seq = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let mixed = (nanos as u64).wrapping_mul(0x9E3779B97F4A7C15).wrapping_add(seq);
+    let mixed = (nanos as u64)
+        .wrapping_mul(0x9E3779B97F4A7C15)
+        .wrapping_add(seq);
     format!("{:08x}", (mixed as u32))
 }
 
@@ -1180,14 +1195,14 @@ fn sha1_hex(input: &str) -> String {
 fn generate_slug() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let adjectives = [
-        "amber", "bold", "calm", "dark", "eager", "fair", "glad", "hazy",
-        "idle", "keen", "lean", "mild", "neat", "odd", "pale", "quick",
-        "rare", "slim", "tall", "vast", "warm", "wise", "young", "zen",
+        "amber", "bold", "calm", "dark", "eager", "fair", "glad", "hazy", "idle", "keen", "lean",
+        "mild", "neat", "odd", "pale", "quick", "rare", "slim", "tall", "vast", "warm", "wise",
+        "young", "zen",
     ];
     let nouns = [
-        "bear", "crow", "deer", "dove", "eagle", "fawn", "goat", "hawk",
-        "ibis", "jay", "kite", "lark", "mole", "newt", "owl", "pike",
-        "quail", "robin", "seal", "toad", "urchin", "vole", "wolf", "wren",
+        "bear", "crow", "deer", "dove", "eagle", "fawn", "goat", "hawk", "ibis", "jay", "kite",
+        "lark", "mole", "newt", "owl", "pike", "quail", "robin", "seal", "toad", "urchin", "vole",
+        "wolf", "wren",
     ];
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1573,9 +1588,7 @@ mod tests {
     fn test_base62_encode_only_valid_chars() {
         let encoded = base62_encode(u128::MAX);
         assert!(
-            encoded
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric()),
+            encoded.chars().all(|c| c.is_ascii_alphanumeric()),
             "should only contain alphanumeric chars: {encoded}"
         );
     }
@@ -1610,7 +1623,11 @@ mod tests {
     fn test_generate_slug_format() {
         let slug = generate_slug();
         let parts: Vec<&str> = slug.split('-').collect();
-        assert_eq!(parts.len(), 3, "slug should be adjective-noun-suffix: {slug}");
+        assert_eq!(
+            parts.len(),
+            3,
+            "slug should be adjective-noun-suffix: {slug}"
+        );
         assert!(
             parts[0].chars().all(|c| c.is_ascii_lowercase()),
             "adjective should be lowercase: {}",
@@ -1691,13 +1708,11 @@ mod tests {
         .unwrap();
 
         // Verify find_or_create_opencode_project creates a project
-        let project_id =
-            find_or_create_opencode_project(&conn, "/home/test/project").unwrap();
+        let project_id = find_or_create_opencode_project(&conn, "/home/test/project").unwrap();
         assert!(!project_id.is_empty());
 
         // Second call should return the same project
-        let project_id2 =
-            find_or_create_opencode_project(&conn, "/home/test/project").unwrap();
+        let project_id2 = find_or_create_opencode_project(&conn, "/home/test/project").unwrap();
         assert_eq!(project_id, project_id2);
 
         // Verify project was created
@@ -1777,10 +1792,7 @@ mod tests {
         // The fallback must kick in for missing AND empty values, otherwise
         // the resulting filename starts with '_' and pi rejects the file.
         let mut empty = serde_json::Map::new();
-        empty.insert(
-            "timestamp".into(),
-            serde_json::Value::String(String::new()),
-        );
+        empty.insert("timestamp".into(), serde_json::Value::String(String::new()));
         let ts = pi_session_timestamp_or_now(&empty);
         assert!(!ts.is_empty(), "empty timestamp must fall back to now");
         assert_eq!(ts.len(), 24, "fallback should be ISO-8601: {ts}");
@@ -1844,7 +1856,10 @@ mod tests {
             .iter()
             .map(|v| serde_json::to_string(v).unwrap().len() + 1)
             .sum();
-        assert!(new_total <= budget, "post-trim {new_total} > budget {budget}");
+        assert!(
+            new_total <= budget,
+            "post-trim {new_total} > budget {budget}"
+        );
     }
 
     #[test]

--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -81,7 +81,7 @@ pub fn inject_session(
     let (result, target_path) = match target_cli {
         "claude" | "claude-code" => inject_into_claude(&session, &hub_records)?,
         "codex" => inject_into_codex(&session, &hub_records)?,
-        "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" => {
+        "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" | "agy" => {
             inject_into_gemini(&session, &hub_records)?
         }
         "opencode" => inject_into_opencode(&session, &hub_records)?,
@@ -115,7 +115,7 @@ fn normalize_target_cli(target: &str) -> &str {
         "claude" | "claude-code" => "claude",
         "codex" => "codex",
         "gemini" | "gemini-cli" => "gemini",
-        "antigravity" | "antigravity-cli" => "gemini", // Map to gemini since they share storage layout and resume strategy
+        "antigravity" | "antigravity-cli" | "agy" => "gemini", // Map to gemini since they share storage layout and resume strategy
         "opencode" => "opencode",
         "pi" | "pi-coding-agent" => "pi",
         other => other,
@@ -127,7 +127,7 @@ fn resume_args_for(target: &str, session_id: &str) -> Vec<String> {
         "claude" | "claude-code" => crate::agents::AgentType::Claude,
         "codex" => crate::agents::AgentType::Codex,
         "gemini" | "gemini-cli" => crate::agents::AgentType::Gemini,
-        "antigravity" | "antigravity-cli" => crate::agents::AgentType::Antigravity,
+        "antigravity" | "antigravity-cli" | "agy" => crate::agents::AgentType::Antigravity,
         "opencode" => crate::agents::AgentType::OpenCode,
         "pi" | "pi-coding-agent" => crate::agents::AgentType::Pi,
         _ => crate::agents::AgentType::Custom(target.to_string()),
@@ -149,7 +149,7 @@ pub fn source_to_hub(session: &SessionInfo) -> Result<Vec<HubRecord>, ConvertErr
             let reader = std::io::BufReader::new(data.as_bytes());
             codex::to_hub(reader)
         }
-        "gemini" | "antigravity" => {
+        "gemini" | "antigravity" | "agy" => {
             let data = std::fs::read(&session.path)?;
             gemini::to_hub(&data)
         }

--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -81,7 +81,7 @@ pub fn inject_session(
     let (result, target_path) = match target_cli {
         "claude" | "claude-code" => inject_into_claude(&session, &hub_records)?,
         "codex" => inject_into_codex(&session, &hub_records)?,
-        "gemini" | "gemini-cli" => inject_into_gemini(&session, &hub_records)?,
+        "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" => inject_into_gemini(&session, &hub_records)?,
         "opencode" => inject_into_opencode(&session, &hub_records)?,
         "pi" | "pi-coding-agent" => inject_into_pi(&session, &hub_records)?,
         _ => {
@@ -113,6 +113,7 @@ fn normalize_target_cli(target: &str) -> &str {
         "claude" | "claude-code" => "claude",
         "codex" => "codex",
         "gemini" | "gemini-cli" => "gemini",
+        "antigravity" | "antigravity-cli" => "antigravity",
         "opencode" => "opencode",
         "pi" | "pi-coding-agent" => "pi",
         other => other,
@@ -124,6 +125,7 @@ fn resume_args_for(target: &str, session_id: &str) -> Vec<String> {
         "claude" | "claude-code" => crate::agents::AgentType::Claude,
         "codex" => crate::agents::AgentType::Codex,
         "gemini" | "gemini-cli" => crate::agents::AgentType::Gemini,
+        "antigravity" | "antigravity-cli" => crate::agents::AgentType::Antigravity,
         "opencode" => crate::agents::AgentType::OpenCode,
         "pi" | "pi-coding-agent" => crate::agents::AgentType::Pi,
         _ => crate::agents::AgentType::Custom(target.to_string()),
@@ -143,7 +145,7 @@ pub fn source_to_hub(session: &SessionInfo) -> Result<Vec<HubRecord>, ConvertErr
             let reader = std::io::BufReader::new(data.as_bytes());
             codex::to_hub(reader)
         }
-        "gemini" => {
+        "gemini" | "antigravity" => {
             let data = std::fs::read(&session.path)?;
             gemini::to_hub(&data)
         }

--- a/src/interchange/mod.rs
+++ b/src/interchange/mod.rs
@@ -121,7 +121,9 @@ pub fn convert_command(
             let reader = BufReader::new(input_data.as_bytes());
             codex::to_hub(reader)?
         }
-        "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" => gemini::to_hub(input_data.as_bytes())?,
+        "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" => {
+            gemini::to_hub(input_data.as_bytes())?
+        }
         "pi" | "pi-coding-agent" => {
             let reader = BufReader::new(input_data.as_bytes());
             pi::to_hub(reader)?

--- a/src/interchange/mod.rs
+++ b/src/interchange/mod.rs
@@ -46,7 +46,7 @@ impl std::str::FromStr for CliFormat {
         match s {
             "claude" | "claude-code" => Ok(Self::ClaudeCode),
             "codex" => Ok(Self::Codex),
-            "gemini" | "gemini-cli" => Ok(Self::GeminiCli),
+            "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" => Ok(Self::GeminiCli),
             "opencode" => Ok(Self::OpenCode),
             "pi" | "pi-coding-agent" => Ok(Self::Pi),
             "ucf" | "hub" => Ok(Self::Ucf),
@@ -121,7 +121,7 @@ pub fn convert_command(
             let reader = BufReader::new(input_data.as_bytes());
             codex::to_hub(reader)?
         }
-        "gemini" | "gemini-cli" => gemini::to_hub(input_data.as_bytes())?,
+        "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" => gemini::to_hub(input_data.as_bytes())?,
         "pi" | "pi-coding-agent" => {
             let reader = BufReader::new(input_data.as_bytes());
             pi::to_hub(reader)?
@@ -155,7 +155,7 @@ pub fn convert_command(
         }
         _ => {
             return Err(ConvertError::InvalidFormat(format!(
-                "Unsupported source format: {from}. Supported: claude, codex, gemini, opencode, pi, hub"
+                "Unsupported source format: {from}. Supported: claude, codex, gemini, antigravity, opencode, pi, hub"
             )));
         }
     };
@@ -166,7 +166,7 @@ pub fn convert_command(
             "claude" | "claude-code" => claude::from_hub(&hub_records)?,
             "codex" => codex::from_hub(&hub_records)?,
             "pi" | "pi-coding-agent" => pi::from_hub(&hub_records)?,
-            "gemini" | "gemini-cli" => {
+            "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" => {
                 let back_val = gemini::from_hub(&hub_records)?;
                 // Gemini is a single JSON file, compare the whole object
                 let orig_val: serde_json::Value = serde_json::from_str(&input_data)?;
@@ -176,7 +176,7 @@ pub fn convert_command(
                         "Round-trip verification failed".into(),
                     ));
                 }
-                println!("Lossless round-trip verified: Gemini session OK");
+                println!("Lossless round-trip verified: Gemini/Antigravity session OK");
                 return Ok(());
             }
             "opencode" => {
@@ -271,14 +271,14 @@ pub fn convert_command(
             "claude" | "claude-code" => claude::from_hub(&hub_records)?,
             "codex" => codex::from_hub(&hub_records)?,
             "pi" | "pi-coding-agent" => pi::from_hub(&hub_records)?,
-            "gemini" | "gemini-cli" => {
+            "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" => {
                 let val = gemini::from_hub(&hub_records)?;
                 let json = serde_json::to_string_pretty(&val)?;
                 match output {
                     Some(path) => {
                         let mut f = std::fs::File::create(path)?;
                         std::io::Write::write_all(&mut f, json.as_bytes())?;
-                        eprintln!("Wrote Gemini session to {path}");
+                        eprintln!("Wrote Gemini/Antigravity session to {path}");
                     }
                     None => print!("{json}"),
                 }
@@ -309,7 +309,7 @@ pub fn convert_command(
             }
             _ => {
                 return Err(ConvertError::InvalidFormat(format!(
-                    "Unsupported target format: {to}. Supported: claude, codex, gemini, opencode, pi, hub"
+                    "Unsupported target format: {to}. Supported: claude, codex, gemini, antigravity, opencode, pi, hub"
                 )));
             }
         };

--- a/src/interchange/mod.rs
+++ b/src/interchange/mod.rs
@@ -46,7 +46,7 @@ impl std::str::FromStr for CliFormat {
         match s {
             "claude" | "claude-code" => Ok(Self::ClaudeCode),
             "codex" => Ok(Self::Codex),
-            "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" => Ok(Self::GeminiCli),
+            "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" | "agy" => Ok(Self::GeminiCli),
             "opencode" => Ok(Self::OpenCode),
             "pi" | "pi-coding-agent" => Ok(Self::Pi),
             "ucf" | "hub" => Ok(Self::Ucf),
@@ -121,7 +121,7 @@ pub fn convert_command(
             let reader = BufReader::new(input_data.as_bytes());
             codex::to_hub(reader)?
         }
-        "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" => {
+        "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" | "agy" => {
             gemini::to_hub(input_data.as_bytes())?
         }
         "pi" | "pi-coding-agent" => {
@@ -168,7 +168,7 @@ pub fn convert_command(
             "claude" | "claude-code" => claude::from_hub(&hub_records)?,
             "codex" => codex::from_hub(&hub_records)?,
             "pi" | "pi-coding-agent" => pi::from_hub(&hub_records)?,
-            "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" => {
+            "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" | "agy" => {
                 let back_val = gemini::from_hub(&hub_records)?;
                 // Gemini is a single JSON file, compare the whole object
                 let orig_val: serde_json::Value = serde_json::from_str(&input_data)?;
@@ -273,7 +273,7 @@ pub fn convert_command(
             "claude" | "claude-code" => claude::from_hub(&hub_records)?,
             "codex" => codex::from_hub(&hub_records)?,
             "pi" | "pi-coding-agent" => pi::from_hub(&hub_records)?,
-            "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" => {
+            "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" | "agy" => {
                 let val = gemini::from_hub(&hub_records)?;
                 let json = serde_json::to_string_pretty(&val)?;
                 match output {

--- a/src/interchange/opencode.rs
+++ b/src/interchange/opencode.rs
@@ -66,11 +66,7 @@ pub fn to_hub(input: &OpenCodeInput) -> Result<Vec<HubRecord>, ConvertError> {
         // content variant losslessly (mixed thinking/text/tool blocks,
         // standalone tool_results on user messages, foreign metadata), but
         // the stashed blob captures everything the foreign source produced.
-        if let Some(stashed) = msg
-            .get("_ucf_hub")
-            .and_then(|u| u.get("message"))
-            .cloned()
-        {
+        if let Some(stashed) = msg.get("_ucf_hub").and_then(|u| u.get("message")).cloned() {
             if let Ok(mut hub_msg) = serde_json::from_value::<HubMessage>(stashed) {
                 // OpenCode has no native `tool` role — tool results live on
                 // user-role messages. Coerce so cross-CLI sources whose hub
@@ -955,7 +951,11 @@ fn hub_message_to_opencode(msg: &HubMessage) -> Result<(Value, Vec<Value>), Conv
     // incoming tool-role hub message (e.g. from Pi) is coerced to user so
     // the output matches OpenCode's on-the-wire shape and the cross-CLI
     // round-trip produces portable roles.
-    let out_role = if msg.role == "tool" { "user" } else { msg.role.as_str() };
+    let out_role = if msg.role == "tool" {
+        "user"
+    } else {
+        msg.role.as_str()
+    };
 
     let mut message = serde_json::json!({
         "role": out_role,

--- a/src/interchange/pi.rs
+++ b/src/interchange/pi.rs
@@ -491,11 +491,7 @@ fn pi_message_to_hub(val: &Value, foreign_originated: bool) -> Result<HubMessage
                 title: None,
                 truncated: false,
             }];
-            (
-                "tool".to_string(),
-                content,
-                MessageMetadata::default(),
-            )
+            ("tool".to_string(), content, MessageMetadata::default())
         }
         other => {
             return Err(ConvertError::InvalidFormat(format!(
@@ -565,10 +561,7 @@ fn extract_content_blocks(content: Option<&Value>) -> Vec<ContentBlock> {
 }
 
 fn content_block_from_pi(block: &Value) -> ContentBlock {
-    let block_type = block
-        .get("type")
-        .and_then(|t| t.as_str())
-        .unwrap_or("");
+    let block_type = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
     match block_type {
         "text" => ContentBlock::Text {
             text: block
@@ -768,10 +761,7 @@ fn hub_message_to_pi(msg: &HubMessage) -> Result<Option<Value>, ConvertError> {
         }
         inner.insert(
             "isError".into(),
-            pi_obj
-                .get("isError")
-                .cloned()
-                .unwrap_or(Value::Bool(tr.2)),
+            pi_obj.get("isError").cloned().unwrap_or(Value::Bool(tr.2)),
         );
         if let Some(ts) = pi_obj.get("envelope_timestamp") {
             inner.insert("timestamp".into(), ts.clone());
@@ -850,10 +840,7 @@ fn hub_message_to_pi(msg: &HubMessage) -> Result<Option<Value>, ConvertError> {
     }
 
     // Restore any envelope fields we preserved but didn't map.
-    if let Some(extras) = pi_obj
-        .get("envelope_extras")
-        .and_then(|v| v.as_object())
-    {
+    if let Some(extras) = pi_obj.get("envelope_extras").and_then(|v| v.as_object()) {
         for (k, v) in extras {
             inner.insert(k.clone(), v.clone());
         }
@@ -869,10 +856,7 @@ fn hub_message_to_pi(msg: &HubMessage) -> Result<Option<Value>, ConvertError> {
             .map(|s| Value::String(s.clone()))
             .unwrap_or(Value::Null),
     );
-    out.insert(
-        "timestamp".into(),
-        Value::String(msg.timestamp.clone()),
-    );
+    out.insert("timestamp".into(), Value::String(msg.timestamp.clone()));
     out.insert("message".into(), Value::Object(inner));
 
     Ok(Some(Value::Object(out)))

--- a/src/interchange/semantic_eq.rs
+++ b/src/interchange/semantic_eq.rs
@@ -13,9 +13,7 @@ fn semantic_eq_inner(a: &Value, b: &Value, path: &str) -> Result<(), String> {
         // fields like `extensions`, `metadata`, `project`, etc. This keeps
         // round-trip equality stable across converters that normalize "no
         // extra data" differently (some emit `{}`, others emit `null`).
-        (Value::Null, Value::Object(m)) | (Value::Object(m), Value::Null) if m.is_empty() => {
-            Ok(())
-        }
+        (Value::Null, Value::Object(m)) | (Value::Object(m), Value::Null) if m.is_empty() => Ok(()),
         (Value::Bool(a), Value::Bool(b)) if a == b => Ok(()),
         (Value::Number(a), Value::Number(b)) => {
             let af = a.as_f64().unwrap_or(0.0);

--- a/src/interchange/sessions.rs
+++ b/src/interchange/sessions.rs
@@ -479,10 +479,14 @@ mod tests {
     #[test]
     fn test_is_claude_backup_stem() {
         // Live session UUIDs should pass through.
-        assert!(!is_claude_backup_stem("8de7c62b-e0ba-4485-8af0-15b6912613a7"));
+        assert!(!is_claude_backup_stem(
+            "8de7c62b-e0ba-4485-8af0-15b6912613a7"
+        ));
         assert!(!is_claude_backup_stem(""));
         // Rotated archive ID — must be skipped or pi crossload eats a 700MB file.
-        assert!(is_claude_backup_stem("8de7c62b-e0ba-4485-8af0-15b6912613a7.archive"));
+        assert!(is_claude_backup_stem(
+            "8de7c62b-e0ba-4485-8af0-15b6912613a7.archive"
+        ));
         // Pre-compact snapshots claude writes alongside the live file.
         assert!(is_claude_backup_stem("abc.pre-compact-full"));
         assert!(is_claude_backup_stem("abc.pre-supercompact"));
@@ -622,7 +626,10 @@ fn discover_ucf() -> Vec<SessionInfo> {
             continue;
         }
 
-        let id = file_name.strip_suffix(".ucf.jsonl").unwrap_or(&file_name).to_string();
+        let id = file_name
+            .strip_suffix(".ucf.jsonl")
+            .unwrap_or(&file_name)
+            .to_string();
 
         let Ok(file) = std::fs::File::open(&path) else {
             continue;
@@ -640,7 +647,10 @@ fn discover_ucf() -> Vec<SessionInfo> {
                         .and_then(|t| t.as_str())
                         .unwrap_or("1970-01-01T00:00:00.000Z")
                         .to_string();
-                    let title = val.get("title").and_then(|t| t.as_str()).map(|s| s.to_string());
+                    let title = val
+                        .get("title")
+                        .and_then(|t| t.as_str())
+                        .map(|s| s.to_string());
 
                     // remaining lines after header (messages + events)
                     let message_count = lines.filter(|l| l.is_ok()).count();

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -242,8 +242,7 @@ pub fn run(auto_mode: bool, prompt: Option<String>, extra_args: Vec<String>) -> 
             // then re-register hooks for currently-enabled plugins.
             let plugin_dirs = find_plugin_dirs();
             let all_plugin_dirs = find_all_plugin_dirs();
-            if let Err(e) =
-                manager.prune_hooks_for_disabled_plugins(&all_plugin_dirs, &plugin_dirs)
+            if let Err(e) = manager.prune_hooks_for_disabled_plugins(&all_plugin_dirs, &plugin_dirs)
             {
                 eprintln!("Warning: Failed to prune disabled plugin hooks: {}", e);
             }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -314,7 +314,7 @@ fn find_agent_command() -> io::Result<PathBuf> {
                         "AGENT_CMD is set to '{}' which resolves to the unleash binary itself.\n\
                          This would cause infinite recursion.\n\
                          Set agent_cli_path in your profile to the actual agent binary \
-                         (e.g. 'claude', 'codex', 'gemini', 'opencode').",
+                         (e.g. 'claude', 'codex', 'antigravity', 'opencode').",
                         cmd
                     ),
                 ));
@@ -506,9 +506,12 @@ fn run_agent(
     if env::var("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC").is_err() {
         cmd.env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1");
     }
-    // Gemini CLI (telemetry off by default, but be explicit)
+    // Gemini/Antigravity CLI (telemetry off by default, but be explicit)
     if env::var("GEMINI_TELEMETRY_ENABLED").is_err() {
         cmd.env("GEMINI_TELEMETRY_ENABLED", "false");
+    }
+    if env::var("ANTIGRAVITY_TELEMETRY_ENABLED").is_err() {
+        cmd.env("ANTIGRAVITY_TELEMETRY_ENABLED", "false");
     }
     // OpenCode
     if env::var("OPENCODE_DISABLE_SHARE").is_err() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,13 @@ mod json_output;
 pub mod launcher;
 pub mod pixel_art;
 pub mod polyfill;
+mod progress;
 mod sandbox;
 pub mod search;
-pub mod token_count;
-mod progress;
 #[cfg(feature = "tui")]
 mod text_input;
 pub mod theme;
+pub mod token_count;
 #[cfg(feature = "tui")]
 mod tui;
 mod updater;
@@ -194,60 +194,26 @@ fn print_profile_help(profile_name: &str) {
     println!(
         "      --safe                       Restore approval prompts (permissions bypassed by default)"
     );
-    println!(
-        "  -p, --prompt <PROMPT>            Run non-interactively with the given prompt"
-    );
-    println!(
-        "  -m, --model <MODEL>              Model to use for the session"
-    );
-    println!(
-        "  -c, --continue                   Continue the most recent session"
-    );
-    println!(
-        "  -r, --resume [ID]                Resume a session by ID, or open picker"
-    );
+    println!("  -p, --prompt <PROMPT>            Run non-interactively with the given prompt");
+    println!("  -m, --model <MODEL>              Model to use for the session");
+    println!("  -c, --continue                   Continue the most recent session");
+    println!("  -r, --resume [ID]                Resume a session by ID, or open picker");
     println!(
         "      --fork                       Fork the session (use with --continue or --resume)"
     );
-    println!(
-        "  -a, --auto                       Enable auto-mode (autonomous operation)"
-    );
-    println!(
-        "  -e, --effort <LEVEL>             Reasoning effort level (e.g., high, low)"
-    );
-    println!(
-        "  -v, --verbose                    Enable verbose/debug output"
-    );
-    println!(
-        "      --output-format <FORMAT>     Output format (json, text, stream-json)"
-    );
-    println!(
-        "      --system-prompt <TEXT>        System prompt text to inject"
-    );
-    println!(
-        "      --allowed-tools <TOOLS>      Allowed tools filter (comma-separated)"
-    );
-    println!(
-        "      --sandbox                    Enable sandbox mode"
-    );
-    println!(
-        "      --name <NAME>                Session name"
-    );
-    println!(
-        "      --add-dir <DIR>              Additional directory to include"
-    );
-    println!(
-        "      --approval-mode <MODE>       Approval/permission mode"
-    );
-    println!(
-        "      --worktree [NAME]            Git worktree mode (optional name)"
-    );
-    println!(
-        "      --dry-run                    Show the resolved command without executing it"
-    );
-    println!(
-        "  -h, --help                       Print this help message"
-    );
+    println!("  -a, --auto                       Enable auto-mode (autonomous operation)");
+    println!("  -e, --effort <LEVEL>             Reasoning effort level (e.g., high, low)");
+    println!("  -v, --verbose                    Enable verbose/debug output");
+    println!("      --output-format <FORMAT>     Output format (json, text, stream-json)");
+    println!("      --system-prompt <TEXT>        System prompt text to inject");
+    println!("      --allowed-tools <TOOLS>      Allowed tools filter (comma-separated)");
+    println!("      --sandbox                    Enable sandbox mode");
+    println!("      --name <NAME>                Session name");
+    println!("      --add-dir <DIR>              Additional directory to include");
+    println!("      --approval-mode <MODE>       Approval/permission mode");
+    println!("      --worktree [NAME]            Git worktree mode (optional name)");
+    println!("      --dry-run                    Show the resolved command without executing it");
+    println!("  -h, --help                       Print this help message");
     println!();
     println!("Passthrough (after --):");
     println!("  Any arguments after '--' are passed directly to the agent CLI unchanged.");
@@ -765,8 +731,8 @@ pub fn run() -> io::Result<()> {
                 Some(HooksAction::Sync) => {
                     let plugin_dirs = launcher::find_plugin_dirs();
                     let all_plugin_dirs = launcher::find_all_plugin_dirs();
-                    let pruned = manager
-                        .prune_hooks_for_disabled_plugins(&all_plugin_dirs, &plugin_dirs)?;
+                    let pruned =
+                        manager.prune_hooks_for_disabled_plugins(&all_plugin_dirs, &plugin_dirs)?;
                     manager.sync_plugin_hooks(&plugin_dirs)?;
                     println!(
                         "Synced hooks from {} plugin(s){}",
@@ -862,8 +828,10 @@ pub fn run() -> io::Result<()> {
                         let items: Vec<json_output::AgentInfoOutput> = defs
                             .iter()
                             .map(|def| {
-                                let installed =
-                                    manager.get_installed_version(def.agent_type.clone()).ok().flatten();
+                                let installed = manager
+                                    .get_installed_version(def.agent_type.clone())
+                                    .ok()
+                                    .flatten();
                                 json_output::AgentInfoOutput {
                                     agent_type: format!("{:?}", def.agent_type).to_lowercase(),
                                     name: def.name.clone(),
@@ -905,7 +873,10 @@ pub fn run() -> io::Result<()> {
                         print!("Checking {}... ", agent_type.display_name());
                         match manager.check_update(agent_type.clone()) {
                             Ok(true) => {
-                                let latest = manager.get_latest_version(agent_type.clone()).ok().flatten();
+                                let latest = manager
+                                    .get_latest_version(agent_type.clone())
+                                    .ok()
+                                    .flatten();
                                 println!(
                                     "update available: {}",
                                     latest.as_deref().unwrap_or("unknown")
@@ -1182,9 +1153,7 @@ pub fn run() -> io::Result<()> {
             top,
         })
         .map_err(|e| io::Error::other(e.to_string())),
-        Some(Commands::Sandbox { action }) => {
-            sandbox::handle_sandbox(action.as_ref())
-        }
+        Some(Commands::Sandbox { action }) => sandbox::handle_sandbox(action.as_ref()),
         Some(Commands::TokenCount { file, tokenizer }) => {
             token_count::handle_token_count(&file, tokenizer.as_deref())
         }
@@ -1379,11 +1348,13 @@ fn handle_config(action: ConfigAction) -> io::Result<()> {
 
 fn setup_ucf_session(ucf_name: &str, target_cli: &str) -> io::Result<(String, Vec<String>)> {
     let ucf_path = dirs::data_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from(env::var("HOME").unwrap_or_default()).join(".local/share"))
+        .unwrap_or_else(|| {
+            std::path::PathBuf::from(env::var("HOME").unwrap_or_default()).join(".local/share")
+        })
         .join("unleash")
         .join("sessions")
         .join(format!("{}.ucf.jsonl", ucf_name));
-        
+
     let ucf_query = format!("ucf:{}", ucf_name);
 
     if !ucf_path.exists() {
@@ -1452,18 +1423,25 @@ fn sync_ucf_session(ucf_name: &str, target_cli: &str, session_id: &str) {
     if let Some(session) = interchange::sessions::find_session(&query) {
         if let Ok(records) = interchange::inject::source_to_hub(&session) {
             let ucf_path = dirs::data_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from(env::var("HOME").unwrap_or_default()).join(".local/share"))
+                .unwrap_or_else(|| {
+                    std::path::PathBuf::from(env::var("HOME").unwrap_or_default())
+                        .join(".local/share")
+                })
                 .join("unleash")
                 .join("sessions")
                 .join(format!("{}.ucf.jsonl", ucf_name));
-            
+
             let mut out = String::new();
             for r in records {
                 out.push_str(&serde_json::to_string(&r).unwrap());
                 out.push('\n');
             }
             if let Err(e) = std::fs::write(&ucf_path, out) {
-                eprintln!("Warning: Failed to save UCF session back to {}: {}", ucf_path.display(), e);
+                eprintln!(
+                    "Warning: Failed to save UCF session back to {}: {}",
+                    ucf_path.display(),
+                    e
+                );
             } else {
                 eprintln!("\x1b[32m✓\x1b[0m Saved native UCF session: {}", ucf_name);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ fn run_agent_with_polyfill(
     let target_cli = match &agent_type {
         AgentType::Claude => "claude",
         AgentType::Codex => "codex",
-        AgentType::Antigravity => "antigravity",
+        AgentType::Antigravity => "agy",
         AgentType::Gemini => "gemini",
         AgentType::OpenCode => "opencode",
         AgentType::Pi => "pi",
@@ -551,7 +551,7 @@ pub fn run() -> io::Result<()> {
             let target_cli = match first_arg {
                 "claude" | "claude-code" => "claude",
                 "codex" => "codex",
-                "antigravity" | "antigravity-cli" | "agy" => "antigravity",
+                "antigravity" | "antigravity-cli" | "agy" => "agy",
                 "gemini" | "gemini-cli" => "gemini",
                 "opencode" => "opencode",
                 "pi" => "pi",
@@ -563,7 +563,7 @@ pub fn run() -> io::Result<()> {
                         .map(|agent| match agent {
                             AgentType::Claude => "claude",
                             AgentType::Codex => "codex",
-                            AgentType::Antigravity => "antigravity",
+                            AgentType::Antigravity => "agy",
                             AgentType::Gemini => "gemini",
                             AgentType::OpenCode => "opencode",
                             AgentType::Pi => "pi",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ fn resolve_target_binary(target_cli: &str) -> String {
     let canonical = match target_cli {
         "claude" | "claude-code" => Some(AgentType::Claude),
         "codex" => Some(AgentType::Codex),
+        "antigravity" | "antigravity-cli" => Some(AgentType::Antigravity),
         "gemini" | "gemini-cli" => Some(AgentType::Gemini),
         "opencode" => Some(AgentType::OpenCode),
         "pi" | "pi-coding-agent" => Some(AgentType::Pi),
@@ -321,6 +322,7 @@ fn run_agent_with_polyfill(
     let target_cli = match &agent_type {
         AgentType::Claude => "claude",
         AgentType::Codex => "codex",
+        AgentType::Antigravity => "antigravity",
         AgentType::Gemini => "gemini",
         AgentType::OpenCode => "opencode",
         AgentType::Pi => "pi",
@@ -581,6 +583,7 @@ pub fn run() -> io::Result<()> {
             let target_cli = match first_arg {
                 "claude" | "claude-code" => "claude",
                 "codex" => "codex",
+                "antigravity" | "antigravity-cli" => "antigravity",
                 "gemini" | "gemini-cli" => "gemini",
                 "opencode" => "opencode",
                 "pi" => "pi",
@@ -592,6 +595,7 @@ pub fn run() -> io::Result<()> {
                         .map(|agent| match agent {
                             AgentType::Claude => "claude",
                             AgentType::Codex => "codex",
+                            AgentType::Antigravity => "antigravity",
                             AgentType::Gemini => "gemini",
                             AgentType::OpenCode => "opencode",
                             AgentType::Pi => "pi",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ fn resolve_target_binary(target_cli: &str) -> String {
     let canonical = match target_cli {
         "claude" | "claude-code" => Some(AgentType::Claude),
         "codex" => Some(AgentType::Codex),
-        "antigravity" | "antigravity-cli" => Some(AgentType::Antigravity),
+        "antigravity" | "antigravity-cli" | "agy" => Some(AgentType::Antigravity),
         "gemini" | "gemini-cli" => Some(AgentType::Gemini),
         "opencode" => Some(AgentType::OpenCode),
         "pi" | "pi-coding-agent" => Some(AgentType::Pi),
@@ -261,7 +261,9 @@ fn run_agent_with_polyfill(
         }
     })?;
 
-    ensure_profile_cli_available(&profile.name, &profile.agent_cli_path)?;
+    if !polyfill_args.dry_run {
+        ensure_profile_cli_available(&profile.name, &profile.agent_cli_path)?;
+    }
 
     let mut app_config = manager.load_app_config().unwrap_or_default();
     if app_config.current_profile != profile.name {
@@ -549,7 +551,7 @@ pub fn run() -> io::Result<()> {
             let target_cli = match first_arg {
                 "claude" | "claude-code" => "claude",
                 "codex" => "codex",
-                "antigravity" | "antigravity-cli" => "antigravity",
+                "antigravity" | "antigravity-cli" | "agy" => "antigravity",
                 "gemini" | "gemini-cli" => "gemini",
                 "opencode" => "opencode",
                 "pi" => "pi",

--- a/src/pixel_art.rs
+++ b/src/pixel_art.rs
@@ -812,7 +812,7 @@ pub mod mascots {
     pub fn full_art(agent: &str) -> &'static str {
         match agent {
             "codex" => ART_CODEX,
-            "gemini" | "gemini-cli" => ART_GEMINI,
+            "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" | "agy" => ART_GEMINI,
             "opencode" => ART_OPENCODE,
             // "jules" => ART_JULES,
             _ => ART_CLAUDE,
@@ -900,8 +900,18 @@ pub mod mascots {
         max_lines: usize,
         gradient: &crate::theme::GradientTheme,
     ) -> Vec<RatatuiLine<'static>> {
+        to_ratatui_gradient_with_width(art, max_lines, gradient, crate::pixel_art::mascots::HALF_WIDTH)
+    }
+
+    /// Helper: parse with diagonal gradient and custom width
+    #[cfg(feature = "tui")]
+    fn to_ratatui_gradient_with_width(
+        art: &str,
+        max_lines: usize,
+        gradient: &crate::theme::GradientTheme,
+        width: usize,
+    ) -> Vec<RatatuiLine<'static>> {
         let height = art.lines().count();
-        let width = crate::pixel_art::mascots::HALF_WIDTH;
         let all_lines = super::parse_ansi_to_ratatui_gradient(art, gradient, width, height);
         all_lines
             .into_iter()
@@ -935,6 +945,15 @@ pub mod mascots {
         to_ratatui_themed(&right_half(agent), max_lines, shift)
     }
 
+    #[cfg(feature = "tui")]
+    pub fn right_ratatui_gradient(
+        agent: &str,
+        max_lines: usize,
+        gradient: &crate::theme::GradientTheme,
+    ) -> Vec<RatatuiLine<'static>> {
+        to_ratatui_gradient(&right_half(agent), max_lines, gradient)
+    }
+
     // --- Agent-aware ratatui rendering (left half) ---
 
     #[cfg(feature = "tui")]
@@ -960,6 +979,15 @@ pub mod mascots {
         to_ratatui_themed(&left_half(agent), max_lines, shift)
     }
 
+    #[cfg(feature = "tui")]
+    pub fn left_ratatui_gradient(
+        agent: &str,
+        max_lines: usize,
+        gradient: &crate::theme::GradientTheme,
+    ) -> Vec<RatatuiLine<'static>> {
+        to_ratatui_gradient(&left_half(agent), max_lines, gradient)
+    }
+
     // --- Agent-aware ratatui rendering (full) ---
 
     #[cfg(feature = "tui")]
@@ -974,6 +1002,15 @@ pub mod mascots {
         shift: crate::theme::ThemeShift,
     ) -> Vec<RatatuiLine<'static>> {
         to_ratatui_themed(full_art(agent), max_lines, shift)
+    }
+
+    #[cfg(feature = "tui")]
+    pub fn full_ratatui_gradient(
+        agent: &str,
+        max_lines: usize,
+        gradient: &crate::theme::GradientTheme,
+    ) -> Vec<RatatuiLine<'static>> {
+        to_ratatui_gradient_with_width(full_art(agent), max_lines, gradient, HALF_WIDTH * 2)
     }
 
     // --- Legacy claude-specific aliases (kept for backward compat) ---

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -118,15 +118,21 @@ pub fn resolve(
     // instead of args, so the resume subcommand replaces the headless `exec`
     // subcommand cleanly. Flag-style agents append into args as before.
     let resume_is_subcommand = if flags.resume.is_some() {
-        matches!(config.session.resume_strategy, crate::agents::ResumeStrategy::Subcommand(_))
+        matches!(
+            config.session.resume_strategy,
+            crate::agents::ResumeStrategy::Subcommand(_)
+        )
     } else if flags.continue_session {
-        matches!(config.session.continue_strategy, crate::agents::ResumeStrategy::Subcommand(_))
+        matches!(
+            config.session.continue_strategy,
+            crate::agents::ResumeStrategy::Subcommand(_)
+        )
     } else {
         false
     };
 
     let resume_or_continue_active = flags.resume.is_some() || flags.continue_session;
-    
+
     if let Some(ref resume_id) = flags.resume {
         let resume_args = config.get_resume_args(resume_id.as_deref());
         if resume_is_subcommand {
@@ -798,7 +804,10 @@ mod tests {
             ..default_flags()
         };
         let inv = resolve(&config, &flags, &[]);
-        assert!(!inv.args.iter().any(|a| a.contains("verbose") || a.contains("debug") || a.contains("print-logs")));
+        assert!(!inv
+            .args
+            .iter()
+            .any(|a| a.contains("verbose") || a.contains("debug") || a.contains("print-logs")));
     }
 
     // ── Output Format ────────────────��──────────────────────

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -202,8 +202,18 @@ pub fn network_exists() -> bool {
 pub fn iptables_rules_active() -> bool {
     // Silence stderr — without root, iptables prints noisy lock errors we don't care about.
     let raw_ok = Command::new("iptables")
-        .args(["-t", "raw", "-C", "PREROUTING",
-               "-s", "172.30.0.0/16", "-d", "10.0.0.0/8", "-j", "DROP"])
+        .args([
+            "-t",
+            "raw",
+            "-C",
+            "PREROUTING",
+            "-s",
+            "172.30.0.0/16",
+            "-d",
+            "10.0.0.0/8",
+            "-j",
+            "DROP",
+        ])
         .stderr(Stdio::null())
         .status()
         .map(|s| s.success())
@@ -377,10 +387,7 @@ pub enum SudoOutcome {
 /// `args` are forwarded to the privileged command. Output is inherited so the
 /// password prompt is visible to the user — callers running inside a TUI must
 /// suspend the alternate screen first.
-pub fn run_sudo<P: AsRef<std::ffi::OsStr>>(
-    cmd_path: &str,
-    args: &[P],
-) -> io::Result<SudoOutcome> {
+pub fn run_sudo<P: AsRef<std::ffi::OsStr>>(cmd_path: &str, args: &[P]) -> io::Result<SudoOutcome> {
     if which::which("sudo").is_err() {
         return Ok(SudoOutcome::SudoMissing);
     }
@@ -485,9 +492,9 @@ pub fn step_gvisor(auto_install: bool) -> Result<String, StepFailure> {
         SudoOutcome::SudoMissing => Err(StepFailure::SudoMissing),
         SudoOutcome::AuthFailed => Err(StepFailure::SudoAuth),
         SudoOutcome::NoTty => Err(StepFailure::NoTty),
-        SudoOutcome::CommandFailed(s) | SudoOutcome::Other(s) => {
-            Err(StepFailure::Recoverable(format!("gVisor install failed: {}", s)))
-        }
+        SudoOutcome::CommandFailed(s) | SudoOutcome::Other(s) => Err(StepFailure::Recoverable(
+            format!("gVisor install failed: {}", s),
+        )),
     }
 }
 
@@ -573,9 +580,8 @@ pub fn step_env_seed(docker_dir: &Path) -> Result<String, StepFailure> {
     let example = docker_dir.join("example.env");
     let dotenv = docker_dir.join(".env");
     if example.exists() {
-        std::fs::copy(&example, &dotenv).map_err(|e| {
-            StepFailure::Recoverable(format!("Failed to copy example.env: {}", e))
-        })?;
+        std::fs::copy(&example, &dotenv)
+            .map_err(|e| StepFailure::Recoverable(format!("Failed to copy example.env: {}", e)))?;
         Ok(format!(
             "Created {} from example.env. Edit it with your API keys before running agents.",
             dotenv.display()
@@ -646,7 +652,9 @@ pub fn canonical_keys_from_example(docker_dir: &Path) -> Vec<String> {
             if let Some(eq) = trimmed.find('=') {
                 let key = trimmed[..eq].trim();
                 if !key.is_empty()
-                    && key.chars().all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+                    && key
+                        .chars()
+                        .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
                     && !keys.contains(&key.to_string())
                 {
                     keys.push(key.to_string());
@@ -753,7 +761,10 @@ pub fn run_setup(docker_dir: &Path) -> io::Result<()> {
     print!("  Docker image... ");
     if image_exists() {
         println!("\x1b[32m✓\x1b[0m {} exists", image_name());
-        println!("    (to update: docker pull {}:{})", DOCKER_IMAGE, DOCKER_TAG);
+        println!(
+            "    (to update: docker pull {}:{})",
+            DOCKER_IMAGE, DOCKER_TAG
+        );
     } else {
         println!("\x1b[33m!\x1b[0m not found — pulling from Docker Hub...");
         match step_container_image(docker_dir) {
@@ -834,14 +845,18 @@ pub fn run_status(docker_dir: Option<&Path>) -> io::Result<()> {
     print!("  Container image:  ");
     if image_exists() {
         let name = image_name();
-        let age = run_command_output("docker", &[
-            "image", "inspect", &name,
-            "--format", "{{.Created}}",
-        ])
+        let age = run_command_output(
+            "docker",
+            &["image", "inspect", &name, "--format", "{{.Created}}"],
+        )
         .ok()
         .map(|s| s.trim().to_string())
         .unwrap_or_default();
-        println!("\x1b[32m✓\x1b[0m {} ({})", name, if age.is_empty() { "unknown age" } else { &age });
+        println!(
+            "\x1b[32m✓\x1b[0m {} ({})",
+            name,
+            if age.is_empty() { "unknown age" } else { &age }
+        );
     } else {
         println!("\x1b[31m✗\x1b[0m not found (run: unleash sandbox setup)");
     }
@@ -857,7 +872,9 @@ pub fn run_status(docker_dir: Option<&Path>) -> io::Result<()> {
                         .lines()
                         .filter(|l| {
                             let l = l.trim();
-                            !l.is_empty() && !l.starts_with('#') && l.contains('=')
+                            !l.is_empty()
+                                && !l.starts_with('#')
+                                && l.contains('=')
                                 && l.split('=').nth(1).map(|v| !v.is_empty()).unwrap_or(false)
                         })
                         .count()
@@ -899,15 +916,24 @@ fn validate_sandbox_name(name: &str) -> io::Result<()> {
         return Err(io::Error::other("sandbox name must be 1-63 characters"));
     }
     if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
-        return Err(io::Error::other("sandbox name must contain only alphanumeric characters and hyphens"));
+        return Err(io::Error::other(
+            "sandbox name must contain only alphanumeric characters and hyphens",
+        ));
     }
     if name.starts_with('-') || name.ends_with('-') {
-        return Err(io::Error::other("sandbox name must not start or end with a hyphen"));
+        return Err(io::Error::other(
+            "sandbox name must not start or end with a hyphen",
+        ));
     }
     Ok(())
 }
 
-pub fn run_agent(docker_dir: Option<&Path>, agent: &str, name: &str, extra_args: &[String]) -> io::Result<()> {
+pub fn run_agent(
+    docker_dir: Option<&Path>,
+    agent: &str,
+    name: &str,
+    extra_args: &[String],
+) -> io::Result<()> {
     // Validate sandbox name (used as Docker hostname, must be RFC 1123 compliant)
     validate_sandbox_name(name)?;
 
@@ -934,7 +960,9 @@ pub fn run_agent(docker_dir: Option<&Path>, agent: &str, name: &str, extra_args:
     }
 
     if !network_exists() {
-        eprintln!("\x1b[33mwarning:\x1b[0m Sandbox network not found. LAN isolation may not be active.");
+        eprintln!(
+            "\x1b[33mwarning:\x1b[0m Sandbox network not found. LAN isolation may not be active."
+        );
         eprintln!("  Fix: sudo unleash sandbox setup");
     }
 
@@ -968,9 +996,12 @@ pub fn run_agent(docker_dir: Option<&Path>, agent: &str, name: &str, extra_args:
         }
 
         cmd.args([
-            "run", "--rm",
-            "-e", &format!("SANDBOX_NAME={}", name),
-            "-e", &format!("HOSTNAME={}", name),
+            "run",
+            "--rm",
+            "-e",
+            &format!("SANDBOX_NAME={}", name),
+            "-e",
+            &format!("HOSTNAME={}", name),
         ]);
 
         // Inject any wizard-configured passthrough keys.
@@ -981,17 +1012,32 @@ pub fn run_agent(docker_dir: Option<&Path>, agent: &str, name: &str, extra_args:
         // Direct docker run (no compose files available — e.g., installed via binary only)
         let container_name = format!("unleash-{}", name);
         cmd.args([
-            "run", "--rm", "-it",
-            "--runtime", "runsc",
-            "--network", "unleash-sandbox",
-            "--name", &container_name,
-            "--hostname", name,
-            "--dns", "8.8.8.8", "--dns", "8.8.4.4",
-            "-e", &format!("SANDBOX_NAME={}", name),
-            "-v", &format!("{}:/workspace", std::env::current_dir()
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_else(|_| ".".to_string())),
-            "-w", "/workspace",
+            "run",
+            "--rm",
+            "-it",
+            "--runtime",
+            "runsc",
+            "--network",
+            "unleash-sandbox",
+            "--name",
+            &container_name,
+            "--hostname",
+            name,
+            "--dns",
+            "8.8.8.8",
+            "--dns",
+            "8.8.4.4",
+            "-e",
+            &format!("SANDBOX_NAME={}", name),
+            "-v",
+            &format!(
+                "{}:/workspace",
+                std::env::current_dir()
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_else(|_| ".".to_string())
+            ),
+            "-w",
+            "/workspace",
         ]);
 
         // Wizard-configured passthrough keys (replaces the previous hard-coded list).
@@ -1030,7 +1076,10 @@ pub fn run_agent(docker_dir: Option<&Path>, agent: &str, name: &str, extra_args:
 /// Shared helper: run `<bash> <abs-script-path> <args...>` under sudo.
 fn run_sudo_script(script: &Path, args: &[&str]) -> io::Result<()> {
     if !script.exists() {
-        eprintln!("\x1b[31merror:\x1b[0m sandbox-network.sh not found at {}", script.display());
+        eprintln!(
+            "\x1b[31merror:\x1b[0m sandbox-network.sh not found at {}",
+            script.display()
+        );
         return Err(io::Error::other("script not found"));
     }
     let bash = which::which("bash")
@@ -1076,8 +1125,10 @@ pub fn run_list() -> io::Result<()> {
     let output = Command::new("docker")
         .args([
             "ps",
-            "--filter", "network=unleash-sandbox",
-            "--format", "table {{.ID}}\t{{.Names}}\t{{.Status}}\t{{.RunningFor}}\t{{.Command}}",
+            "--filter",
+            "network=unleash-sandbox",
+            "--format",
+            "table {{.ID}}\t{{.Names}}\t{{.Status}}\t{{.RunningFor}}\t{{.Command}}",
         ])
         .output()?;
 
@@ -1118,10 +1169,7 @@ pub fn run_enter(target: &str, shell: &str) -> io::Result<()> {
     } else {
         // Search sandbox containers by hostname
         let output = Command::new("docker")
-            .args([
-                "ps", "-q",
-                "--filter", "network=unleash-sandbox",
-            ])
+            .args(["ps", "-q", "--filter", "network=unleash-sandbox"])
             .output()?;
 
         let raw = String::from_utf8_lossy(&output.stdout).to_string();
@@ -1134,9 +1182,10 @@ pub fn run_enter(target: &str, shell: &str) -> io::Result<()> {
         // Check each container's hostname
         let mut match_id = None;
         for id in &container_ids {
-            let hostname = run_command_output("docker", &[
-                "inspect", "--format", "{{.Config.Hostname}}", id,
-            ])?;
+            let hostname = run_command_output(
+                "docker",
+                &["inspect", "--format", "{{.Config.Hostname}}", id],
+            )?;
             if hostname.trim() == target {
                 match_id = Some(id.to_string());
                 break;

--- a/src/search.rs
+++ b/src/search.rs
@@ -122,10 +122,7 @@ alpha = 0.4
 tunnel_hint = "ssh -fN -L 18000:10.42.1.11:8000 sentinel"
 "#;
     if let Err(e) = fs::write(&path, default) {
-        eprintln!(
-            "warning: could not write default {}: {e}",
-            path.display()
-        );
+        eprintln!("warning: could not write default {}: {e}", path.display());
     } else {
         eprintln!("wrote default config: {}", path.display());
     }
@@ -141,7 +138,11 @@ fn resolve_config() -> ResolvedConfig {
             .unwrap_or_else(|| default.to_string())
     };
 
-    let oai_base = pick("OAI_BASE", file.oai_base.clone(), "http://127.0.0.1:18000/v1");
+    let oai_base = pick(
+        "OAI_BASE",
+        file.oai_base.clone(),
+        "http://127.0.0.1:18000/v1",
+    );
     let embed_model = pick("OAI_EMBED_MODEL", file.embed_model.clone(), "lco-omni-3b");
     let chat_base = env::var("OAI_CHAT_BASE")
         .ok()
@@ -303,7 +304,9 @@ async fn set_session_title(
                 None => String::new(),
             };
             if text.is_empty() {
-                return Err("session has no indexed text — run `unleash sessions reindex` first".into());
+                return Err(
+                    "session has no indexed text — run `unleash sessions reindex` first".into(),
+                );
             }
 
             let http = reqwest::Client::builder()
@@ -388,10 +391,7 @@ async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
                         recovered = true;
                         break;
                     }
-                    tokio::time::sleep(std::time::Duration::from_millis(
-                        200 + attempt * 100,
-                    ))
-                    .await;
+                    tokio::time::sleep(std::time::Duration::from_millis(200 + attempt * 100)).await;
                 }
             }
         }
@@ -438,8 +438,11 @@ async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     bootstrap_schema(&conn).await?;
 
     if args.reindex {
-        conn.execute("UPDATE sessions SET embedding=NULL, model_id=NULL, generated_title=NULL", ())
-            .await?;
+        conn.execute(
+            "UPDATE sessions SET embedding=NULL, model_id=NULL, generated_title=NULL",
+            (),
+        )
+        .await?;
     }
 
     // ── Discover + upsert ──────────────────────────────────────────────
@@ -742,7 +745,9 @@ fn available_profiles() -> Vec<String> {
 fn launch_crossload(profile: &str, source_cli: &str, source_id: &str) {
     use std::os::unix::process::CommandExt;
     let handle = format!("{source_cli}:{source_id}");
-    let argv0 = std::env::args().next().unwrap_or_else(|| "unleash".to_string());
+    let argv0 = std::env::args()
+        .next()
+        .unwrap_or_else(|| "unleash".to_string());
     eprintln!("\n→ exec: {argv0} {profile} -x {handle}");
     let err = std::process::Command::new(&argv0)
         .arg(profile)
@@ -1036,14 +1041,7 @@ fn extract_text(s: &SessionInfo) -> Option<String> {
 fn collect_content_strings(val: &serde_json::Value, out: &mut Vec<String>) {
     use serde_json::Value;
     const CONTENT_KEYS: &[&str] = &[
-        "content",
-        "text",
-        "message",
-        "summary",
-        "input",
-        "prompt",
-        "messages",
-        "payload",
+        "content", "text", "message", "summary", "input", "prompt", "messages", "payload",
     ];
     match val {
         Value::Object(map) => {
@@ -1698,7 +1696,11 @@ fn rescore(state: &mut TuiState) {
         state
             .rows
             .iter()
-            .map(|r| r.embedding.as_ref().map(|emb| cosine_distance(qv, emb) as f32))
+            .map(|r| {
+                r.embedding
+                    .as_ref()
+                    .map(|emb| cosine_distance(qv, emb) as f32)
+            })
             .collect()
     } else {
         vec![None; state.rows.len()]
@@ -1732,7 +1734,11 @@ fn rescore(state: &mut TuiState) {
         // Empty query: sort by recency (already the order from discover_all).
         scored.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
     } else {
-        scored.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        scored.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
     }
     scored.truncate(state.top.max(50));
     for (i, h) in scored.iter_mut().enumerate() {
@@ -1793,7 +1799,11 @@ fn render_tui(frame: &mut Frame, state: &TuiState) {
             Block::default()
                 .borders(Borders::ALL)
                 .title(title)
-                .title_style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+                .title_style(
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ),
         );
     frame.render_widget(q_para, chunks[0]);
 
@@ -1810,7 +1820,9 @@ fn render_tui(frame: &mut Frame, state: &TuiState) {
             let selected = i == state.selected;
             let prefix = if selected { "> " } else { "  " };
             let style_sel = if selected {
-                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default()
             };
@@ -1837,7 +1849,10 @@ fn render_tui(frame: &mut Frame, state: &TuiState) {
                     },
                 ),
                 Span::styled(format!("{:<6} ", cos), Style::default().fg(Color::DarkGray)),
-                Span::styled(format!("[{:>7}] ", h.cli), Style::default().fg(Color::Magenta)),
+                Span::styled(
+                    format!("[{:>7}] ", h.cli),
+                    Style::default().fg(Color::Magenta),
+                ),
                 Span::styled(format!("{:<40} ", truncate(&title, 40)), style_sel),
                 Span::styled(
                     truncate(h.directory.as_deref().unwrap_or(""), 28),
@@ -1848,11 +1863,7 @@ fn render_tui(frame: &mut Frame, state: &TuiState) {
             ])
         })
         .collect();
-    let count_title = format!(
-        " {} / {} ",
-        state.scored.len(),
-        state.rows.len()
-    );
+    let count_title = format!(" {} / {} ", state.scored.len(), state.rows.len());
     let list = Paragraph::new(lines).block(
         Block::default()
             .borders(Borders::ALL)
@@ -1881,7 +1892,9 @@ fn render_tui(frame: &mut Frame, state: &TuiState) {
 
     // Help line
     let help = match state.mode {
-        Mode::Searching => "type=filter  ↑↓=move  Enter=pick profile  Tab=cycle α  ⇧←/→=fine α  Esc=quit",
+        Mode::Searching => {
+            "type=filter  ↑↓=move  Enter=pick profile  Tab=cycle α  ⇧←/→=fine α  Esc=quit"
+        }
         Mode::PickingProfile => "↑↓=move  Enter=launch crossload  Esc=back",
     };
     let help_p = Paragraph::new(Line::from(vec![Span::styled(
@@ -1902,7 +1915,10 @@ fn render_tui(frame: &mut Frame, state: &TuiState) {
         };
         frame.render_widget(Clear, modal);
         let header = if let Some(hit) = state.scored.get(state.selected) {
-            format!(" launch into profile — {} ", truncate(&display_title(hit), 30))
+            format!(
+                " launch into profile — {} ",
+                truncate(&display_title(hit), 30)
+            )
         } else {
             " launch into profile ".to_string()
         };
@@ -1913,7 +1929,9 @@ fn render_tui(frame: &mut Frame, state: &TuiState) {
             .map(|(i, p)| {
                 let sel = i == state.profile_selected;
                 let style = if sel {
-                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD)
                 } else {
                     Style::default()
                 };

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -288,6 +288,15 @@ impl GradientTheme {
             (0xC3, 0x67, 0x7F), // #C3677F pink
         ])
     }
+
+    /// The Antigravity CLI gradient: purple → futuristic blue → neon cyan/teal
+    pub fn antigravity() -> Self {
+        Self::new(&[
+            (0x9b, 0x51, 0xe0), // purple
+            (0x30, 0x80, 0xe0), // futuristic blue
+            (0x00, 0xc2, 0xff), // neon cyan/teal
+        ])
+    }
 }
 
 /// Transform a color using a diagonal gradient.

--- a/src/token_count.rs
+++ b/src/token_count.rs
@@ -52,8 +52,11 @@ fn count_file_tiktoken(path: &Path) -> io::Result<usize> {
 }
 
 fn count_file_hf(path: &Path, tokenizer_path: &str) -> io::Result<usize> {
-    let tokenizer = tokenizers::Tokenizer::from_file(tokenizer_path)
-        .map_err(|e| io::Error::other(format!("Failed to load tokenizer from {tokenizer_path}: {e}")))?;
+    let tokenizer = tokenizers::Tokenizer::from_file(tokenizer_path).map_err(|e| {
+        io::Error::other(format!(
+            "Failed to load tokenizer from {tokenizer_path}: {e}"
+        ))
+    })?;
 
     let file = fs::File::open(path)?;
     let reader = io::BufReader::new(file);

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -4099,15 +4099,15 @@ impl App {
             };
 
             let max_lines = figure_rect.height as usize;
-            let agent = self.app_config.current_profile.as_str();
+            let agent_type = self.selected_profile.as_ref().and_then(|p| p.agent_type());
+            let mascot_name = agent_type.as_ref().map(|t| t.mascot_name()).unwrap_or("claude");
             let shift = self.theme_color.theme_shift();
-            let art_lines: Vec<Line> = if self.is_gemini_profile() {
-                let gradient = crate::theme::GradientTheme::gemini();
-                mascots::unleashed_claude_full_ratatui_gradient(max_lines, &gradient)
+            let art_lines: Vec<Line> = if let Some(gradient) = self.profile_gradient() {
+                mascots::full_ratatui_gradient(mascot_name, max_lines, &gradient)
             } else if !shift.is_identity() {
-                mascots::full_ratatui_themed(agent, max_lines, shift)
+                mascots::full_ratatui_themed(mascot_name, max_lines, shift)
             } else {
-                mascots::full_ratatui(agent, max_lines)
+                mascots::full_ratatui(mascot_name, max_lines)
             };
             let art_widget = Paragraph::new(art_lines).scroll((0, scroll_x));
             frame.render_widget(art_widget, figure_rect);
@@ -4188,29 +4188,32 @@ impl App {
         }
     }
 
-    /// Check if the current profile is a Gemini agent (uses gradient)
-    fn is_gemini_profile(&self) -> bool {
-        self.selected_profile
-            .as_ref()
-            .and_then(|p| p.agent_type())
-            .is_some_and(|t| t == crate::agents::AgentType::Gemini)
+
+    /// Get the gradient theme for the current profile if it uses a gradient
+    fn profile_gradient(&self) -> Option<crate::theme::GradientTheme> {
+        let t = self.selected_profile.as_ref().and_then(|p| p.agent_type())?;
+        match t {
+            crate::agents::AgentType::Gemini => Some(crate::theme::GradientTheme::gemini()),
+            crate::agents::AgentType::Antigravity => Some(crate::theme::GradientTheme::antigravity()),
+            _ => None,
+        }
     }
 
     fn render_art_sidebar(&self, frame: &mut Frame, area: Rect) {
         // Render mascot ANSI art (right-facing) for the current agent profile
         // Lava lamp mode is an easter egg triggered by Konami code (idea by cac taurus)
         let max_lines = area.height as usize;
-        let agent = self.app_config.current_profile.as_str();
+        let agent_type = self.selected_profile.as_ref().and_then(|p| p.agent_type());
+        let mascot_name = agent_type.as_ref().map(|t| t.mascot_name()).unwrap_or("claude");
         let shift = self.theme_color.theme_shift();
         let art_lines: Vec<Line> = if self.lava_mode {
-            mascots::right_ratatui_lava(agent, max_lines, self.animation_frame)
-        } else if self.is_gemini_profile() {
-            let gradient = crate::theme::GradientTheme::gemini();
-            mascots::unleashed_claude_ratatui_gradient(max_lines, &gradient)
+            mascots::right_ratatui_lava(mascot_name, max_lines, self.animation_frame)
+        } else if let Some(gradient) = self.profile_gradient() {
+            mascots::right_ratatui_gradient(mascot_name, max_lines, &gradient)
         } else if !shift.is_identity() {
-            mascots::right_ratatui_themed(agent, max_lines, shift)
+            mascots::right_ratatui_themed(mascot_name, max_lines, shift)
         } else {
-            mascots::right_ratatui(agent, max_lines)
+            mascots::right_ratatui(mascot_name, max_lines)
         };
         let art_widget = Paragraph::new(art_lines);
         frame.render_widget(art_widget, area);
@@ -4220,17 +4223,17 @@ impl App {
         // Render mascot ANSI art (left-facing) for the current agent profile
         // Lava lamp mode is an easter egg triggered by Konami code (idea by cac taurus)
         let max_lines = area.height as usize;
-        let agent = self.app_config.current_profile.as_str();
+        let agent_type = self.selected_profile.as_ref().and_then(|p| p.agent_type());
+        let mascot_name = agent_type.as_ref().map(|t| t.mascot_name()).unwrap_or("claude");
         let shift = self.theme_color.theme_shift();
         let art_lines: Vec<Line> = if self.lava_mode {
-            mascots::left_ratatui_lava(agent, max_lines, self.animation_frame)
-        } else if self.is_gemini_profile() {
-            let gradient = crate::theme::GradientTheme::gemini();
-            mascots::unleashed_claude_left_ratatui_gradient(max_lines, &gradient)
+            mascots::left_ratatui_lava(mascot_name, max_lines, self.animation_frame)
+        } else if let Some(gradient) = self.profile_gradient() {
+            mascots::left_ratatui_gradient(mascot_name, max_lines, &gradient)
         } else if !shift.is_identity() {
-            mascots::left_ratatui_themed(agent, max_lines, shift)
+            mascots::left_ratatui_themed(mascot_name, max_lines, shift)
         } else {
-            mascots::left_ratatui(agent, max_lines)
+            mascots::left_ratatui(mascot_name, max_lines)
         };
         let art_widget = Paragraph::new(art_lines);
         frame.render_widget(art_widget, area);

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -264,10 +264,7 @@ pub fn build_agent_cli_picker_entries(custom: &[AgentDefinition]) -> Vec<AgentCl
 /// Resolve the binary path for an agent type.
 /// For built-ins, prefer `which::which(<binary>)` so the profile records the
 /// resolved absolute path. Falls back to the bare binary name if `which` fails.
-pub fn resolve_agent_binary_path(
-    agent: &AgentType,
-    custom: &[AgentDefinition],
-) -> String {
+pub fn resolve_agent_binary_path(agent: &AgentType, custom: &[AgentDefinition]) -> String {
     let binary = match agent {
         AgentType::Claude => AgentDefinition::claude().binary,
         AgentType::Codex => AgentDefinition::codex().binary,
@@ -319,7 +316,10 @@ pub enum SandboxStepStatus {
 
 impl SandboxStepStatus {
     pub fn is_done(&self) -> bool {
-        matches!(self, SandboxStepStatus::Success(_) | SandboxStepStatus::Skipped)
+        matches!(
+            self,
+            SandboxStepStatus::Success(_) | SandboxStepStatus::Skipped
+        )
     }
 }
 
@@ -1700,10 +1700,7 @@ impl App {
     /// and ask the run_app loop to open it.
     pub fn start_custom_agent_editor(&mut self) {
         let dir = std::env::temp_dir();
-        let path = dir.join(format!(
-            "unleash-custom-agent-{}.toml",
-            std::process::id()
-        ));
+        let path = dir.join(format!("unleash-custom-agent-{}.toml", std::process::id()));
         if let Err(e) = std::fs::write(&path, custom_agent_toml_template()) {
             self.status_message = Some(format!("Failed to write template: {}", e));
             self.edit_field = EditField::None;
@@ -1735,11 +1732,10 @@ impl App {
         self.refresh_available_agents();
 
         // Point profile at the new custom agent
-        let resolved =
-            which::which(&binary)
-                .ok()
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or(binary);
+        let resolved = which::which(&binary)
+            .ok()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or(binary);
         if let Some(ref mut profile) = self.editing_profile {
             profile.agent_cli_path = resolved;
             let _ = self.profile_manager.save_profile(profile);
@@ -1750,7 +1746,9 @@ impl App {
         let entries = self.agent_cli_picker_entries();
         self.agent_picker_index = entries
             .iter()
-            .position(|e| matches!(e, AgentCliPickerEntry::Agent(AgentType::Custom(n)) if *n == name))
+            .position(
+                |e| matches!(e, AgentCliPickerEntry::Agent(AgentType::Custom(n)) if *n == name),
+            )
             .unwrap_or(0);
         self.status_message = Some(format!("Custom agent '{}' added", name));
         self.edit_field = EditField::AgentCliPicker;
@@ -1917,7 +1915,8 @@ impl App {
                 match self.version_focus {
                     VersionFocus::Unleash => {} // no scroll in unleash section
                     VersionFocus::AgentPicker => {
-                        let current_idx = self.available_agents
+                        let current_idx = self
+                            .available_agents
                             .iter()
                             .position(|a| *a == self.version_agent)
                             .unwrap_or(0);
@@ -2209,8 +2208,8 @@ impl App {
                         if let Some(draft) = self.custom_agent_draft.as_mut() {
                             draft.model_flag = self.key_input.value.trim().to_string();
                         }
-                        self.key_input = TextInput::new()
-                            .with_placeholder("optional, blank = none");
+                        self.key_input =
+                            TextInput::new().with_placeholder("optional, blank = none");
                         self.edit_field = EditField::CustomAgentYoloFlag;
                     }
                     EditField::CustomAgentYoloFlag => {
@@ -2545,9 +2544,7 @@ impl App {
                             AgentType::OpenCode => {
                                 vm.install_opencode_version_streaming(&version, log_tx)
                             }
-                            AgentType::Pi => {
-                                vm.install_pi_version_streaming(&version, log_tx)
-                            }
+                            AgentType::Pi => vm.install_pi_version_streaming(&version, log_tx),
                             AgentType::Hermes => {
                                 vm.install_hermes_version_streaming(&version, log_tx)
                             }
@@ -2703,12 +2700,15 @@ impl App {
             VersionFocus::AgentPicker => {
                 match action {
                     NavAction::Up | NavAction::Down => {
-                        let current_idx = self.available_agents
+                        let current_idx = self
+                            .available_agents
                             .iter()
                             .position(|a| *a == self.version_agent)
                             .unwrap_or(0);
                         let new_idx = match action {
-                            NavAction::Down => (current_idx + 1).min(self.available_agents.len() - 1),
+                            NavAction::Down => {
+                                (current_idx + 1).min(self.available_agents.len() - 1)
+                            }
                             NavAction::Up => {
                                 if current_idx == 0 {
                                     // At top of agent list, move focus to unleash
@@ -2883,7 +2883,9 @@ impl App {
                         success: false,
                         stdout: String::new(),
                         stderr: String::new(),
-                        error: Some("Version management not yet supported for custom agents".into()),
+                        error: Some(
+                            "Version management not yet supported for custom agents".into(),
+                        ),
                     }),
                 };
 
@@ -3307,8 +3309,7 @@ impl App {
                     if let Ok(manager) = crate::hooks::HookManager::new() {
                         let enabled_dirs = crate::launcher::find_plugin_dirs();
                         let all_dirs = crate::launcher::find_all_plugin_dirs();
-                        let _ =
-                            manager.prune_hooks_for_disabled_plugins(&all_dirs, &enabled_dirs);
+                        let _ = manager.prune_hooks_for_disabled_plugins(&all_dirs, &enabled_dirs);
                         let _ = manager.sync_plugin_hooks(&enabled_dirs);
                     }
                 }
@@ -3765,7 +3766,10 @@ impl App {
                     EnvKeyChoice::Skip => "—".into(),
                 };
                 detail_lines.push(Line::from(vec![
-                    Span::styled(format!("  {} ", host_marker), Style::default().fg(Color::Yellow)),
+                    Span::styled(
+                        format!("  {} ", host_marker),
+                        Style::default().fg(Color::Yellow),
+                    ),
                     Span::styled(format!("{:<28}", row.key), highlight),
                     Span::styled(" ◀ ", Style::default().fg(Color::DarkGray)),
                     Span::styled(format!("{:<12}", row.choice.label()), highlight),
@@ -4977,12 +4981,8 @@ impl App {
         frame.render_widget(Clear, dialog_area);
 
         let (step, total, label, hint) = match self.edit_field {
-            EditField::CustomAgentName => {
-                (1, 8, "Name", "A short identifier (no spaces)")
-            }
-            EditField::CustomAgentBinary => {
-                (2, 8, "Binary", "Executable on PATH or absolute path")
-            }
+            EditField::CustomAgentName => (1, 8, "Name", "A short identifier (no spaces)"),
+            EditField::CustomAgentBinary => (2, 8, "Binary", "Executable on PATH or absolute path"),
             EditField::CustomAgentHeadlessFlag => (
                 3,
                 8,
@@ -5007,9 +5007,12 @@ impl App {
                 "Resume flag",
                 "Flag for resuming a specific session (default: --resume)",
             ),
-            EditField::CustomAgentModelFlag => {
-                (6, 8, "Model flag", "Flag for model selection (default: --model)")
-            }
+            EditField::CustomAgentModelFlag => (
+                6,
+                8,
+                "Model flag",
+                "Flag for model selection (default: --model)",
+            ),
             EditField::CustomAgentYoloFlag => (
                 7,
                 8,
@@ -5652,7 +5655,11 @@ impl App {
 
             let (prefix, style) = if is_depr {
                 (
-                    if is_selected { "> ⚠️ " } else { "  ⚠️ " },
+                    if is_selected {
+                        "> ⚠️ "
+                    } else {
+                        "  ⚠️ "
+                    },
                     Style::default()
                         .fg(Color::DarkGray)
                         .add_modifier(Modifier::DIM),
@@ -5699,10 +5706,7 @@ impl App {
             let spans = vec![
                 prefix_span,
                 Span::styled(format!("{:<20}", name_str), style),
-                Span::styled(
-                    format!("{:<12}", version_str),
-                    version_style,
-                ),
+                Span::styled(format!("{:<12}", version_str), version_style),
             ];
 
             lines.push(Line::from(spans));
@@ -6821,8 +6825,14 @@ mod tests {
     fn test_agent_from_str() {
         assert_eq!(AgentType::from_str("claude"), Some(AgentType::Claude));
         assert_eq!(AgentType::from_str("codex"), Some(AgentType::Codex));
-        assert_eq!(AgentType::from_str("antigravity"), Some(AgentType::Antigravity));
-        assert_eq!(AgentType::from_str("antigravity-cli"), Some(AgentType::Antigravity));
+        assert_eq!(
+            AgentType::from_str("antigravity"),
+            Some(AgentType::Antigravity)
+        );
+        assert_eq!(
+            AgentType::from_str("antigravity-cli"),
+            Some(AgentType::Antigravity)
+        );
         assert_eq!(AgentType::from_str("gemini"), Some(AgentType::Gemini));
         assert_eq!(AgentType::from_str("gemini-cli"), Some(AgentType::Gemini));
         assert_eq!(AgentType::from_str("opencode"), Some(AgentType::OpenCode));
@@ -6830,10 +6840,7 @@ mod tests {
         assert_eq!(AgentType::from_str("pi"), Some(AgentType::Pi));
         assert_eq!(AgentType::from_str("pi-coding-agent"), Some(AgentType::Pi));
         assert_eq!(AgentType::from_str("hermes"), Some(AgentType::Hermes));
-        assert_eq!(
-            AgentType::from_str("hermes-agent"),
-            Some(AgentType::Hermes)
-        );
+        assert_eq!(AgentType::from_str("hermes-agent"), Some(AgentType::Hermes));
         assert_eq!(AgentType::from_str("unknown"), None);
     }
 
@@ -6975,7 +6982,10 @@ mod tests {
         assert_eq!(entries.len(), 8);
         assert_eq!(entries[0], AgentCliPickerEntry::Agent(AgentType::Claude));
         assert_eq!(entries[1], AgentCliPickerEntry::Agent(AgentType::Codex));
-        assert_eq!(entries[2], AgentCliPickerEntry::Agent(AgentType::Antigravity));
+        assert_eq!(
+            entries[2],
+            AgentCliPickerEntry::Agent(AgentType::Antigravity)
+        );
         assert_eq!(entries[3], AgentCliPickerEntry::Agent(AgentType::OpenCode));
         assert_eq!(entries[4], AgentCliPickerEntry::Agent(AgentType::Pi));
         assert_eq!(entries[5], AgentCliPickerEntry::Agent(AgentType::Hermes));
@@ -7067,7 +7077,11 @@ mod tests {
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_default();
-        assert_eq!(file_name, "codex", "agent_cli_path: {}", saved.agent_cli_path);
+        assert_eq!(
+            file_name, "codex",
+            "agent_cli_path: {}",
+            saved.agent_cli_path
+        );
         assert_eq!(saved.agent_type(), Some(AgentType::Codex));
     }
 
@@ -7324,10 +7338,7 @@ yolo_flag = "--yes"
     fn test_sandbox_record_result_failure_includes_hints() {
         let (mut app, _temp) = test_app();
         app.open_sandbox_wizard();
-        app.sandbox_record_result(
-            0,
-            Err(crate::sandbox::StepFailure::SudoMissing),
-        );
+        app.sandbox_record_result(0, Err(crate::sandbox::StepFailure::SudoMissing));
         match &app.sandbox_wizard.as_ref().unwrap().statuses[0] {
             SandboxStepStatus::FailedRecoverable(_msg, hints) => {
                 assert!(!hints.is_empty(), "failure should ship next-action hints");
@@ -7405,7 +7416,7 @@ yolo_flag = "--yes"
         app.screen = Screen::Sandbox;
         let wiz = app.sandbox_wizard.as_mut().unwrap();
         wiz.step = 5; // Summary
-        // Mark every row as Skip so finishing produces an empty config (safe).
+                      // Mark every row as Skip so finishing produces an empty config (safe).
         for row in &mut wiz.env_draft.rows {
             row.choice = EnvKeyChoice::Skip;
         }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -271,6 +271,7 @@ pub fn resolve_agent_binary_path(
     let binary = match agent {
         AgentType::Claude => AgentDefinition::claude().binary,
         AgentType::Codex => AgentDefinition::codex().binary,
+        AgentType::Antigravity => AgentDefinition::antigravity().binary,
         AgentType::Gemini => AgentDefinition::gemini().binary,
         AgentType::OpenCode => AgentDefinition::opencode().binary,
         AgentType::Pi => AgentDefinition::pi().binary,
@@ -884,6 +885,7 @@ impl App {
         let agent_keys: &[(&str, AgentType)] = &[
             ("claude", AgentType::Claude),
             ("codex", AgentType::Codex),
+            ("antigravity", AgentType::Antigravity),
             ("gemini", AgentType::Gemini),
             ("opencode", AgentType::OpenCode),
             ("pi", AgentType::Pi),
@@ -916,6 +918,7 @@ impl App {
             if let Ok(mut mgr) = AgentManager::new() {
                 for agent_type in &[
                     AgentType::Codex,
+                    AgentType::Antigravity,
                     AgentType::Gemini,
                     AgentType::OpenCode,
                     AgentType::Pi,
@@ -1456,6 +1459,14 @@ impl App {
                     let versions = vm.get_codex_version_list(installed.as_deref());
                     let conflicts = vm.detect_conflicts("codex");
                     let _ = tx.send((AgentType::Codex, versions, conflicts));
+                });
+            }
+            AgentType::Antigravity => {
+                thread::spawn(move || {
+                    let vm = VersionManager::new();
+                    let versions = vm.get_antigravity_version_list(installed.as_deref());
+                    let conflicts = vm.detect_conflicts("antigravity");
+                    let _ = tx.send((AgentType::Antigravity, versions, conflicts));
                 });
             }
             AgentType::Gemini => {
@@ -2528,6 +2539,9 @@ impl App {
                             AgentType::Gemini => {
                                 vm.install_gemini_version_streaming(&version, log_tx)
                             }
+                            AgentType::Antigravity => {
+                                vm.install_antigravity_version_streaming(&version, log_tx)
+                            }
                             AgentType::OpenCode => {
                                 vm.install_opencode_version_streaming(&version, log_tx)
                             }
@@ -2598,6 +2612,7 @@ impl App {
                     AgentType::Claude => "claude",
                     AgentType::Codex => "codex",
                     AgentType::Gemini => "gemini",
+                    AgentType::Antigravity => "antigravity",
                     AgentType::OpenCode => "opencode",
                     AgentType::Pi => "pi",
                     AgentType::Hermes => "hermes",
@@ -2853,6 +2868,9 @@ impl App {
                     AgentType::Codex => vm.install_codex_version_streaming(&version_clone, log_tx),
                     AgentType::Gemini => {
                         vm.install_gemini_version_streaming(&version_clone, log_tx)
+                    }
+                    AgentType::Antigravity => {
+                        vm.install_antigravity_version_streaming(&version_clone, log_tx)
                     }
                     AgentType::OpenCode => {
                         vm.install_opencode_version_streaming(&version_clone, log_tx)
@@ -5630,8 +5648,16 @@ impl App {
 
         for agent in self.available_agents.iter() {
             let is_selected = *agent == self.version_agent;
+            let is_depr = agent == &AgentType::Gemini;
 
-            let (prefix, style) = if is_selected {
+            let (prefix, style) = if is_depr {
+                (
+                    if is_selected { "> ⚠️ " } else { "  ⚠️ " },
+                    Style::default()
+                        .fg(Color::DarkGray)
+                        .add_modifier(Modifier::DIM),
+                )
+            } else if is_selected {
                 (
                     "> ",
                     Style::default()
@@ -5650,12 +5676,32 @@ impl App {
                 .map(|v| format!("  v{}", v))
                 .unwrap_or_default();
 
+            let name_str = if is_depr {
+                "Gemini CLI (depr.)".to_string()
+            } else {
+                agent.display_name().to_string()
+            };
+
+            let prefix_span = if is_depr {
+                Span::styled(prefix, Style::default().fg(Color::Yellow))
+            } else {
+                Span::styled(prefix, style)
+            };
+
+            let version_style = if is_depr {
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM)
+            } else {
+                Style::default().fg(Color::Green)
+            };
+
             let spans = vec![
-                Span::styled(prefix, style),
-                Span::styled(format!("{:<12}", agent.display_name()), style),
+                prefix_span,
+                Span::styled(format!("{:<20}", name_str), style),
                 Span::styled(
                     format!("{:<12}", version_str),
-                    Style::default().fg(Color::Green),
+                    version_style,
                 ),
             ];
 
@@ -6461,12 +6507,12 @@ mod tests {
         app.version_focus = VersionFocus::AgentPicker;
         assert_eq!(app.version_agent, AgentType::Claude);
 
-        // Navigate down: Claude -> Codex -> Gemini -> OpenCode -> Pi -> Hermes
+        // Navigate down: Claude -> Codex -> Antigravity -> OpenCode -> Pi -> Hermes -> Gemini
         let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
         assert_eq!(app.version_agent, AgentType::Codex);
 
         let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
-        assert_eq!(app.version_agent, AgentType::Gemini);
+        assert_eq!(app.version_agent, AgentType::Antigravity);
 
         let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
         assert_eq!(app.version_agent, AgentType::OpenCode);
@@ -6477,9 +6523,12 @@ mod tests {
         let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
         assert_eq!(app.version_agent, AgentType::Hermes);
 
+        let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
+        assert_eq!(app.version_agent, AgentType::Gemini);
+
         // Clamp at bottom (no wrap)
         let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
-        assert_eq!(app.version_agent, AgentType::Hermes);
+        assert_eq!(app.version_agent, AgentType::Gemini);
     }
 
     #[test]
@@ -6494,9 +6543,9 @@ mod tests {
         app.switch_to_agent_index(3);
         assert_eq!(app.version_agent, AgentType::OpenCode);
 
-        // Navigate up: OpenCode -> Gemini -> Codex -> Claude
+        // Navigate up: OpenCode -> Antigravity -> Codex -> Claude
         let _ = app.handle_version_input(NavAction::Up, key_for(NavAction::Up));
-        assert_eq!(app.version_agent, AgentType::Gemini);
+        assert_eq!(app.version_agent, AgentType::Antigravity);
 
         let _ = app.handle_version_input(NavAction::Up, key_for(NavAction::Up));
         assert_eq!(app.version_agent, AgentType::Codex);
@@ -6685,10 +6734,10 @@ mod tests {
         assert!(app.version_list_receiver.is_some());
         assert_eq!(app.version_agent, AgentType::Codex);
 
-        // Immediately switch to Gemini (should replace receiver)
+        // Immediately switch to Antigravity (should replace receiver)
         let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
         assert!(app.version_list_receiver.is_some());
-        assert_eq!(app.version_agent, AgentType::Gemini);
+        assert_eq!(app.version_agent, AgentType::Antigravity);
 
         // Switch again to OpenCode
         let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
@@ -6747,19 +6796,21 @@ mod tests {
     #[test]
     fn test_all_agent_types_in_cycle() {
         let agents = AgentType::builtin();
-        assert_eq!(agents.len(), 6);
+        assert_eq!(agents.len(), 7);
         assert_eq!(agents[0], AgentType::Claude);
         assert_eq!(agents[1], AgentType::Codex);
-        assert_eq!(agents[2], AgentType::Gemini);
+        assert_eq!(agents[2], AgentType::Antigravity);
         assert_eq!(agents[3], AgentType::OpenCode);
         assert_eq!(agents[4], AgentType::Pi);
         assert_eq!(agents[5], AgentType::Hermes);
+        assert_eq!(agents[6], AgentType::Gemini);
     }
 
     #[test]
     fn test_agent_display_names() {
         assert_eq!(AgentType::Claude.display_name(), "Claude Code");
         assert_eq!(AgentType::Codex.display_name(), "Codex");
+        assert_eq!(AgentType::Antigravity.display_name(), "Antigravity CLI");
         assert_eq!(AgentType::Gemini.display_name(), "Gemini CLI");
         assert_eq!(AgentType::OpenCode.display_name(), "OpenCode");
         assert_eq!(AgentType::Pi.display_name(), "Pi");
@@ -6770,6 +6821,8 @@ mod tests {
     fn test_agent_from_str() {
         assert_eq!(AgentType::from_str("claude"), Some(AgentType::Claude));
         assert_eq!(AgentType::from_str("codex"), Some(AgentType::Codex));
+        assert_eq!(AgentType::from_str("antigravity"), Some(AgentType::Antigravity));
+        assert_eq!(AgentType::from_str("antigravity-cli"), Some(AgentType::Antigravity));
         assert_eq!(AgentType::from_str("gemini"), Some(AgentType::Gemini));
         assert_eq!(AgentType::from_str("gemini-cli"), Some(AgentType::Gemini));
         assert_eq!(AgentType::from_str("opencode"), Some(AgentType::OpenCode));
@@ -6880,7 +6933,7 @@ mod tests {
         // Press 'G' to jump to bottom
         let big_g_key = KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT);
         let _ = app.handle_version_input(NavAction::None, big_g_key);
-        assert_eq!(app.version_agent, AgentType::Hermes);
+        assert_eq!(app.version_agent, AgentType::Gemini);
     }
 
     #[test]
@@ -6919,14 +6972,15 @@ mod tests {
     #[test]
     fn test_picker_entries_default_order() {
         let entries = build_agent_cli_picker_entries(&[]);
-        assert_eq!(entries.len(), 7);
+        assert_eq!(entries.len(), 8);
         assert_eq!(entries[0], AgentCliPickerEntry::Agent(AgentType::Claude));
         assert_eq!(entries[1], AgentCliPickerEntry::Agent(AgentType::Codex));
-        assert_eq!(entries[2], AgentCliPickerEntry::Agent(AgentType::Gemini));
+        assert_eq!(entries[2], AgentCliPickerEntry::Agent(AgentType::Antigravity));
         assert_eq!(entries[3], AgentCliPickerEntry::Agent(AgentType::OpenCode));
         assert_eq!(entries[4], AgentCliPickerEntry::Agent(AgentType::Pi));
         assert_eq!(entries[5], AgentCliPickerEntry::Agent(AgentType::Hermes));
-        assert_eq!(entries[6], AgentCliPickerEntry::AddCustom);
+        assert_eq!(entries[6], AgentCliPickerEntry::Agent(AgentType::Gemini));
+        assert_eq!(entries[7], AgentCliPickerEntry::AddCustom);
     }
 
     /// Custom agents appear in the picker between built-ins and AddCustom.
@@ -6937,12 +6991,12 @@ mod tests {
         def.name = "aider".to_string();
         def.binary = "aider".to_string();
         let entries = build_agent_cli_picker_entries(&[def]);
-        assert_eq!(entries.len(), 8);
+        assert_eq!(entries.len(), 9);
         assert_eq!(
-            entries[6],
+            entries[7],
             AgentCliPickerEntry::Agent(AgentType::Custom("aider".to_string()))
         );
-        assert_eq!(entries[7], AgentCliPickerEntry::AddCustom);
+        assert_eq!(entries[8], AgentCliPickerEntry::AddCustom);
     }
 
     /// Right key advances and wraps; left key wraps backwards.
@@ -6967,9 +7021,9 @@ mod tests {
         app.handle_agent_cli_picker_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
         assert_eq!(app.agent_picker_index, 0);
 
-        // Left from 0 wraps to last (AddCustom = 6 with no custom agents)
+        // Left from 0 wraps to last (AddCustom = 7 with no custom agents)
         app.handle_agent_cli_picker_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
-        assert_eq!(app.agent_picker_index, 6);
+        assert_eq!(app.agent_picker_index, 7);
 
         // Right from last wraps back to 0
         app.handle_agent_cli_picker_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
@@ -7049,10 +7103,10 @@ mod tests {
         app.app_config.custom_agents.push(cfg);
 
         let entries = app.agent_cli_picker_entries();
-        // 6 builtins + 1 custom + AddCustom = 8
-        assert_eq!(entries.len(), 8);
+        // 7 builtins + 1 custom + AddCustom = 9
+        assert_eq!(entries.len(), 9);
         assert!(matches!(
-            &entries[6],
+            &entries[7],
             AgentCliPickerEntry::Agent(AgentType::Custom(n)) if n == "aider"
         ));
     }
@@ -7591,10 +7645,11 @@ yolo_flag = "--yes"
     #[test]
     fn test_picker_snapshot_cycle_right_to_gemini() {
         let (mut app, _temp) = picker_open_app("claude");
-        // Right twice: Claude -> Codex -> Gemini
-        app.handle_agent_cli_picker_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
-        app.handle_agent_cli_picker_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
-        assert_eq!(app.agent_picker_index, 2);
+        // Right six times: Claude -> Codex -> Antigravity -> OpenCode -> Pi -> Hermes -> Gemini
+        for _ in 0..6 {
+            app.handle_agent_cli_picker_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+        }
+        assert_eq!(app.agent_picker_index, 6);
 
         let buf = render_region_to_buffer(80, 8, |frame, area| {
             app.render_profile_edit(frame, area);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -337,8 +337,7 @@ fn run_app(
                         }
                         Err(e) => {
                             // Re-queue the file so the user can fix it.
-                            app.status_message =
-                                Some(format!("Custom agent TOML invalid: {}", e));
+                            app.status_message = Some(format!("Custom agent TOML invalid: {}", e));
                             app.pending_custom_agent_edit = Some(path.clone());
                             app.edit_field = app::EditField::AgentCliPicker;
                         }
@@ -474,16 +473,13 @@ fn handle_sandbox_pending_external(
                 .and_then(|w| w.docker_dir.clone());
             let step = SandboxStep::ALL[step_idx];
 
-            let mut result: Result<String, crate::sandbox::StepFailure> =
-                Err(crate::sandbox::StepFailure::Recoverable(
-                    "step did not run".into(),
-                ));
+            let mut result: Result<String, crate::sandbox::StepFailure> = Err(
+                crate::sandbox::StepFailure::Recoverable("step did not run".into()),
+            );
             run_with_terminal_suspended(terminal, || {
                 eprintln!("\n--- {} ---\n", step.title());
                 if step.needs_sudo() {
-                    eprintln!(
-                        "This step needs root. You'll be prompted for your sudo password.\n"
-                    );
+                    eprintln!("This step needs root. You'll be prompted for your sudo password.\n");
                 }
                 result = match step {
                     SandboxStep::Docker => crate::sandbox::step_check_docker(),
@@ -500,11 +496,11 @@ fn handle_sandbox_pending_external(
                             "docker/ directory not located".into(),
                         )),
                     },
-                    SandboxStep::Env | SandboxStep::Summary => Err(
-                        crate::sandbox::StepFailure::Recoverable(
+                    SandboxStep::Env | SandboxStep::Summary => {
+                        Err(crate::sandbox::StepFailure::Recoverable(
                             "this step is not externally runnable".into(),
-                        ),
-                    ),
+                        ))
+                    }
                 };
                 Ok(())
             })?;

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -761,7 +761,10 @@ pub fn uninstall_interactive() -> io::Result<()> {
     if !installed_bins.is_empty() {
         println!("  Binaries/symlinks in {}:", bin_dir.display());
         for p in &installed_bins {
-            println!("    - {}", p.file_name().and_then(|n| n.to_str()).unwrap_or(""));
+            println!(
+                "    - {}",
+                p.file_name().and_then(|n| n.to_str()).unwrap_or("")
+            );
         }
     }
     if data_dir.exists() {
@@ -933,7 +936,7 @@ fn update_agent(
         AgentType::Claude => update_claude(tx, index),
         AgentType::Codex => update_codex(tx, index, latest_version),
         AgentType::Antigravity => Err(io::Error::other(
-            "Antigravity CLI updates are managed by the system package manager (pacman/yay)"
+            "Antigravity CLI updates are managed by the system package manager (pacman/yay)",
         )),
         AgentType::Gemini => update_gemini(tx, index, latest_version),
         AgentType::OpenCode => update_opencode(tx, index),
@@ -1385,7 +1388,10 @@ mod tests {
             msg.contains("failed"),
             "error message must contain 'failed' (was: {msg})"
         );
-        assert!(msg.contains('1'), "error must mention the count (was: {msg})");
+        assert!(
+            msg.contains('1'),
+            "error must mention the count (was: {msg})"
+        );
         // Singular: "1 agent failed", not "1 agents".
         assert!(
             msg.contains("agent failed"),
@@ -1403,7 +1409,10 @@ mod tests {
         let err = summary_to_result(3, false).expect_err("should error on failure");
         let msg = err.to_string();
         assert!(msg.contains("failed"), "msg lacks 'failed': {msg}");
-        assert!(msg.contains("3 agents failed"), "expected plural agents: {msg}");
+        assert!(
+            msg.contains("3 agents failed"),
+            "expected plural agents: {msg}"
+        );
     }
 
     #[test]
@@ -1481,12 +1490,18 @@ mod tests {
             err_outcome(AgentType::Gemini, "1.0.0", "npm install failed"),
         ];
         let failed = print_summary(&[], &outcomes);
-        assert_eq!(failed, 2, "exactly two errored outcomes must yield failed=2");
+        assert_eq!(
+            failed, 2,
+            "exactly two errored outcomes must yield failed=2"
+        );
 
         // And the run() error path must be triggered with the expected message.
         let err = summary_to_result(failed, false).expect_err("must propagate Err");
         let msg = err.to_string();
-        assert!(msg.contains("2 agents failed"), "expected '2 agents failed': {msg}");
+        assert!(
+            msg.contains("2 agents failed"),
+            "expected '2 agents failed': {msg}"
+        );
         assert!(msg.contains("update"), "expected 'update' verb: {msg}");
     }
 

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -932,6 +932,9 @@ fn update_agent(
     let result = match agent_type {
         AgentType::Claude => update_claude(tx, index),
         AgentType::Codex => update_codex(tx, index, latest_version),
+        AgentType::Antigravity => Err(io::Error::other(
+            "Antigravity CLI updates are managed by the system package manager (pacman/yay)"
+        )),
         AgentType::Gemini => update_gemini(tx, index, latest_version),
         AgentType::OpenCode => update_opencode(tx, index),
         AgentType::Pi => update_pi(tx, index, latest_version),

--- a/src/version.rs
+++ b/src/version.rs
@@ -58,7 +58,15 @@ pub fn load_embedded_versions() -> HashMap<String, Vec<String>> {
     let content = std::fs::read_to_string(&path).unwrap_or_else(|_| "{}".to_string());
     let parsed: serde_json::Value = serde_json::from_str(&content).unwrap_or_default();
     let mut map = HashMap::new();
-    for key in &["claude", "codex", "gemini", "antigravity", "opencode", "pi", "hermes"] {
+    for key in &[
+        "claude",
+        "codex",
+        "gemini",
+        "antigravity",
+        "opencode",
+        "pi",
+        "hermes",
+    ] {
         if let Some(arr) = parsed.get(key).and_then(|v| v.as_array()) {
             let versions: Vec<String> = arr
                 .iter()
@@ -816,7 +824,10 @@ impl VersionManager {
                 success: false,
                 stdout: String::new(),
                 stderr: "npm not available".into(),
-                error: Some("npm not available (native install skipped by UNLEASH_SKIP_NATIVE_INSTALL)".into()),
+                error: Some(
+                    "npm not available (native install skipped by UNLEASH_SKIP_NATIVE_INSTALL)"
+                        .into(),
+                ),
             })
         }
     }
@@ -1601,7 +1612,9 @@ impl VersionManager {
 
     /// Get combined Antigravity CLI version list with status
     pub fn get_antigravity_version_list(&self, installed: Option<&str>) -> Vec<VersionInfo> {
-        let available = self.get_antigravity_available_versions().unwrap_or_default();
+        let available = self
+            .get_antigravity_available_versions()
+            .unwrap_or_default();
 
         let mut versions: Vec<VersionInfo> = available
             .into_iter()
@@ -1621,13 +1634,9 @@ impl VersionManager {
         _version: &str,
         log_tx: mpsc::Sender<String>,
     ) -> io::Result<InstallResult> {
-        let _ = log_tx.send("Antigravity CLI updates are managed by the system package manager (pacman/yay)".to_string());
-        Ok(InstallResult {
-            success: false,
-            stdout: String::new(),
-            stderr: "System-managed packages cannot be installed via unleash".to_string(),
-            error: Some("Antigravity CLI updates are managed by the system package manager (pacman/yay)".to_string()),
-        })
+        let msg = "Antigravity CLI updates are managed by the system package manager (pacman/yay)";
+        let _ = log_tx.send(msg.to_string());
+        Err(io::Error::other(msg))
     }
 
     /// Install Gemini CLI with streaming log output
@@ -1853,7 +1862,6 @@ impl VersionManager {
         format!("codex-{}", target_triple)
     }
 }
-
 
 /// Canonically compare two version strings (semver-like).
 ///

--- a/src/version.rs
+++ b/src/version.rs
@@ -58,7 +58,7 @@ pub fn load_embedded_versions() -> HashMap<String, Vec<String>> {
     let content = std::fs::read_to_string(&path).unwrap_or_else(|_| "{}".to_string());
     let parsed: serde_json::Value = serde_json::from_str(&content).unwrap_or_default();
     let mut map = HashMap::new();
-    for key in &["claude", "codex", "gemini", "opencode", "pi", "hermes"] {
+    for key in &["claude", "codex", "gemini", "antigravity", "opencode", "pi", "hermes"] {
         if let Some(arr) = parsed.get(key).and_then(|v| v.as_array()) {
             let versions: Vec<String> = arr
                 .iter()
@@ -77,6 +77,7 @@ pub fn save_embedded_versions(map: &HashMap<crate::agents::AgentType, Vec<Versio
         let key = match agent_type {
             crate::agents::AgentType::Claude => "claude",
             crate::agents::AgentType::Codex => "codex",
+            crate::agents::AgentType::Antigravity => "antigravity",
             crate::agents::AgentType::Gemini => "gemini",
             crate::agents::AgentType::OpenCode => "opencode",
             crate::agents::AgentType::Pi => "pi",
@@ -1587,6 +1588,45 @@ impl VersionManager {
             stdout: format!("Codex v{} installed to {}", version, install_path.display()),
             stderr: String::new(),
             error: None,
+        })
+    }
+
+    // ── Antigravity CLI ───────────────────────────────────────
+
+    /// Get available Antigravity CLI versions (reads embedded versions)
+    pub fn get_antigravity_available_versions(&self) -> io::Result<Vec<String>> {
+        let embedded = load_embedded_versions();
+        Ok(embedded.get("antigravity").cloned().unwrap_or_default())
+    }
+
+    /// Get combined Antigravity CLI version list with status
+    pub fn get_antigravity_version_list(&self, installed: Option<&str>) -> Vec<VersionInfo> {
+        let available = self.get_antigravity_available_versions().unwrap_or_default();
+
+        let mut versions: Vec<VersionInfo> = available
+            .into_iter()
+            .map(|v| VersionInfo {
+                is_installed: installed == Some(v.as_str()),
+                version: v,
+            })
+            .collect();
+
+        versions.sort_by(|a, b| version_compare(&b.version, &a.version));
+        versions
+    }
+
+    /// Mock installation of Antigravity CLI (returning an error indicating system-managed status)
+    pub fn install_antigravity_version_streaming(
+        &self,
+        _version: &str,
+        log_tx: mpsc::Sender<String>,
+    ) -> io::Result<InstallResult> {
+        let _ = log_tx.send("Antigravity CLI updates are managed by the system package manager (pacman/yay)".to_string());
+        Ok(InstallResult {
+            success: false,
+            stdout: String::new(),
+            stderr: "System-managed packages cannot be installed via unleash".to_string(),
+            error: Some("Antigravity CLI updates are managed by the system package manager (pacman/yay)".to_string()),
         })
     }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -55,8 +55,14 @@ pub fn get_versions_file_path() -> PathBuf {
 /// Returns a map of agent key -> list of version strings (newest first).
 pub fn load_embedded_versions() -> HashMap<String, Vec<String>> {
     let path = get_versions_file_path();
-    let content = std::fs::read_to_string(&path).unwrap_or_else(|_| "{}".to_string());
-    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap_or_default();
+    let content = std::fs::read_to_string(&path).unwrap_or_else(|_| "".to_string());
+    let parsed_disk: serde_json::Value = if content.trim().is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_str(&content).unwrap_or(serde_json::Value::Null)
+    };
+    let parsed_fallback: serde_json::Value = serde_json::from_str(include_str!("../data/versions.json")).unwrap_or_default();
+
     let mut map = HashMap::new();
     for key in &[
         "claude",
@@ -67,13 +73,22 @@ pub fn load_embedded_versions() -> HashMap<String, Vec<String>> {
         "pi",
         "hermes",
     ] {
-        if let Some(arr) = parsed.get(key).and_then(|v| v.as_array()) {
-            let versions: Vec<String> = arr
+        let mut versions: Vec<String> = Vec::new();
+        if let Some(arr) = parsed_disk.get(key).and_then(|v| v.as_array()) {
+            versions = arr
                 .iter()
                 .filter_map(|v| v.as_str().map(String::from))
                 .collect();
-            map.insert(key.to_string(), versions);
         }
+        if versions.is_empty() {
+            if let Some(arr) = parsed_fallback.get(key).and_then(|v| v.as_array()) {
+                versions = arr
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect();
+            }
+        }
+        map.insert(key.to_string(), versions);
     }
     map
 }
@@ -699,6 +714,13 @@ impl VersionManager {
         }
 
         if versions.is_empty() {
+            // Fallback to embedded versions
+            let embedded = load_embedded_versions();
+            if let Some(v_list) = embedded.get("claude") {
+                if !v_list.is_empty() {
+                    return Ok(v_list.clone());
+                }
+            }
             return Err(io::Error::other(
                 "Failed to query available versions from GCS and npm",
             ));
@@ -931,7 +953,8 @@ impl VersionManager {
 
     /// Get available Codex versions from GitHub releases (tags matching rust-v*)
     pub fn get_codex_available_versions(&self) -> io::Result<Vec<String>> {
-        let output = Command::new("gh")
+        let mut versions = Vec::new();
+        if let Ok(output) = Command::new("gh")
             .args([
                 "api",
                 "repos/openai/codex/tags",
@@ -939,26 +962,37 @@ impl VersionManager {
                 "--jq",
                 ".[].name",
             ])
-            .output()?;
-
-        if output.status.success() {
-            let tag_output = String::from_utf8_lossy(&output.stdout);
-            let mut versions: Vec<String> = tag_output
-                .lines()
-                .filter(|line| line.starts_with("rust-v"))
-                .filter(|line| !line.contains("alpha"))
-                .map(|line| line.trim_start_matches("rust-v").to_string())
-                .filter(|v| !v.is_empty() && v.starts_with(|c: char| c.is_ascii_digit()))
-                .collect();
-            // Sort newest first, then take top 20
-            versions.sort_by(|a, b| version_compare(b, a));
-            versions.truncate(20);
-            Ok(versions)
-        } else {
-            Err(io::Error::other(
-                "Failed to query GitHub releases for Codex",
-            ))
+            .output()
+        {
+            if output.status.success() {
+                let tag_output = String::from_utf8_lossy(&output.stdout);
+                versions = tag_output
+                    .lines()
+                    .filter(|line| line.starts_with("rust-v"))
+                    .filter(|line| !line.contains("alpha"))
+                    .map(|line| line.trim_start_matches("rust-v").to_string())
+                    .filter(|v| !v.is_empty() && v.starts_with(|c: char| c.is_ascii_digit()))
+                    .collect();
+            }
         }
+
+        if versions.is_empty() {
+            // Fallback to embedded versions
+            let embedded = load_embedded_versions();
+            if let Some(v_list) = embedded.get("codex") {
+                if !v_list.is_empty() {
+                    return Ok(v_list.clone());
+                }
+            }
+            return Err(io::Error::other(
+                "Failed to query GitHub releases for Codex",
+            ));
+        }
+
+        // Sort newest first, then take top 20
+        versions.sort_by(|a, b| version_compare(b, a));
+        versions.truncate(20);
+        Ok(versions)
     }
 
     /// Get combined Codex version list with status
@@ -1077,7 +1111,19 @@ impl VersionManager {
 
     /// Get available Gemini CLI versions from npm registry
     pub fn get_gemini_available_versions(&self) -> io::Result<Vec<String>> {
-        Self::query_npm_registry_versions("@google/gemini-cli", 20)
+        let res = Self::query_npm_registry_versions("@google/gemini-cli", 20);
+        match res {
+            Ok(versions) if !versions.is_empty() => Ok(versions),
+            _ => {
+                let embedded = load_embedded_versions();
+                if let Some(v_list) = embedded.get("gemini") {
+                    if !v_list.is_empty() {
+                        return Ok(v_list.clone());
+                    }
+                }
+                Err(io::Error::other("Failed to query available versions for Gemini CLI"))
+            }
+        }
     }
 
     /// Get combined Gemini CLI version list with status
@@ -1139,7 +1185,19 @@ impl VersionManager {
 
     /// Get available Pi versions from npm registry
     pub fn get_pi_available_versions(&self) -> io::Result<Vec<String>> {
-        Self::query_npm_registry_versions("@mariozechner/pi-coding-agent", 20)
+        let res = Self::query_npm_registry_versions("@mariozechner/pi-coding-agent", 20);
+        match res {
+            Ok(versions) if !versions.is_empty() => Ok(versions),
+            _ => {
+                let embedded = load_embedded_versions();
+                if let Some(v_list) = embedded.get("pi") {
+                    if !v_list.is_empty() {
+                        return Ok(v_list.clone());
+                    }
+                }
+                Err(io::Error::other("Failed to query available versions for Pi"))
+            }
+        }
     }
 
     /// Get combined Pi version list with status
@@ -1177,10 +1235,20 @@ impl VersionManager {
     /// for `opencode-ai/opencode` use a different versioning scheme (0.0.x) and
     /// should not be mixed with npm versions (1.x.x).
     pub fn get_opencode_available_versions(&self) -> io::Result<Vec<String>> {
-        let mut versions = Self::query_npm_registry_versions("opencode-ai", 20)?;
-        versions.retain(|s| s.starts_with(|c: char| c.is_ascii_digit()));
+        let mut versions = Vec::new();
+        if let Ok(mut v) = Self::query_npm_registry_versions("opencode-ai", 20) {
+            v.retain(|s| s.starts_with(|c: char| c.is_ascii_digit()));
+            versions = v;
+        }
 
         if versions.is_empty() {
+            // Fallback to embedded versions
+            let embedded = load_embedded_versions();
+            if let Some(v_list) = embedded.get("opencode") {
+                if !v_list.is_empty() {
+                    return Ok(v_list.clone());
+                }
+            }
             return Err(io::Error::other(
                 "Failed to query available versions for OpenCode",
             ));

--- a/tests/auto_mode_loop.rs
+++ b/tests/auto_mode_loop.rs
@@ -195,9 +195,7 @@ fn auto_mode_restart_loop_runs_agent_twice_with_continue_on_second_invocation() 
     );
     // Non-Claude agent_type → must NOT inject --dangerously-skip-permissions
     assert!(
-        !args2
-            .iter()
-            .any(|a| a == "--dangerously-skip-permissions"),
+        !args2.iter().any(|a| a == "--dangerously-skip-permissions"),
         "non-Claude agent_type must not get --dangerously-skip-permissions, got: {:?}",
         args2
     );

--- a/tests/crossload_runtime.rs
+++ b/tests/crossload_runtime.rs
@@ -73,7 +73,8 @@ fn fixture(name: &str) -> Vec<u8> {
         .join("tests")
         .join("fixtures")
         .join(name);
-    std::fs::read(&path).unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()))
+    std::fs::read(&path)
+        .unwrap_or_else(|e| panic!("failed to read fixture {}: {e}", path.display()))
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -109,7 +110,11 @@ fn place_claude_source(home: &Path, jsonl_bytes: &[u8], session_id: &str) -> Pat
 
 /// Drop a Codex rollout into `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<id>.jsonl`.
 fn place_codex_source(codex_home: &Path, jsonl_bytes: &[u8], session_id: &str) -> PathBuf {
-    let dir = codex_home.join("sessions").join("2026").join("03").join("30");
+    let dir = codex_home
+        .join("sessions")
+        .join("2026")
+        .join("03")
+        .join("30");
     std::fs::create_dir_all(&dir).unwrap();
     // Filename pattern:  rollout-YYYY-MM-DDTHH-MM-SS-<uuid>.jsonl
     // Discovery extracts the id by stripping "rollout-" + 19-char timestamp + "-".
@@ -240,7 +245,12 @@ fn isolated_home(guard: &EnvGuard) -> (tempfile::TempDir, PathBuf, PathBuf) {
 /// expected `sessions/YYYY/MM/DD/` layout with a `session_meta` header.
 #[test]
 fn inject_claude_into_codex() {
-    let guard = EnvGuard::new(&["HOME", "XDG_DATA_HOME", "CODEX_HOME", "UNLEASH_CROSSLOAD_FORCE"]);
+    let guard = EnvGuard::new(&[
+        "HOME",
+        "XDG_DATA_HOME",
+        "CODEX_HOME",
+        "UNLEASH_CROSSLOAD_FORCE",
+    ]);
     let (_tmp, home, _xdg) = isolated_home(&guard);
     let codex_home = home.join(".codex");
     std::fs::create_dir_all(&codex_home).unwrap();
@@ -311,7 +321,12 @@ fn inject_claude_into_codex() {
 /// well-formed `parentUuid` chain.
 #[test]
 fn inject_codex_into_claude() {
-    let guard = EnvGuard::new(&["HOME", "XDG_DATA_HOME", "CODEX_HOME", "UNLEASH_CROSSLOAD_FORCE"]);
+    let guard = EnvGuard::new(&[
+        "HOME",
+        "XDG_DATA_HOME",
+        "CODEX_HOME",
+        "UNLEASH_CROSSLOAD_FORCE",
+    ]);
     let (_tmp, home, _xdg) = isolated_home(&guard);
     let codex_home = home.join(".codex");
     std::fs::create_dir_all(&codex_home).unwrap();
@@ -349,13 +364,19 @@ fn inject_codex_into_claude() {
         lines += 1;
         let v: serde_json::Value = serde_json::from_str(line).unwrap();
         let sid = v.get("sessionId").and_then(|s| s.as_str()).unwrap_or("");
-        assert_eq!(sid, result.session_id, "sessionId must be patched on every line");
+        assert_eq!(
+            sid, result.session_id,
+            "sessionId must be patched on every line"
+        );
         let uuid = v
             .get("uuid")
             .and_then(|u| u.as_str())
             .expect("every claude line must have a uuid")
             .to_string();
-        let parent = v.get("parentUuid").cloned().unwrap_or(serde_json::Value::Null);
+        let parent = v
+            .get("parentUuid")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
         match (&prev, parent) {
             (None, serde_json::Value::Null) => {}
             (Some(p), serde_json::Value::String(pu)) => {
@@ -384,7 +405,12 @@ fn inject_codex_into_claude() {
 /// and assert a session JSON file landed in the expected chats layout.
 #[test]
 fn inject_claude_into_antigravity() {
-    let guard = EnvGuard::new(&["HOME", "XDG_DATA_HOME", "CODEX_HOME", "UNLEASH_CROSSLOAD_FORCE"]);
+    let guard = EnvGuard::new(&[
+        "HOME",
+        "XDG_DATA_HOME",
+        "CODEX_HOME",
+        "UNLEASH_CROSSLOAD_FORCE",
+    ]);
     let (_tmp, home, _xdg) = isolated_home(&guard);
 
     let session_id = "5abf6b0c-d3a9-4692-bd17-1507f00cb3f7";
@@ -421,7 +447,12 @@ fn inject_claude_into_antigravity() {
 /// with corresponding messages and parts.
 #[test]
 fn inject_gemini_into_opencode() {
-    let guard = EnvGuard::new(&["HOME", "XDG_DATA_HOME", "CODEX_HOME", "UNLEASH_CROSSLOAD_FORCE"]);
+    let guard = EnvGuard::new(&[
+        "HOME",
+        "XDG_DATA_HOME",
+        "CODEX_HOME",
+        "UNLEASH_CROSSLOAD_FORCE",
+    ]);
     let (_tmp, home, xdg) = isolated_home(&guard);
     let db_path = init_opencode_db(&xdg);
 
@@ -459,7 +490,11 @@ fn inject_gemini_into_opencode() {
             |r| r.get(0),
         )
         .unwrap();
-    assert_eq!(session_count, 1, "session row missing for {}", result.session_id);
+    assert_eq!(
+        session_count, 1,
+        "session row missing for {}",
+        result.session_id
+    );
 
     let msg_count: i64 = conn
         .query_row(

--- a/tests/crossload_runtime.rs
+++ b/tests/crossload_runtime.rs
@@ -379,6 +379,43 @@ fn inject_codex_into_claude() {
     );
 }
 
+/// claude → antigravity: drop a Claude JSONL session, inject into the
+/// (tempdir) Antigravity store (which uses Gemini's underlying store),
+/// and assert a session JSON file landed in the expected chats layout.
+#[test]
+fn inject_claude_into_antigravity() {
+    let guard = EnvGuard::new(&["HOME", "XDG_DATA_HOME", "CODEX_HOME", "UNLEASH_CROSSLOAD_FORCE"]);
+    let (_tmp, home, _xdg) = isolated_home(&guard);
+
+    let session_id = "5abf6b0c-d3a9-4692-bd17-1507f00cb3f7";
+    place_claude_source(&home, &fixture("claude-10turn.jsonl"), session_id);
+
+    let result = inject_session(&format!("claude:{session_id}"), "antigravity")
+        .expect("inject_session claude→antigravity failed");
+
+    // Sanity: a target session id and resume args were produced.
+    assert!(!result.session_id.is_empty(), "empty target session id");
+    assert_eq!(
+        result.resume_args,
+        vec!["--resume".to_string(), result.session_id.clone()],
+        "antigravity resume args must be --resume <id>"
+    );
+
+    // Antigravity sessions land under `$HOME/.gemini/tmp/` because it takes place of Gemini CLI.
+    let gemini_tmp = home.join(".gemini").join("tmp");
+    let written = find_json_for_session(&gemini_tmp, &result.session_id)
+        .expect("no <session_id>.json appeared under .gemini/tmp");
+    let body = std::fs::read_to_string(&written).unwrap();
+    assert!(!body.is_empty(), "antigravity json should not be empty");
+
+    // Parse the written JSON and verify session id matches.
+    let val: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(
+        val.get("id").and_then(|id| id.as_str()),
+        Some(result.session_id.as_str())
+    );
+}
+
 /// gemini → opencode: drop a Gemini session JSON, set up an OpenCode
 /// SQLite DB, inject, then verify a session row appears in the DB along
 /// with corresponding messages and parts.
@@ -501,6 +538,30 @@ fn find_jsonl_with_stem(dir: &Path, stem: &str) -> Option<PathBuf> {
             && path.file_stem().and_then(|s| s.to_str()) == Some(stem)
         {
             return Some(path);
+        }
+    }
+    None
+}
+
+fn find_json_for_session(dir: &Path, session_id: &str) -> Option<PathBuf> {
+    if !dir.exists() {
+        return None;
+    }
+    for entry in std::fs::read_dir(dir).ok()?.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(found) = find_json_for_session(&path, session_id) {
+                return Some(found);
+            }
+        } else if path.extension().and_then(|e| e.to_str()) == Some("json") {
+            // Read and parse to see if it matches session_id
+            if let Ok(content) = std::fs::read_to_string(&path) {
+                if let Ok(val) = serde_json::from_str::<serde_json::Value>(&content) {
+                    if val.get("id").and_then(|id| id.as_str()) == Some(session_id) {
+                        return Some(path);
+                    }
+                }
+            }
         }
     }
     None

--- a/tests/custom_agents.rs
+++ b/tests/custom_agents.rs
@@ -32,10 +32,7 @@ yolo_flag = "--yes"
     assert_eq!(def.polyfill.model_flag, "--model");
     assert_eq!(def.polyfill.yolo_flag, Some("--yes".to_string()));
     assert_eq!(def.description, "AI pair programming in your terminal");
-    assert_eq!(
-        def.github_repo,
-        Some("paul-gauthier/aider".to_string())
-    );
+    assert_eq!(def.github_repo, Some("paul-gauthier/aider".to_string()));
     assert!(def.enabled);
 }
 

--- a/tests/profile_integration_tests.rs
+++ b/tests/profile_integration_tests.rs
@@ -1,0 +1,50 @@
+use std::process::Command;
+
+fn verify_dry_run_output(stdout: &str, expected_bin: &str) {
+    let dry_run_line = stdout
+        .lines()
+        .find(|line| line.starts_with("Would execute:"))
+        .expect("Should contain 'Would execute:' line");
+
+    let tokens: Vec<&str> = dry_run_line.split_whitespace().collect();
+    assert!(
+        tokens.len() >= 3,
+        "Line should have at least 'Would execute:' and binary name: {:?}",
+        dry_run_line
+    );
+
+    let executed_bin = tokens[2];
+    assert!(
+        executed_bin == expected_bin || executed_bin.ends_with(&format!("/{}", expected_bin)),
+        "Expected executed binary to be or end with '{}', but got '{}' in line: '{}'",
+        expected_bin,
+        executed_bin,
+        dry_run_line
+    );
+}
+
+#[test]
+fn test_agy_profile_dry_run() {
+    let bin_path = env!("CARGO_BIN_EXE_unleash");
+    let output = Command::new(bin_path)
+        .args(["agy", "--dry-run"])
+        .output()
+        .expect("failed to execute unleash");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    verify_dry_run_output(&stdout, "antigravity");
+}
+
+#[test]
+fn test_hermes_profile_dry_run() {
+    let bin_path = env!("CARGO_BIN_EXE_unleash");
+    let output = Command::new(bin_path)
+        .args(["hermes", "--dry-run"])
+        .output()
+        .expect("failed to execute unleash");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    verify_dry_run_output(&stdout, "hermes");
+}

--- a/tests/profile_integration_tests.rs
+++ b/tests/profile_integration_tests.rs
@@ -33,7 +33,7 @@ fn test_agy_profile_dry_run() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    verify_dry_run_output(&stdout, "antigravity");
+    verify_dry_run_output(&stdout, "agy");
 }
 
 #[test]


### PR DESCRIPTION
This PR adds the Antigravity CLI to the unleash agent picker, positions Gemini CLI at the bottom with deprecated styling, and implements version detection from app.asar.