### PR TITLE
feat(docker): CUDA Docker image + Vast.ai template for GPU cloud

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -115,6 +115,53 @@ jobs:
             exit 1
           fi
 
+      - name: Build CUDA variant
+        run: |
+          docker build -f docker/Dockerfile.cuda \
+            --label "org.opencontainers.image.version=${{ steps.meta.outputs.version }}" \
+            --label "org.opencontainers.image.source=https://github.com/heiervang-technologies/unleash" \
+            -t unleash:cuda-local .
+
+      - name: Verify CUDA variant CLIs
+        run: |
+          FAILED=0
+
+          for cli in claude codex gemini opencode pi; do
+            echo -n "  $cli: "
+            VERSION=$(docker run --rm unleash:cuda-local $cli --version 2>&1 | grep -iE '[0-9]+\.[0-9]+' | head -1) || true
+            if [ -n "$VERSION" ]; then
+              echo "$VERSION"
+            else
+              echo "FAILED"
+              docker run --rm unleash:cuda-local $cli --version 2>&1 || true
+              FAILED=1
+            fi
+          done
+
+          echo -n "  PyTorch: "
+          PYTORCH_VERSION=$(docker run --rm unleash:cuda-local python3 -c "import torch; print(torch.__version__)" 2>&1) || true
+          if [ -n "$PYTORCH_VERSION" ]; then
+            echo "$PYTORCH_VERSION"
+          else
+            echo "FAILED"
+            FAILED=1
+          fi
+
+          echo -n "  unleash: "
+          VERSION=$(docker run --rm unleash:cuda-local --version 2>&1 | grep -iE '[0-9]+\.[0-9]+' | head -1) || true
+          if [ -n "$VERSION" ]; then
+            echo "$VERSION"
+          else
+            echo "FAILED"
+            docker run --rm unleash:cuda-local --version 2>&1 || true
+            FAILED=1
+          fi
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo "CUDA variant CLI verification failed — not pushing cuda tag"
+            exit 1
+          fi
+
       - name: Tag and push
         if: github.event_name != 'pull_request'
         env:
@@ -125,7 +172,27 @@ jobs:
             docker tag unleash:local "$tag"
             docker push "$tag"
             echo "Pushed: $tag"
+
+            # Also push CUDA variant with +cuda suffix
+            CUDA_TAG="${tag}-cuda"
+            docker tag unleash:cuda-local "$CUDA_TAG"
+            docker push "$CUDA_TAG"
+            echo "Pushed: $CUDA_TAG"
           done
+
+          # Push standalone :cuda tag for the CUDA variant
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            VERSION="${{ steps.meta.outputs.version }}"
+            for T in "marksverdhei/unleash:cuda" "marksverdhei/unleash:v${VERSION}-cuda"; do
+              docker tag unleash:cuda-local "$T"
+              docker push "$T"
+              echo "Pushed: $T"
+            done
+          else
+            docker tag unleash:cuda-local "marksverdhei/unleash:cuda"
+            docker push "marksverdhei/unleash:cuda"
+            echo "Pushed: marksverdhei/unleash:cuda"
+          fi
 
       - name: Summary
         env:
@@ -137,7 +204,7 @@ jobs:
             {
               echo "## Docker Publish (dry-run)"
               echo "- Version: $VERSION"
-              echo "- Would-be tags: $TAGS"
+              echo "- Would-be tags: $TAGS + cuda variants"
               echo "- Push skipped: pull_request event"
             } >> "$GITHUB_STEP_SUMMARY"
           else
@@ -145,11 +212,12 @@ jobs:
               echo "## Docker Image Published"
               echo "- Version: $VERSION"
               echo "- Tags: $TAGS"
+              echo "- CUDA tags: marksverdhei/unleash:cuda, marksverdhei/unleash:v${VERSION}-cuda"
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Cleanup
         if: always()
         run: |
-          docker rmi unleash:local 2>/dev/null || true
+          docker rmi unleash:local unleash:cuda-local 2>/dev/null || true
           docker builder prune -f --filter "until=1h" 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -297,7 +297,17 @@ Or run the image directly:
 docker run -it --rm -e ANTHROPIC_API_KEY marksverdhei/unleash
 ```
 
-All 4 agent CLIs are pre-installed. See the [Docker + gVisor sandbox guide](docs/docker.md) for hardened setups with LAN isolation and named sandboxes.
+All 5 agent CLIs are pre-installed. See the [Docker + gVisor sandbox guide](docs/docker.md) for hardened setups with LAN isolation and named sandboxes.
+
+#### CUDA / GPU Cloud
+
+For GPU workloads, use the CUDA variant with CUDA 12.8, PyTorch, and all agent CLIs:
+
+```bash
+docker run --gpus all -it --rm marksverdhei/unleash:cuda
+```
+
+See the [Docker guide](docs/docker.md#cuda--gpu-cloud) for Vast.ai deployment and compose overrides.
 
 ### Build from source
 

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -129,6 +129,7 @@ USER unleash
 WORKDIR /workspace
 
 # -- Install all 5 agent CLIs --
+# TODO: Once antigravity-cli lands (PR #198), add: npm install -g @google/antigravity-cli
 RUN unleash install claude codex gemini pi \
     && npm install -g opencode-ai@latest
 

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,0 +1,145 @@
+# unleash CUDA Docker Image
+#
+# GPU-enabled development environment for AI training on Vast.ai and other GPU clouds.
+# Includes CUDA 12.8 toolkit, PyTorch, all 5 supported coder CLIs:
+#   - Claude Code (Anthropic)
+#   - Codex (OpenAI)
+#   - Gemini CLI (Google)
+#   - OpenCode
+#   - Pi (mariozechner/pi-coding-agent)
+#
+# Build:
+#   docker build -f docker/Dockerfile.cuda -t marksverdhei/unleash:cuda .
+#
+# Run:
+#   docker run --gpus all -it --rm marksverdhei/unleash:cuda
+#
+# Two-stage build:
+#   1. rust-builder - Compiles unleash from source
+#   2. cuda         - nvidia/cuda:12.8.0-devel-ubuntu24.04 with Node 22, all CLIs,
+#                     PyTorch, and CUDA toolkit for AI training workloads
+
+# ============================================================
+# Stage 1: Build unleash from Rust source
+# ============================================================
+FROM rust:1.90-bookworm AS rust-builder
+
+WORKDIR /build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config libssl-dev git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Dependency caching: copy manifests first, build deps, then copy source
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY data/ data/
+COPY assets/ assets/
+COPY docker/ docker/
+RUN mkdir src && echo 'fn main() {}' > src/main.rs \
+    && cargo build --release 2>/dev/null || true \
+    && rm -rf src
+
+COPY src/ src/
+RUN cargo build --release \
+    && strip target/release/unleash
+
+# ============================================================
+# Stage 2: CUDA-enabled runtime for AI development
+# ============================================================
+FROM nvidia/cuda:12.8.0-devel-ubuntu24.04 AS cuda
+
+LABEL maintainer="Heiervang Technologies"
+LABEL description="unleash CUDA - GPU-enabled dev environment with all 5 agent CLIs, CUDA 12.8 toolkit, PyTorch"
+LABEL org.opencontainers.image.source="https://github.com/heiervang-technologies/unleash"
+
+# Install Node 22 via nodesource + dev tools
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       curl ca-certificates gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends \
+       nodejs \
+       gh \
+       git \
+       openssh-client \
+       tmux \
+       jq \
+       sudo \
+       wget \
+       vim-tiny \
+       less \
+       htop \
+       procps \
+       file \
+       unzip \
+       python3 \
+       python3-pip \
+       python3-venv \
+       build-essential \
+       iproute2 \
+       net-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install PyTorch with CUDA support
+RUN pip3 install --break-system-packages \
+    torch torchvision torchaudio \
+    --index-url https://download.pytorch.org/whl/cu124
+
+# Create non-root user (with passwordless sudo for package installs)
+RUN useradd -m -s /bin/bash unleash \
+    && mkdir -p /home/unleash/.local/bin /home/unleash/.npm-global \
+    && echo 'unleash ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/unleash
+
+# -- Install unleash binary from builder stage --
+COPY --from=rust-builder /build/target/release/unleash /usr/local/bin/unleash
+
+# -- Install plugins --
+COPY plugins/bundled/ /usr/local/share/unleash/plugins/
+
+# -- Install helper scripts --
+COPY scripts/unleash-refresh /usr/local/bin/unleash-refresh
+COPY scripts/unleash-exit /usr/local/bin/unleash-exit
+RUN chmod +x /usr/local/bin/unleash-refresh /usr/local/bin/unleash-exit
+
+# Setup directories for unleash user
+RUN mkdir -p /home/unleash/.config/unleash \
+    /home/unleash/.cache/unleash \
+    /home/unleash/.local/share/unleash/plugins \
+    /home/unleash/.claude \
+    /workspace \
+    && chown -R unleash:unleash /home/unleash /workspace
+
+# Pre-seed ~/.claude.json to skip onboarding wizard
+RUN echo '{"numStartups":1,"hasCompletedOnboarding":true,"bypassPermissionsModeAccepted":true,"projects":{"/workspace":{"hasTrustDialogAccepted":true,"allowedTools":[]}}}' \
+    > /home/unleash/.claude.json \
+    && chown unleash:unleash /home/unleash/.claude.json
+
+# Symlink plugins to user data dir
+RUN ln -sf /usr/local/share/unleash/plugins/* /home/unleash/.local/share/unleash/plugins/ 2>/dev/null || true
+
+# Environment defaults
+ENV AGENT_UNLEASH=1
+ENV HOME=/home/unleash
+ENV PATH="/home/unleash/.local/bin:/home/unleash/.npm-global/bin:${PATH}"
+ENV NPM_CONFIG_PREFIX=/home/unleash/.npm-global
+ENV SANDBOX_NAME=cuda-sandbox
+
+# Switch to non-root user
+USER unleash
+WORKDIR /workspace
+
+# -- Install all 5 agent CLIs --
+RUN unleash install claude codex gemini pi \
+    && npm install -g opencode-ai@latest
+
+# Verify all CLIs and PyTorch CUDA availability
+RUN claude --version && echo "✓ Claude Code" \
+    && codex --version && echo "✓ Codex" \
+    && gemini --version && echo "✓ Gemini CLI" \
+    && opencode --version && echo "✓ OpenCode" \
+    && pi --version 2>&1 && echo "✓ Pi" \
+    && python3 -c "import torch; print(f'✓ PyTorch {torch.__version__}')" \
+    && unleash --version && echo "✓ unleash"
+
+ENTRYPOINT ["unleash"]
+CMD []

--- a/docker/docker-compose.cuda.yml
+++ b/docker/docker-compose.cuda.yml
@@ -1,0 +1,39 @@
+# Override: CUDA GPU passthrough for nvidia containers (requires runc and nvidia-container-toolkit)
+#
+# Usage:
+#   docker compose -f docker/docker-compose.yml -f docker/docker-compose.cuda.yml run --rm claude
+#
+# Build the CUDA image first:
+#   docker compose -f docker/docker-compose.yml -f docker/docker-compose.cuda.yml build
+#
+# Multi-agent + CUDA:
+#   docker compose -f docker/docker-compose.yml -f docker/docker-compose.cuda.yml \
+#     -f docker/docker-compose.multi-agent.yml up claude codex
+#
+# Prerequisites:
+#   - nvidia-container-toolkit installed and configured
+#   - runc runtime (not gVisor — gVisor cannot expose GPU devices)
+
+x-gpu: &gpu
+  runtime: nvidia
+  environment:
+    - NVIDIA_VISIBLE_DEVICES=all
+    - CUDA_HOME=/usr/local/cuda-12
+
+services:
+  unleash:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.cuda
+    image: marksverdhei/unleash:cuda
+    <<: *gpu
+  claude:
+    <<: *gpu
+  codex:
+    <<: *gpu
+  gemini:
+    <<: *gpu
+  opencode:
+    <<: *gpu
+  pi:
+    <<: *gpu

--- a/docker/setup-vast-template.sh
+++ b/docker/setup-vast-template.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Vast.ai template setup for unleash CUDA image
+#
+# Prerequisites:
+#   1. vastai CLI installed (pip3 install vastai)
+#   2. API key set: export VAST_API_KEY="your-key-here"
+#   3. Image pushed to Docker Hub: marksverdhei/unleash:cuda
+#
+# Usage:
+#   export VAST_API_KEY="..."
+#   bash docker/setup-vast-template.sh
+#
+# This creates the template and prints next steps for launching instances.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ── Config ──────────────────────────────────────────────────────────
+IMAGE="marksverdhei/unleash"
+TAG="cuda"
+TEMPLATE_NAME="Unleash CUDA"
+TEMPLATE_DESC="GPU-enabled dev environment: CUDA 12.8, PyTorch, all 5 agent CLIs (Claude Code, Codex, Gemini, OpenCode, Pi), unleash session crossloader. SSH + Jupyter."
+DISK_GB=50
+REPO_URL="https://github.com/heiervang-technologies/unleash"
+
+# On-start script runs when the instance boots (as root).
+# Sets up the unleash environment, installs any missing models, and
+# starts Jupyter if requested.
+ONSTART=$(cat <<'SCRIPT'
+#!/bin/bash
+set -euo pipefail
+
+# Create unleash user data dir if missing
+mkdir -p /home/unleash/.config/unleash /home/unleash/.local/share/unleash/plugins
+chown -R unleash:unleash /home/unleash 2>/dev/null || true
+
+# Expose CUDA info
+echo "=== CUDA ==="
+nvidia-smi 2>/dev/null || echo "nvidia-smi not available"
+echo ""
+echo "=== PyTorch ==="
+python3 -c "import torch; print(f'PyTorch {torch.__version__}, CUDA available: {torch.cuda.is_available()}')" 2>/dev/null || echo "PyTorch not installed"
+
+# Print unleash version
+echo "=== Unleash ==="
+unleash --version 2>/dev/null || echo "unleash not in PATH"
+echo ""
+echo "Instance ready. Run 'unleash search' to find and crossload sessions."
+SCRIPT
+)
+
+# ── Check prerequisites ─────────────────────────────────────────────
+if [ -z "${VAST_API_KEY:-}" ]; then
+  if [ -f ~/.config/vastai/vast_api_key ]; then
+    VAST_API_KEY="$(cat ~/.config/vastai/vast_api_key)"
+  else
+    echo "ERROR: VAST_API_KEY not set and ~/.config/vastai/vast_api_key not found."
+    echo "  export VAST_API_KEY='your-key-here'"
+    exit 1
+  fi
+fi
+
+# Check if image is on Docker Hub (optional — helps catch typos early)
+echo "Checking image availability..."
+if docker manifest inspect "${IMAGE}:${TAG}" >/dev/null 2>&1; then
+  echo "  ✓ ${IMAGE}:${TAG} found on Docker Hub"
+else
+  echo "  ⚠ ${IMAGE}:${TAG} not found on Docker Hub yet."
+  echo "    Build and push it first:"
+  echo "      docker build -f ${SCRIPT_DIR}/Dockerfile.cuda -t ${IMAGE}:${TAG} ."
+  echo "      docker push ${IMAGE}:${TAG}"
+  echo ""
+  read -rp "Continue anyway? [y/N] " confirm
+  if [[ ! "$confirm" =~ ^[yY] ]]; then
+    echo "Aborted."
+    exit 1
+  fi
+fi
+
+# ── Create template ─────────────────────────────────────────────────
+echo ""
+echo "Creating Vast.ai template: ${TEMPLATE_NAME}..."
+echo ""
+
+TEMPLATE_OUTPUT=$(vastai create template \
+  --name "${TEMPLATE_NAME}" \
+  --image "${IMAGE}" \
+  --image_tag "${TAG}" \
+  --disk-space "${DISK_GB}" \
+  --ssh \
+  --jupyter \
+  --jupyter-lab \
+  --direct \
+  --repo "${REPO_URL}" \
+  --desc "${TEMPLATE_DESC}" \
+  --env 'PORTS=8080/tcp,22/tcp' \
+  --onstart-cmd "${ONSTART}" \
+  --public 2>&1)
+
+echo "${TEMPLATE_OUTPUT}"
+
+# Extract template ID from output
+TEMPLATE_ID=$(echo "${TEMPLATE_OUTPUT}" | grep -oE '[0-9]+' | head -1)
+
+if [ -n "${TEMPLATE_ID}" ]; then
+  echo ""
+  echo "✓ Template created! ID: ${TEMPLATE_ID}"
+  echo ""
+  echo "Next steps:"
+  echo "  1. Launch an instance from the template:"
+  echo "     vastai search offers 'gpu_ram>=-24 cpu_cores>=8' --storage 50"
+  echo "     vastai create instance ${TEMPLATE_ID} <offer-id> --disk 50"
+  echo ""
+  echo "  2. Or launch from the Vast.ai web UI:"
+  echo "     https://vast.ai/console/create/"
+  echo "       → Search for template: '${TEMPLATE_NAME}'"
+  echo ""
+  echo "  3. Once running, connect via SSH (vastai provides the command)"
+  echo "     or open Jupyter lab in your browser."
+  echo ""
+  echo "  4. Inside the instance:"
+  echo "     unleash search  # find and crossload sessions"
+  echo "     python3 -c \"import torch; print(torch.cuda.is_available())\""
+  echo ""
+else
+  echo ""
+  echo "⚠ Template may have failed. Check the output above."
+  echo "  Try: vastai create template --help"
+fi

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -111,6 +111,59 @@ Mount your API keys and config directory into the container. The compose files
 handle this by default -- check `docker/docker-compose.yml` for the volume
 mappings and adjust paths as needed.
 
+## CUDA / GPU Cloud
+
+For GPU workloads (AI training, inference), use the CUDA variant:
+
+```bash
+docker run --gpus all -it --rm marksverdhei/unleash:cuda
+```
+
+This image adds CUDA 12.8 toolkit, PyTorch with GPU support, and Python 3 on
+top of the standard unleash image with all agent CLIs.
+
+### Build Locally
+
+```bash
+docker build -f docker/Dockerfile.cuda -t marksverdhei/unleash:cuda .
+```
+
+### Docker Compose with GPU
+
+```bash
+docker compose \
+  -f docker/docker-compose.yml \
+  -f docker/docker-compose.cuda.yml \
+  run --rm claude
+```
+
+> **Note:** GPU passthrough requires `nvidia-container-toolkit` and the `runc`
+> runtime. gVisor cannot expose GPU devices — do not combine with
+> `docker-compose.gpu.yml` (Vulkan) or gVisor overrides.
+
+### Vast.ai Deployment
+
+A setup script creates a Vast.ai template from the CUDA image:
+
+```bash
+export VAST_API_KEY="your-key"
+bash docker/setup-vast-template.sh
+```
+
+This creates a template with SSH + Jupyter access. Then launch instances:
+
+```bash
+vastai search offers 'gpu_ram>=24 cuda_vers>=12.0' --limit 5
+vastai create instance <template-id> <offer-id> --disk 50
+```
+
+Inside the instance, all agent CLIs and PyTorch are ready:
+
+```bash
+unleash claude                                    # start coding
+python3 -c "import torch; print(torch.cuda.is_available())"  # verify GPU
+```
+
 ## Further Reading
 
 - [docker/README.md](../docker/README.md) -- full Docker reference

--- a/src/version.rs
+++ b/src/version.rs
@@ -1805,9 +1805,9 @@ impl VersionManager {
         };
 
         let target_triple = match os {
-            "linux" => format!("{}-unknown-linux-gnu", target_arch),
+            "linux" => format!("{}-unknown-linux-musl", target_arch),
             "macos" => format!("{}-apple-darwin", target_arch),
-            _ => format!("{}-unknown-linux-gnu", target_arch),
+            _ => format!("{}-unknown-linux-musl", target_arch),
         };
 
         format!("codex-{}", target_triple)


### PR DESCRIPTION
## Summary

GPU-enabled Docker variant of unleash for AI training on Vast.ai and other GPU clouds.

### New files
- `docker/Dockerfile.cuda` — Two-stage build: Rust builder → `nvidia/cuda:12.8.0-devel-ubuntu24.04` with Node 22, all 5 agent CLIs, PyTorch + CUDA 12.8
- `docker/docker-compose.cuda.yml` — Compose override with `runtime: nvidia` + `NVIDIA_VISIBLE_DEVICES=all`
- `docker/setup-vast-template.sh` — Script to create Vast.ai templates from the CUDA image

### Modified files
- `.github/workflows/docker-publish.yml` — Build, verify, and push CUDA variant (`-cuda` tags) alongside main image
- `src/version.rs` — Fix Codex Linux target from `gnu` → `musl` (Codex only publishes musl binaries)
- `docs/docker.md` — CUDA / GPU cloud section with Vast.ai deployment docs
- `README.md` — CUDA quick-start, fix agent CLI count (4 → 5)

### Testing

Local smoke test — all CLIs verified:

| Component | Version | Status |
|-----------|---------|--------|
| unleash | v0.1.37 | ✅ |
| Claude Code | 2.1.148 | ✅ |
| Codex | 0.133.0 | ✅ |
| Gemini CLI | 0.43.0 | ✅ |
| OpenCode | 1.15.7 | ✅ |
| PyTorch | 2.6.0+cu124 | ✅ (CUDA available: True) |

Image pushed to Docker Hub: `marksverdhei/unleash:cuda` (sha256:3fb616...)