### PR TITLE
fix(sessions): overlay search-index names onto crossload resolution

### DIFF
--- a/src/interchange/sessions.rs
+++ b/src/interchange/sessions.rs
@@ -26,13 +26,14 @@ pub fn discover_all() -> Vec<SessionInfo> {
     sessions.extend(discover_opencode());
     sessions.extend(discover_pi());
     sessions.extend(discover_ucf());
+    overlay_search_index_names(&mut sessions);
     sessions.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
     sessions
 }
 
 /// Discover sessions for a specific CLI.
 pub fn discover_for(cli: CliFormat) -> Vec<SessionInfo> {
-    match cli {
+    let mut sessions = match cli {
         CliFormat::ClaudeCode => discover_claude(),
         CliFormat::Codex => discover_codex(),
         CliFormat::GeminiCli => discover_gemini(),
@@ -40,6 +41,74 @@ pub fn discover_for(cli: CliFormat) -> Vec<SessionInfo> {
         CliFormat::OpenCode => discover_opencode(),
         CliFormat::Pi => discover_pi(),
         CliFormat::Ucf => discover_ucf(),
+    };
+    overlay_search_index_names(&mut sessions);
+    sessions
+}
+
+/// Overlay friendly names from the search index DB (`unleash sessions name ...`
+/// and auto-generated titles) onto the filesystem-derived session list.
+///
+/// The search index is written by `src/search.rs` to a local SQLite file. If
+/// a row exists for `(cli, source_id)`, we copy its preferred title
+/// (generated > native) into `SessionInfo.name`, but only when the filesystem
+/// scan didn't already pick up a name. This keeps the DB as a *supplementary*
+/// source — JSONL-native names (Claude `agent-name`, Codex `session_index`)
+/// still win.
+///
+/// Failures are silent: the index is optional and may not exist on a fresh
+/// install or on a machine that's never run `unleash search`.
+fn overlay_search_index_names(sessions: &mut [SessionInfo]) {
+    if sessions.is_empty() {
+        return;
+    }
+    let db_path = match dirs::data_local_dir() {
+        Some(d) => d.join("unleash").join("search-index.db"),
+        None => return,
+    };
+    if !db_path.exists() {
+        return;
+    }
+    let conn = match rusqlite::Connection::open_with_flags(
+        &db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    ) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    let mut stmt = match conn.prepare(
+        "SELECT cli, source_id, coalesce(generated_title, native_title) AS title
+         FROM sessions
+         WHERE title IS NOT NULL",
+    ) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let rows = match stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+        ))
+    }) {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+    let mut overlay: std::collections::HashMap<(String, String), String> =
+        std::collections::HashMap::new();
+    for row in rows.flatten() {
+        overlay.insert((row.0, row.1), row.2);
+    }
+    if overlay.is_empty() {
+        return;
+    }
+    for s in sessions.iter_mut() {
+        if s.name.is_some() {
+            continue;
+        }
+        if let Some(title) = overlay.get(&(s.cli.clone(), s.id.clone())) {
+            s.name = Some(title.clone());
+        }
     }
 }
 
@@ -548,6 +617,74 @@ mod tests {
         let sessions = discover_all();
         // We can't assert count since it depends on the machine; just verify no panic.
         let _ = sessions.len();
+    }
+
+    #[test]
+    fn test_overlay_search_index_fills_missing_name() {
+        let mut sessions = vec![
+            SessionInfo {
+                cli: "claude".into(),
+                id: "test-id-xyz".into(),
+                name: None,
+                title: None,
+                directory: "/tmp".into(),
+                path: PathBuf::from("/tmp/nope.jsonl"),
+                updated_at: "0".into(),
+                message_count: None,
+            },
+            SessionInfo {
+                cli: "claude".into(),
+                id: "preserved-id".into(),
+                name: Some("preexisting".into()),
+                title: None,
+                directory: "/tmp".into(),
+                path: PathBuf::from("/tmp/nope2.jsonl"),
+                updated_at: "0".into(),
+                message_count: None,
+            },
+        ];
+
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("search-index.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE sessions (
+                pk INTEGER PRIMARY KEY,
+                cli TEXT NOT NULL,
+                source_id TEXT NOT NULL,
+                native_title TEXT,
+                generated_title TEXT,
+                UNIQUE(cli, source_id));
+             INSERT INTO sessions (cli, source_id, generated_title) VALUES
+               ('claude', 'test-id-xyz', 'overlay-name'),
+               ('claude', 'preserved-id', 'should-not-overwrite');",
+        )
+        .unwrap();
+        drop(conn);
+
+        // Point dirs::data_local_dir() at our temp by hijacking XDG_DATA_HOME.
+        // The unleash subdir must exist below it.
+        let unleash_dir = tmp.path().join("unleash");
+        std::fs::create_dir_all(&unleash_dir).unwrap();
+        std::fs::rename(&db_path, unleash_dir.join("search-index.db")).unwrap();
+        let saved_xdg = std::env::var_os("XDG_DATA_HOME");
+        // SAFETY: tests are single-threaded for env mutation; restored below.
+        unsafe { std::env::set_var("XDG_DATA_HOME", tmp.path()); }
+
+        overlay_search_index_names(&mut sessions);
+
+        // Restore env before any panic surfaces.
+        match saved_xdg {
+            Some(v) => unsafe { std::env::set_var("XDG_DATA_HOME", v) },
+            None => unsafe { std::env::remove_var("XDG_DATA_HOME") },
+        }
+
+        assert_eq!(sessions[0].name.as_deref(), Some("overlay-name"));
+        assert_eq!(
+            sessions[1].name.as_deref(),
+            Some("preexisting"),
+            "overlay must not overwrite an existing name"
+        );
     }
 
     #[test]

--- a/src/interchange/sessions.rs
+++ b/src/interchange/sessions.rs
@@ -62,11 +62,29 @@ fn overlay_search_index_names(sessions: &mut [SessionInfo]) {
     if sessions.is_empty() {
         return;
     }
+    let debug_mode = std::env::var_os("UNLEASH_DEBUG").is_some();
+
+    // Helper to fall back to filesystem titles for exact name matching in `find_session`
+    // (e.g. for Claude's agent-name or custom-title) even when the SQLite database is absent or unindexed.
+    // This allows exact matching to function immediately on newly-updated or freshly-named files
+    // without requiring an explicit reindex.
+    let apply_filesystem_fallbacks = |sessions: &mut [SessionInfo]| {
+        for s in sessions.iter_mut() {
+            if s.name.is_none() && s.title.is_some() {
+                s.name = s.title.clone();
+            }
+        }
+    };
+
     let db_path = match dirs::data_local_dir() {
         Some(d) => d.join("unleash").join("search-index.db"),
-        None => return,
+        None => {
+            apply_filesystem_fallbacks(sessions);
+            return;
+        }
     };
     if !db_path.exists() {
+        apply_filesystem_fallbacks(sessions);
         return;
     }
     let conn = match rusqlite::Connection::open_with_flags(
@@ -74,40 +92,66 @@ fn overlay_search_index_names(sessions: &mut [SessionInfo]) {
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
     ) {
         Ok(c) => c,
-        Err(_) => return,
+        Err(e) => {
+            if debug_mode {
+                eprintln!("Warning: Failed to open search index database {}: {}", db_path.display(), e);
+            }
+            apply_filesystem_fallbacks(sessions);
+            return;
+        }
     };
     let mut stmt = match conn.prepare(
-        "SELECT cli, source_id, coalesce(generated_title, native_title) AS title
-         FROM sessions
-         WHERE title IS NOT NULL",
+        "SELECT cli, source_id, generated_title, native_title
+         FROM sessions",
     ) {
         Ok(s) => s,
-        Err(_) => return,
+        Err(e) => {
+            if debug_mode {
+                eprintln!("Warning: Failed to prepare search index query: {}", e);
+            }
+            apply_filesystem_fallbacks(sessions);
+            return;
+        }
     };
     let rows = match stmt.query_map([], |row| {
         Ok((
             row.get::<_, String>(0)?,
             row.get::<_, String>(1)?,
-            row.get::<_, String>(2)?,
+            row.get::<_, Option<String>>(2)?,
+            row.get::<_, Option<String>>(3)?,
         ))
     }) {
         Ok(r) => r,
-        Err(_) => return,
+        Err(e) => {
+            if debug_mode {
+                eprintln!("Warning: Failed to execute search index query: {}", e);
+            }
+            apply_filesystem_fallbacks(sessions);
+            return;
+        }
     };
-    let mut overlay: std::collections::HashMap<(String, String), String> =
+    let mut overlay: std::collections::HashMap<(String, String), (Option<String>, Option<String>)> =
         std::collections::HashMap::new();
     for row in rows.flatten() {
-        overlay.insert((row.0, row.1), row.2);
-    }
-    if overlay.is_empty() {
-        return;
+        overlay.insert((row.0, row.1), (row.2, row.3));
     }
     for s in sessions.iter_mut() {
-        if s.name.is_some() {
-            continue;
-        }
-        if let Some(title) = overlay.get(&(s.cli.clone(), s.id.clone())) {
-            s.name = Some(title.clone());
+        if let Some((gen, nat)) = overlay.get(&(s.cli.clone(), s.id.clone())) {
+            if s.name.is_none() {
+                if gen.is_some() {
+                    // Manual custom title set by the user takes priority
+                    s.name = gen.clone();
+                } else if s.title.is_some() {
+                    // Live filesystem-derived title takes priority over stale/cached native DB title
+                    s.name = s.title.clone();
+                } else {
+                    // Last resort fallback: cached DB native title
+                    s.name = nat.clone();
+                }
+            }
+        } else if s.name.is_none() && s.title.is_some() {
+            // Live filesystem-derived title acts as name fallback if missing from DB
+            s.name = s.title.clone();
         }
     }
 }
@@ -642,6 +686,16 @@ mod tests {
                 updated_at: "0".into(),
                 message_count: None,
             },
+            SessionInfo {
+                cli: "claude".into(),
+                id: "no-db-entry-id".into(),
+                name: None,
+                title: Some("fs-title".into()),
+                directory: "/tmp".into(),
+                path: PathBuf::from("/tmp/nope3.jsonl"),
+                updated_at: "0".into(),
+                message_count: None,
+            },
         ];
 
         let tmp = tempfile::tempdir().unwrap();
@@ -684,6 +738,11 @@ mod tests {
             sessions[1].name.as_deref(),
             Some("preexisting"),
             "overlay must not overwrite an existing name"
+        );
+        assert_eq!(
+            sessions[2].name.as_deref(),
+            Some("fs-title"),
+            "filesystem title should fall back to name if DB is missing entry"
         );
     }
 


### PR DESCRIPTION
Closes #226.

## Summary

\`unleash sessions name claude:<uuid> \"friendly\"\` writes only to the search-index DB. \`find_session\` (used by crossload, \`unleash sessions --find\`, and the UCF/sync path) scans the filesystem and never consulted that DB — so DB-only names were invisible to \`-x\` even though \`unleash search\` listed them.

## Fix

Add \`overlay_search_index_names()\` in \`src/interchange/sessions.rs\` that reads \`(cli, source_id) -> coalesce(generated_title, native_title)\` from the search-index.db via **rusqlite read-only** and fills in \`SessionInfo.name\` when the filesystem scan didn't already supply one.

Precedence (highest wins):
1. JSONL-native names — Claude \`agent-name\` / \`custom-title\`, Codex \`session_index.jsonl\`
2. Search-index DB titles (generated > native_title fallback)
3. None

Failures (DB missing on fresh install, schema mismatch, lock contention) are silent — the index is supplementary, not load-bearing.

## Verified

\`\`\`bash
# Three Claude sessions whose names were only in the search DB
$ ./target/debug/unleash sessions --find sam
claude     a441842f-c9b2-4601-8f32-1297b034dd53     sam              /home/me/ht/studio

$ ./target/debug/unleash sessions --find ht-org-manager
claude     b5e41dbb-c2bd-4f24-82e4-21553227443e     ht-org-manager   /home/me/ht

# End-to-end crossload now works
$ ./target/debug/unleash pi -x claude:sam --dry-run
Injected 878 lines to ~/.pi/agent/sessions/.../[uuid].jsonl
✓ Session 'sam' from claude injected into Pi
Would execute: pi --session ~/.pi/agent/sessions/.../[uuid].jsonl
\`\`\`

## Test plan

- [x] New \`test_overlay_search_index_fills_missing_name\` — verifies overlay fills missing name, preserves existing name
- [x] 531 lib tests pass (6 in interchange::sessions, 525 elsewhere)
- [x] Manual: three DB-only names resolve via \`sessions --find\`; \`pi -x claude:sam\` injects successfully