### PR TITLE
fix(sandbox): accept pi as a sandboxed agent

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,7 +6,7 @@
 # with real nameservers if the internal resolver is unreachable.
 #
 # Privilege handling:
-#   - Agent CLIs (claude, codex, gemini, unleash, opencode) run as 'unleash' user
+#   - Agent CLIs (claude, codex, gemini, opencode, pi, unleash) run as 'unleash' user
 #     because Claude Code refuses --dangerously-skip-permissions as root.
 #   - bash/shell sessions run as root for full install capability.
 # gVisor + network isolation is the security boundary, not the in-container user.
@@ -31,7 +31,7 @@ fi
 # Determine if we should drop privileges
 cmd="$(basename "${1:-}" 2>/dev/null)"
 case "$cmd" in
-    claude|codex|gemini|opencode|unleash)
+    claude|codex|gemini|opencode|pi|unleash)
         # Agent CLIs need non-root (Claude Code refuses --dangerously-skip-permissions as root)
         export HOME=/home/unleash
         exec runuser -u unleash -- "$@"

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -937,8 +937,9 @@ pub fn run_agent(
     // Validate sandbox name (used as Docker hostname, must be RFC 1123 compliant)
     validate_sandbox_name(name)?;
 
-    // Validate agent name
-    let valid_agents = ["claude", "codex", "gemini", "opencode", "bash", "unleash"];
+    // Validate agent name — must match a CLI built into the sandbox image
+    // (docker/Dockerfile) and a service in docker-compose.yml.
+    let valid_agents = ["claude", "codex", "gemini", "opencode", "pi", "bash", "unleash"];
     if !valid_agents.contains(&agent) {
         eprintln!(
             "\x1b[31merror:\x1b[0m Unknown agent '{}'. Valid agents: {}",
@@ -1330,7 +1331,7 @@ pub enum SandboxAction {
         #[arg(long, default_value = "sandbox")]
         name: String,
 
-        /// Agent to run: claude, codex, gemini, opencode, bash, unleash
+        /// Agent to run: claude, codex, gemini, opencode, pi, bash, unleash
         /// Defaults to bash if omitted.
         #[arg(default_value = "bash")]
         agent: String,


### PR DESCRIPTION
## Summary

- Pi (\`@mariozechner/pi-coding-agent\`) is built into the sandbox image and has a docker-compose service entry, but \`sandbox::run_agent\`'s allowlist and \`entrypoint.sh\`'s runuser switch both omitted it
- Result: \`unleash sandbox run pi\` failed with \"Unknown agent 'pi'. Valid agents: claude, codex, gemini, opencode, bash, unleash\" even though \`pi --version\` works in the image
- This is now reachable via the TUI sandbox-mode toggle landed in #222 — a profile pointing at \`pi\` would arm sandbox and hit this error on launch

## Fix

- Add \`pi\` to:
  - \`src/sandbox.rs\` \`valid_agents\` allowlist
  - \`SandboxAction::Run\` doc comment in clap so \`--help\` lists it
  - \`docker/entrypoint.sh\` runuser case (so pi runs as the \`unleash\` user, matching the other agent CLIs)

## Test plan

- [x] \`cargo test --lib\` — 530 tests pass
- [x] \`bash -n docker/entrypoint.sh\` — syntax OK
- [ ] Manual: \`unleash sandbox run pi\` resolves to a valid invocation (requires sandbox setup; not exercised on this machine but the change is mechanical)

## Out of scope

- \`agy\` (antigravity) and \`hermes\` are still rejected — they're not installed in the Dockerfile. Adding them is a bigger PR (Dockerfile install steps + compose entries + verification).