### PR TITLE
feat(tui): sandbox mode toggle + management submenu

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -137,6 +137,7 @@ pub enum Screen {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MainMenuItem {
     Start,
+    SandboxMode,
     Profiles,
     Versions,
     Features,
@@ -152,6 +153,11 @@ const MAIN_MENU: &[(MainMenuItem, &str, &str)] = &[
         MainMenuItem::Start,
         "Start Session",
         "Launch with selected profile",
+    ),
+    (
+        MainMenuItem::SandboxMode,
+        "Sandbox Mode: OFF",
+        "Toggle: launch the next session inside the gVisor sandbox",
     ),
     (
         MainMenuItem::Profiles,
@@ -877,6 +883,10 @@ pub struct App {
     pub profiles: Vec<Profile>,
     pub selected_profile: Option<Profile>,
     pub status_message: Option<String>,
+    /// Whether the next "Start Session" launch should be routed through the
+    /// gVisor sandbox (`unleash sandbox run <agent>`). Session-only — resets
+    /// on relaunch. Toggled via `MainMenuItem::SandboxMode`.
+    pub sandbox_armed: bool,
     /// Profile search/filter query
     pub profile_search_query: String,
     /// Whether search input is active
@@ -1103,6 +1113,7 @@ impl App {
             profiles,
             selected_profile,
             status_message: None,
+            sandbox_armed: false,
             profile_search_query: String::new(),
             profile_search_active: false,
             editing_profile: None,
@@ -2566,10 +2577,20 @@ impl App {
                         if let Some(profile) = &self.selected_profile {
                             return Ok(Some(AppAction::Launch(Box::new(LaunchRequest {
                                 profile: profile.clone(),
+                                sandbox: self.sandbox_armed,
                             }))));
                         } else {
                             self.status_message = Some("No profile selected!".to_string());
                         }
+                    }
+                    Some(MainMenuItem::SandboxMode) => {
+                        self.sandbox_armed = !self.sandbox_armed;
+                        self.status_message = Some(if self.sandbox_armed {
+                            "Sandbox mode armed — next Start Session runs in the gVisor sandbox."
+                                .to_string()
+                        } else {
+                            "Sandbox mode off — next Start Session runs on the host.".to_string()
+                        });
                     }
                     Some(MainMenuItem::Profiles) => {
                         self.trigger_screen_animation(true, Screen::Profiles);
@@ -4827,15 +4848,31 @@ impl App {
         self.main_menu.ensure_visible(visible_items);
         let scroll_offset = self.main_menu.scroll_offset;
 
+        let armed = self.sandbox_armed;
         let items: Vec<ListItem> = MAIN_MENU
             .iter()
             .enumerate()
             .skip(scroll_offset)
             .take(visible_items)
-            .map(|(i, (_, name, desc))| {
+            .map(|(i, (id, name, desc))| {
+                let (name_owned, desc_owned) = match id {
+                    MainMenuItem::SandboxMode if armed => (
+                        "Sandbox Mode: ON  [●]".to_string(),
+                        "Next Start Session will run inside the gVisor sandbox".to_string(),
+                    ),
+                    MainMenuItem::SandboxMode => (
+                        "Sandbox Mode: OFF [○]".to_string(),
+                        (*desc).to_string(),
+                    ),
+                    _ => ((*name).to_string(), (*desc).to_string()),
+                };
                 let style = if i == self.main_menu.selected {
                     Style::default()
                         .fg(self.accent_color())
+                        .add_modifier(Modifier::BOLD)
+                } else if matches!(id, MainMenuItem::SandboxMode) && armed {
+                    Style::default()
+                        .fg(Color::Green)
                         .add_modifier(Modifier::BOLD)
                 } else {
                     Style::default()
@@ -4846,9 +4883,9 @@ impl App {
                     "  "
                 };
                 ListItem::new(vec![
-                    Line::from(Span::styled(format!("{}{}", prefix, name), style)),
+                    Line::from(Span::styled(format!("{}{}", prefix, name_owned), style)),
                     Line::from(Span::styled(
-                        format!("    {}", desc),
+                        format!("    {}", desc_owned),
                         Style::default().fg(Color::DarkGray),
                     )),
                 ])
@@ -6510,6 +6547,9 @@ pub enum AppAction {
 #[derive(Debug, Clone)]
 pub struct LaunchRequest {
     pub profile: Profile,
+    /// If true, route the launch through `unleash sandbox run <agent>`
+    /// instead of executing the agent binary directly on the host.
+    pub sandbox: bool,
 }
 
 /// Request to update the TUI
@@ -6521,6 +6561,32 @@ pub struct UpdateRequest {
 impl LaunchRequest {
     pub fn execute(&self) -> io::Result<std::process::ExitStatus> {
         use std::os::unix::process::CommandExt;
+
+        // Sandboxed launch: re-exec ourselves as `unleash sandbox run <agent>`.
+        // The sandbox dispatcher (src/sandbox.rs::run_agent) handles docker
+        // preflight checks, compose lookup, and agent name validation.
+        if self.sandbox {
+            let agent_name = self
+                .profile
+                .agent_type()
+                .as_ref()
+                .map(|t| t.mascot_name().to_string())
+                .or_else(|| {
+                    std::path::Path::new(&self.profile.agent_cli_path)
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .map(|s| s.to_string())
+                })
+                .unwrap_or_else(|| "claude".to_string());
+            let exe = std::env::current_exe()?;
+            let mut cmd = Command::new(&exe);
+            cmd.arg0("unleash");
+            cmd.args(["sandbox", "run", &agent_name]);
+            for (key, value) in &self.profile.env {
+                cmd.env(key, value);
+            }
+            return cmd.status();
+        }
 
         // If the profile points to a known agent binary, route through the wrapper
         // so it gets focus, restart, and plugin features automatically.
@@ -6615,10 +6681,11 @@ mod tests {
             running: true,
             last_frame_area: Rect::default(),
             screen: Screen::Main,
-            main_menu: MenuState::new(6), // Start, Profiles, Features, Versions, Help, Quit
+            main_menu: MenuState::new(MAIN_MENU.len()),
             profile_menu: MenuState::new(profiles.len()),
             profile_manager,
             app_config,
+            sandbox_armed: false,
             profiles: profiles.clone(),
             selected_profile: profiles.first().cloned(),
             status_message: None,
@@ -6758,7 +6825,7 @@ mod tests {
         // Disable animations for instant transitions in test
         app.animations_enabled = false;
 
-        app.main_menu.selected = 1;
+        app.main_menu.selected = menu_index(MainMenuItem::Profiles);
         let _ = app.handle_main_input(NavAction::Select);
         app.tick(); // Complete pending transition
         assert_eq!(app.screen, Screen::Profiles);
@@ -6796,8 +6863,8 @@ mod tests {
         let (mut app, _temp) = test_app();
         app.animations_enabled = false;
 
-        // Navigate to Profiles (index 1)
-        app.main_menu.selected = 1;
+        // Navigate to Profiles
+        app.main_menu.selected = menu_index(MainMenuItem::Profiles);
         let _ = app.handle_main_input(NavAction::Select);
         app.tick();
         assert_eq!(app.screen, Screen::Profiles);
@@ -6823,7 +6890,7 @@ mod tests {
         app.animations_enabled = false;
 
         // Navigate to Profiles
-        app.main_menu.selected = 1;
+        app.main_menu.selected = menu_index(MainMenuItem::Profiles);
         let _ = app.handle_main_input(NavAction::Select);
         app.tick();
         assert_eq!(app.screen, Screen::Profiles);
@@ -6840,6 +6907,35 @@ mod tests {
         app.handle_help_input(NavAction::Back);
         app.tick();
         assert_eq!(app.screen, Screen::Profiles);
+    }
+
+    #[test]
+    fn test_sandbox_mode_toggle_flips_armed_flag() {
+        let (mut app, _temp) = test_app();
+        app.animations_enabled = false;
+        assert!(!app.sandbox_armed);
+
+        app.main_menu.selected = menu_index(MainMenuItem::SandboxMode);
+        let _ = app.handle_main_input(NavAction::Select);
+        assert!(app.sandbox_armed, "first Select should arm sandbox mode");
+        assert_eq!(app.screen, Screen::Main, "toggle should not navigate away");
+
+        let _ = app.handle_main_input(NavAction::Select);
+        assert!(!app.sandbox_armed, "second Select should disarm sandbox mode");
+    }
+
+    #[test]
+    fn test_sandbox_armed_propagates_to_launch_request() {
+        let (mut app, _temp) = test_app();
+        app.animations_enabled = false;
+        app.sandbox_armed = true;
+        app.main_menu.selected = menu_index(MainMenuItem::Start);
+
+        let action = app.handle_main_input(NavAction::Select).unwrap();
+        match action {
+            Some(AppAction::Launch(req)) => assert!(req.sandbox),
+            other => panic!("expected Launch with sandbox=true, got {:?}", other),
+        }
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -129,9 +129,74 @@ pub enum Screen {
     Features,
     /// Interactive sandbox setup wizard (issue #112+)
     Sandbox,
+    /// Submenu listing sandbox management actions (Setup, Status, List, ...).
+    SandboxMenu,
     /// Post-install setup wizard (issue #172)
     Setup,
 }
+
+/// Items in the Sandbox management submenu (`Screen::SandboxMenu`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SandboxMenuItem {
+    Setup,
+    Status,
+    List,
+    Teardown,
+    Back,
+}
+
+/// Strip ANSI CSI sequences (`\x1b[...m` and friends) from a line so captured
+/// stdout from child processes renders as plain text inside ratatui widgets.
+/// Handles colors, cursor moves, and other CSI codes — not OSC, not DCS.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' && chars.peek() == Some(&'[') {
+            chars.next(); // consume '['
+            // Skip parameter / intermediate bytes (0x20..=0x3f), then one final byte (0x40..=0x7e).
+            while let Some(&nc) = chars.peek() {
+                let nu = nc as u32;
+                if (0x40..=0x7e).contains(&nu) {
+                    chars.next();
+                    break;
+                }
+                chars.next();
+            }
+            continue;
+        }
+        out.push(c);
+    }
+    out
+}
+
+const SANDBOX_MENU: &[(SandboxMenuItem, &str, &str)] = &[
+    (
+        SandboxMenuItem::Setup,
+        "Setup / Reconfigure",
+        "Run the interactive gVisor + Docker sandbox wizard",
+    ),
+    (
+        SandboxMenuItem::Status,
+        "Status",
+        "Show sandbox health: network, image, firewall rules",
+    ),
+    (
+        SandboxMenuItem::List,
+        "List Containers",
+        "Show running sandboxed containers",
+    ),
+    (
+        SandboxMenuItem::Teardown,
+        "Teardown",
+        "Remove sandbox network + firewall rules (requires sudo)",
+    ),
+    (
+        SandboxMenuItem::Back,
+        "Back",
+        "Return to the main menu",
+    ),
+];
 
 /// Main menu items — order here defines display order in the TUI.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -887,6 +952,13 @@ pub struct App {
     /// gVisor sandbox (`unleash sandbox run <agent>`). Session-only — resets
     /// on relaunch. Toggled via `MainMenuItem::SandboxMode`.
     pub sandbox_armed: bool,
+    /// Selection state for the Sandbox management submenu (`Screen::SandboxMenu`).
+    pub sandbox_menu: MenuState,
+    /// Captured stdout/stderr from the last sandbox action (Status/List/...).
+    /// When non-empty, an output panel is rendered over the submenu.
+    pub sandbox_action_output: Vec<String>,
+    /// Title shown above the captured output (e.g. "Sandbox Status").
+    pub sandbox_action_title: String,
     /// Profile search/filter query
     pub profile_search_query: String,
     /// Whether search input is active
@@ -1114,6 +1186,9 @@ impl App {
             selected_profile,
             status_message: None,
             sandbox_armed: false,
+            sandbox_menu: MenuState::new(SANDBOX_MENU.len()),
+            sandbox_action_output: Vec::new(),
+            sandbox_action_title: String::new(),
             profile_search_query: String::new(),
             profile_search_active: false,
             editing_profile: None,
@@ -1511,6 +1586,7 @@ impl App {
             | Screen::Help
             | Screen::Features
             | Screen::Sandbox
+            | Screen::SandboxMenu
             | Screen::Setup
             | Screen::ConfirmDelete => {}
         }
@@ -2203,6 +2279,7 @@ impl App {
                 Screen::VersionManagement => return self.handle_version_input(action, key),
                 Screen::Features => self.handle_features_input(action),
                 Screen::Sandbox => self.handle_sandbox_input(action, key),
+                Screen::SandboxMenu => self.handle_sandbox_menu_input(action),
                 Screen::Setup => self.handle_setup_input(action, key),
             }
         }
@@ -2612,9 +2689,10 @@ impl App {
                         self.pending_screen = Some(Screen::Setup);
                     }
                     Some(MainMenuItem::Sandbox) => {
-                        self.open_sandbox_wizard();
-                        self.trigger_screen_animation(true, Screen::Sandbox);
-                        self.pending_screen = Some(Screen::Sandbox);
+                        self.sandbox_action_output.clear();
+                        self.sandbox_action_title.clear();
+                        self.trigger_screen_animation(true, Screen::SandboxMenu);
+                        self.pending_screen = Some(Screen::SandboxMenu);
                     }
                     Some(MainMenuItem::Help) => {
                         self.help_return_screen = Some(Screen::Main);
@@ -3597,6 +3675,100 @@ impl App {
         SandboxStep::ALL.len()
     }
 
+    fn handle_sandbox_menu_input(&mut self, action: NavAction) {
+        // When the action-output panel is showing, any key dismisses it.
+        if !self.sandbox_action_output.is_empty() {
+            match action {
+                NavAction::Back | NavAction::Quit | NavAction::Select => {
+                    self.sandbox_action_output.clear();
+                    self.sandbox_action_title.clear();
+                }
+                _ => {}
+            }
+            return;
+        }
+
+        match action {
+            NavAction::Up | NavAction::Down => {
+                self.sandbox_menu.handle_action(action);
+            }
+            NavAction::Back | NavAction::Quit => {
+                self.trigger_screen_animation(false, Screen::Main);
+                self.pending_screen = Some(Screen::Main);
+            }
+            NavAction::Select => {
+                let item = SANDBOX_MENU
+                    .get(self.sandbox_menu.selected)
+                    .map(|(id, _, _)| *id);
+                match item {
+                    Some(SandboxMenuItem::Setup) => {
+                        self.open_sandbox_wizard();
+                        self.trigger_screen_animation(true, Screen::Sandbox);
+                        self.pending_screen = Some(Screen::Sandbox);
+                    }
+                    Some(SandboxMenuItem::Status) => self.run_sandbox_action_capture(
+                        "Sandbox Status",
+                        &["sandbox", "status"],
+                    ),
+                    Some(SandboxMenuItem::List) => self.run_sandbox_action_capture(
+                        "Running Sandboxes",
+                        &["sandbox", "list"],
+                    ),
+                    Some(SandboxMenuItem::Teardown) => {
+                        self.status_message = Some(
+                            "Teardown needs sudo — run `sudo unleash sandbox teardown` from a shell."
+                                .to_string(),
+                        );
+                    }
+                    Some(SandboxMenuItem::Back) | None => {
+                        self.trigger_screen_animation(false, Screen::Main);
+                        self.pending_screen = Some(Screen::Main);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Spawn `unleash <args>` as a child process and capture its stdout/stderr
+    /// into `sandbox_action_output` for inline display. Synchronous — the
+    /// commands invoked here (sandbox status, list) are docker queries that
+    /// return in well under a second.
+    fn run_sandbox_action_capture(&mut self, title: &str, args: &[&str]) {
+        self.sandbox_action_title = title.to_string();
+        self.sandbox_action_output.clear();
+        let exe = match std::env::current_exe() {
+            Ok(p) => p,
+            Err(e) => {
+                self.sandbox_action_output
+                    .push(format!("error: cannot resolve current exe: {}", e));
+                return;
+            }
+        };
+        let output = match Command::new(&exe).args(args).output() {
+            Ok(o) => o,
+            Err(e) => {
+                self.sandbox_action_output
+                    .push(format!("error: failed to spawn `unleash {}`: {}", args.join(" "), e));
+                return;
+            }
+        };
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            self.sandbox_action_output.push(strip_ansi(line));
+        }
+        for line in String::from_utf8_lossy(&output.stderr).lines() {
+            self.sandbox_action_output.push(strip_ansi(line));
+        }
+        if !output.status.success() {
+            self.sandbox_action_output
+                .push(format!("[exited with status {}]", output.status));
+        }
+        if self.sandbox_action_output.is_empty() {
+            self.sandbox_action_output
+                .push("(no output)".to_string());
+        }
+    }
+
     fn handle_sandbox_input(&mut self, action: NavAction, key: KeyEvent) {
         // While typing an explicit env value, the text input handler owns input.
         if self.edit_field == EditField::SandboxEnvValue {
@@ -3861,6 +4033,77 @@ impl App {
     }
 
     /// Render the sandbox wizard.
+    fn render_sandbox_menu(&mut self, frame: &mut Frame, area: Rect) {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3), // Title
+                Constraint::Min(10),   // Menu / output
+            ])
+            .split(area);
+
+        let title = Paragraph::new(Line::from(Span::styled(
+            "Sandbox Management",
+            Style::default()
+                .fg(self.accent_color())
+                .add_modifier(Modifier::BOLD),
+        )));
+        frame.render_widget(title, chunks[0]);
+
+        // If an action was just run, show its captured output instead of the menu.
+        if !self.sandbox_action_output.is_empty() {
+            let mut lines: Vec<Line> = Vec::with_capacity(self.sandbox_action_output.len() + 2);
+            lines.push(Line::from(Span::styled(
+                self.sandbox_action_title.clone(),
+                Style::default()
+                    .fg(self.accent_color())
+                    .add_modifier(Modifier::BOLD),
+            )));
+            lines.push(Line::from(""));
+            for raw in &self.sandbox_action_output {
+                lines.push(Line::from(raw.clone()));
+            }
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "Press Esc / Enter to return to the menu.",
+                Style::default().fg(Color::DarkGray),
+            )));
+            let para = Paragraph::new(lines).wrap(Wrap { trim: false });
+            frame.render_widget(para, chunks[1]);
+            return;
+        }
+
+        // Otherwise render the action list.
+        let menu_area = chunks[1];
+        let items: Vec<ListItem> = SANDBOX_MENU
+            .iter()
+            .enumerate()
+            .map(|(i, (_, name, desc))| {
+                let style = if i == self.sandbox_menu.selected {
+                    Style::default()
+                        .fg(self.accent_color())
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                };
+                let prefix = if i == self.sandbox_menu.selected {
+                    "> "
+                } else {
+                    "  "
+                };
+                ListItem::new(vec![
+                    Line::from(Span::styled(format!("{}{}", prefix, name), style)),
+                    Line::from(Span::styled(
+                        format!("    {}", desc),
+                        Style::default().fg(Color::DarkGray),
+                    )),
+                ])
+            })
+            .collect();
+        let list = List::new(items);
+        frame.render_widget(list, menu_area);
+    }
+
     fn render_sandbox_wizard(&mut self, frame: &mut Frame, area: Rect) {
         use ratatui::widgets::{Block, Borders, Paragraph};
 
@@ -4594,6 +4837,7 @@ impl App {
             }
             Screen::Features => 50,
             Screen::Sandbox => 80,
+            Screen::SandboxMenu => 70,
             Screen::Setup => 80,
         }
     }
@@ -4751,6 +4995,7 @@ impl App {
                     self.render_sandbox_env_value_dialog(frame, frame.area());
                 }
             }
+            Screen::SandboxMenu => self.render_sandbox_menu(frame, area),
             Screen::Setup => self.render_setup_wizard(frame, area),
         }
     }
@@ -6686,6 +6931,9 @@ mod tests {
             profile_manager,
             app_config,
             sandbox_armed: false,
+            sandbox_menu: MenuState::new(SANDBOX_MENU.len()),
+            sandbox_action_output: Vec::new(),
+            sandbox_action_title: String::new(),
             profiles: profiles.clone(),
             selected_profile: profiles.first().cloned(),
             status_message: None,
@@ -6922,6 +7170,68 @@ mod tests {
 
         let _ = app.handle_main_input(NavAction::Select);
         assert!(!app.sandbox_armed, "second Select should disarm sandbox mode");
+    }
+
+    #[test]
+    fn test_main_menu_sandbox_routes_to_submenu() {
+        let (mut app, _temp) = test_app();
+        app.animations_enabled = false;
+        app.main_menu.selected = menu_index(MainMenuItem::Sandbox);
+        let _ = app.handle_main_input(NavAction::Select);
+        app.tick();
+        assert_eq!(app.screen, Screen::SandboxMenu);
+    }
+
+    #[test]
+    fn test_sandbox_menu_setup_opens_wizard() {
+        let (mut app, _temp) = test_app();
+        app.animations_enabled = false;
+        app.screen = Screen::SandboxMenu;
+        app.sandbox_menu.selected = SANDBOX_MENU
+            .iter()
+            .position(|(id, _, _)| *id == SandboxMenuItem::Setup)
+            .unwrap();
+        app.handle_sandbox_menu_input(NavAction::Select);
+        app.tick();
+        assert_eq!(app.screen, Screen::Sandbox);
+        assert!(app.sandbox_wizard.is_some());
+    }
+
+    #[test]
+    fn test_sandbox_menu_back_returns_to_main() {
+        let (mut app, _temp) = test_app();
+        app.animations_enabled = false;
+        app.screen = Screen::SandboxMenu;
+        app.sandbox_menu.selected = SANDBOX_MENU
+            .iter()
+            .position(|(id, _, _)| *id == SandboxMenuItem::Back)
+            .unwrap();
+        app.handle_sandbox_menu_input(NavAction::Select);
+        app.tick();
+        assert_eq!(app.screen, Screen::Main);
+    }
+
+    #[test]
+    fn test_sandbox_menu_esc_returns_to_main() {
+        let (mut app, _temp) = test_app();
+        app.animations_enabled = false;
+        app.screen = Screen::SandboxMenu;
+        app.handle_sandbox_menu_input(NavAction::Back);
+        app.tick();
+        assert_eq!(app.screen, Screen::Main);
+    }
+
+    #[test]
+    fn test_sandbox_menu_output_panel_dismisses_on_key() {
+        let (mut app, _temp) = test_app();
+        app.screen = Screen::SandboxMenu;
+        app.sandbox_action_output = vec!["line 1".into(), "line 2".into()];
+        app.sandbox_action_title = "Sandbox Status".into();
+        app.handle_sandbox_menu_input(NavAction::Back);
+        assert!(app.sandbox_action_output.is_empty());
+        assert!(app.sandbox_action_title.is_empty());
+        // Still on SandboxMenu — back key dismisses output, doesn't navigate.
+        assert_eq!(app.screen, Screen::SandboxMenu);
     }
 
     #[test]


### PR DESCRIPTION
Two related sandbox UX improvements on the main TUI menu, in one branch since they share state and the main-menu layout.

## 1. Sandbox Mode toggle

- New \`MainMenuItem::SandboxMode\` toggle row directly under \`Start Session\`
- Label flips with state, highlighted green when armed:
  \`\`\`
  Sandbox Mode: OFF [○]
  Sandbox Mode: ON  [●]
  \`\`\`
- When armed, \`Start Session\` execs into \`unleash sandbox run <agent>\` instead of host launch
- Session-only state (resets on TUI relaunch). CLI behavior unchanged

## 2. Sandbox management submenu

- The \`Sandbox\` main-menu row now opens \`Screen::SandboxMenu\` instead of dropping straight into the wizard
- 5 items:
  - **Setup / Reconfigure** → existing wizard
  - **Status** → inline \`unleash sandbox status\` output
  - **List Containers** → inline \`unleash sandbox list\` output
  - **Teardown** → hint to run CLI (sudo required)
  - **Back** → main menu
- Status / List spawn \`unleash <subcmd>\` as a child, capture stdout+stderr, strip ANSI, render as a Paragraph panel. Esc/Enter dismisses

## Verified

- All 84 tui::app tests pass (7 new — toggle x2, submenu navigation x5)
- 524 total lib tests green
- Smoke tested in tmux:
  - Toggle: \`Sandbox Mode: OFF [○]\` flips to \`Sandbox Mode: ON [●]\`, status bar confirms
  - Submenu: rendered, navigated, Status / List captured docker output cleanly (✓ checkmarks render after UTF-8-safe ANSI stripping)
  - Teardown hint visible in status bar

## Deferred to followups

- \`sandbox::run_agent\` only accepts \`claude/codex/gemini/opencode/bash/unleash\` — sandboxed launches from \`agy/pi/hermes\` profiles surface "unknown agent" from the dispatcher
- Submenu has no Enter / container-shell item yet — needs a container picker
- Teardown is a CLI hint rather than an in-TUI confirm + sudo prompt — interactive sudo doesn't play nicely in ratatui