### PR TITLE
fix(agents): drop agy --approval-mode forwarding (closes #219)

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -428,7 +428,7 @@ impl AgentDefinition {
                 sandbox: SandboxStrategy::BoolFlag("--sandbox".to_string()),
                 name_flag: None,
                 add_dir_flag: Some("--include-directories".to_string()),
-                approval_mode_flag: Some("--approval-mode".to_string()),
+                approval_mode_flag: None,
                 worktree_flag: Some("--worktree".to_string()),
             },
             github_repo: None,

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -1057,6 +1057,18 @@ mod tests {
         assert!(!inv.args.contains(&"auto".to_string()));
     }
 
+    #[test]
+    fn test_antigravity_no_approval_mode() {
+        let config = AgentDefinition::antigravity().polyfill;
+        let flags = PolyfillFlags {
+            approval_mode: Some("bypass".into()),
+            ..default_flags()
+        };
+        let inv = resolve(&config, &flags, &[]);
+        assert!(!inv.args.contains(&"--approval-mode".to_string()));
+        assert!(!inv.args.contains(&"bypass".to_string()));
+    }
+
     // ── Worktree ────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

- `unleash agy --approval-mode <anything>` crashed agy with `flags provided but not defined: -approval-mode` because the antigravity polyfill mapped the wrapper flag onto a matching agy flag — but agy doesn't have `--approval-mode`.
- Set `approval_mode_flag: None` for antigravity so the wrapper silently consumes the flag (same pattern as opencode).
- Default yolo posture is unchanged: `unleash agy` still runs as `agy --dangerously-skip-permissions` and gets full permissions out of the gate.

## Why this is the right scope

agy's actual perm-bypass is `--dangerously-skip-permissions`, which yolo (on by default for all agents) already provides. There's no useful value-mapping to do — `--approval-mode bypass` is just a Claude-template muscle-memory flag that should be swallowed rather than crash the spawn.

## Verification

```
$ unleash agy --approval-mode bypass --dry-run
Would execute: agy --dangerously-skip-permissions

$ unleash agy --approval-mode invalidvalue --dry-run
Would execute: agy --dangerously-skip-permissions

$ unleash agy --dry-run
Would execute: agy --dangerously-skip-permissions
```

## Test plan

- [x] New `test_antigravity_no_approval_mode` — asserts `--approval-mode bypass` does not leak through to agy argv
- [x] Existing `test_gemini_approval_mode` / `test_codex_approval_mode` / `test_claude_permission_mode` still pass — other agents continue to map their real flag
- [x] Dry-run on built binary shows clean `agy --dangerously-skip-permissions` invocation for all three test cases above

Closes #219