### PR TITLE
fix(agents): agy uses --dangerously-skip-permissions not --yolo

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -417,7 +417,7 @@ impl AgentDefinition {
                     resume_strategy: ResumeStrategy::Flag("--resume".to_string()),
                 },
                 fork: ForkStrategy::Unsupported,
-                yolo_flag: Some("--yolo".to_string()),
+                yolo_flag: Some("--dangerously-skip-permissions".to_string()),
                 model_flag: "-m".to_string(),
                 effort_flag: None,
                 auto_flag: None,


### PR DESCRIPTION
`agy --help` shows `--dangerously-skip-permissions` as the flag to auto-approve tool requests. The polyfill had `--yolo` which agy does not recognise, causing it to exit immediately with "flags provided but not defined".

One-line fix.