### PR TITLE
feat(sessions): implement unleash sessions doctor subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -803,6 +803,13 @@ pub enum SessionsAction {
         /// New title — if omitted, regenerate via the configured chat model
         title: Option<String>,
     },
+
+    /// Diagnose the crossload-index cache for stale/dead entries
+    Doctor {
+        /// Garbage collect: remove source-gone entries from the cache
+        #[arg(long)]
+        gc: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/interchange/crossload_index.rs
+++ b/src/interchange/crossload_index.rs
@@ -111,6 +111,147 @@ pub fn entry_is_live(entry: &Entry) -> bool {
     Path::new(&entry.target_path).exists()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DoctorStatus {
+    Live,
+    TargetGone,
+    SourceUpdated,
+    SourceGone,
+}
+
+impl std::fmt::Display for DoctorStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            DoctorStatus::Live => "live",
+            DoctorStatus::TargetGone => "target-gone",
+            DoctorStatus::SourceUpdated => "source-updated",
+            DoctorStatus::SourceGone => "source-gone",
+        };
+        write!(f, "{s}")
+    }
+}
+
+#[derive(Serialize)]
+pub struct DoctorReportItem {
+    pub status: DoctorStatus,
+    pub source_cli: String,
+    pub source_id: String,
+    pub target_cli: String,
+    pub target_session_id: String,
+    pub target_path: String,
+    pub source_updated_at: Option<String>,
+    pub reason: String,
+}
+
+fn parse_key(key: &str) -> Option<(String, String, String)> {
+    let (src, target_cli) = key.split_once("->")?;
+    let (source_cli, source_id) = src.split_once(':')?;
+    Some((source_cli.to_string(), source_id.to_string(), target_cli.to_string()))
+}
+
+pub fn run_doctor(json: bool, gc: bool) -> io::Result<()> {
+    let mut index = load();
+    let _reports = run_doctor_impl(json, gc, &mut index, |cli, id| {
+        crate::interchange::sessions::find_session(&format!("{cli}:{id}"))
+    })?;
+    if gc {
+        save(&index)?;
+    }
+    Ok(())
+}
+
+pub fn run_doctor_impl<F>(
+    json: bool,
+    gc: bool,
+    index: &mut CrossloadIndex,
+    mut find_src: F,
+) -> io::Result<Vec<DoctorReportItem>>
+where
+    F: FnMut(&str, &str) -> Option<crate::interchange::sessions::SessionInfo>,
+{
+    let mut reports = Vec::new();
+    let mut live_count = 0;
+    let mut target_gone_count = 0;
+    let mut source_updated_count = 0;
+    let mut source_gone_count = 0;
+
+    let mut keys_to_remove = Vec::new();
+
+    for (k, entry) in &index.entries {
+        let Some((source_cli, source_id, target_cli)) = parse_key(k) else {
+            continue;
+        };
+
+        let source_opt = find_src(&source_cli, &source_id);
+
+        let (status, reason) = if let Some(source) = source_opt {
+            if entry.source_updated_at.as_deref() != Some(&source.updated_at) {
+                (DoctorStatus::SourceUpdated, "source session modified")
+            } else if !entry.target_path.is_empty() && !Path::new(&entry.target_path).exists() {
+                (DoctorStatus::TargetGone, "target file missing")
+            } else {
+                (DoctorStatus::Live, "")
+            }
+        } else {
+            keys_to_remove.push(k.clone());
+            (DoctorStatus::SourceGone, "source session not found")
+        };
+
+        match status {
+            DoctorStatus::Live => live_count += 1,
+            DoctorStatus::TargetGone => target_gone_count += 1,
+            DoctorStatus::SourceUpdated => source_updated_count += 1,
+            DoctorStatus::SourceGone => source_gone_count += 1,
+        }
+
+        reports.push(DoctorReportItem {
+            status,
+            source_cli,
+            source_id,
+            target_cli,
+            target_session_id: entry.target_session_id.clone(),
+            target_path: entry.target_path.clone(),
+            source_updated_at: entry.source_updated_at.clone(),
+            reason: reason.to_string(),
+        });
+    }
+
+    if json {
+        let serialized = serde_json::to_string_pretty(&reports)?;
+        println!("{}", serialized);
+    } else {
+        println!("{:<15} {:<30} {:<30} {}", "STATUS", "SOURCE", "TARGET", "REASON");
+        for r in &reports {
+            println!(
+                "{:<15} {:<30} {:<30} {}",
+                r.status.to_string(),
+                format!("{}:{}", r.source_cli, r.source_id),
+                format!("{}:{}", r.target_cli, r.target_session_id),
+                r.reason
+            );
+        }
+        println!(
+            "\n{} live, {} target-gone, {} source-updated, {} source-gone",
+            live_count, target_gone_count, source_updated_count, source_gone_count
+        );
+    }
+
+    if gc {
+        let removed_count = keys_to_remove.len();
+        for k in keys_to_remove {
+            index.entries.remove(&k);
+        }
+        if json {
+            eprintln!("Removed {} source-gone entries.", removed_count);
+        } else {
+            println!("Removed {} source-gone entries.", removed_count);
+        }
+    }
+
+    Ok(reports)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -210,5 +351,130 @@ mod tests {
         assert!(entry_is_live(&live));
         assert!(!entry_is_live(&dead));
         assert!(entry_is_live(&db));
+    }
+
+    #[test]
+    fn test_doctor_classification_and_gc() {
+        use crate::interchange::sessions::SessionInfo;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let target_file_real = tmp.path().join("real_target.jsonl");
+        std::fs::write(&target_file_real, b"x").unwrap();
+
+        let mut idx = CrossloadIndex::default();
+
+        // 1. Live entry (file-backed target exists, source exists, updated_at matches)
+        idx.record(
+            "claude",
+            "source-live",
+            "pi",
+            "target-live".into(),
+            target_file_real.to_string_lossy().to_string(),
+            Some("2026-05-27T12:00:00Z".into()),
+        );
+
+        // 2. Target-gone entry (file-backed target missing, source exists, updated_at matches)
+        idx.record(
+            "claude",
+            "source-tgone",
+            "pi",
+            "target-tgone".into(),
+            "/nonexistent/target.jsonl".into(),
+            Some("2026-05-27T12:00:00Z".into()),
+        );
+
+        // 3. Source-updated entry (file-backed target exists, source exists, but updated_at drifted)
+        idx.record(
+            "claude",
+            "source-supd",
+            "pi",
+            "target-supd".into(),
+            target_file_real.to_string_lossy().to_string(),
+            Some("2026-05-27T11:00:00Z".into()), // older timestamp
+        );
+
+        // 4. Source-gone entry (source does not exist)
+        idx.record(
+            "claude",
+            "source-sgone",
+            "pi",
+            "target-sgone".into(),
+            target_file_real.to_string_lossy().to_string(),
+            Some("2026-05-27T12:00:00Z".into()),
+        );
+
+        // Mock resolver
+        let mock_sessions = [
+            SessionInfo {
+                cli: "claude".into(),
+                id: "source-live".into(),
+                name: None,
+                title: None,
+                directory: "/tmp".into(),
+                path: std::path::PathBuf::from("/tmp/nope1.jsonl"),
+                updated_at: "2026-05-27T12:00:00Z".into(),
+                message_count: None,
+            },
+            SessionInfo {
+                cli: "claude".into(),
+                id: "source-tgone".into(),
+                name: None,
+                title: None,
+                directory: "/tmp".into(),
+                path: std::path::PathBuf::from("/tmp/nope2.jsonl"),
+                updated_at: "2026-05-27T12:00:00Z".into(),
+                message_count: None,
+            },
+            SessionInfo {
+                cli: "claude".into(),
+                id: "source-supd".into(),
+                name: None,
+                title: None,
+                directory: "/tmp".into(),
+                path: std::path::PathBuf::from("/tmp/nope3.jsonl"),
+                updated_at: "2026-05-27T12:00:00Z".into(), // source has newer timestamp
+                message_count: None,
+            },
+        ];
+
+        let find_src = |cli: &str, id: &str| {
+            mock_sessions.iter().find(|s| s.cli == cli && s.id == id).cloned()
+        };
+
+        // Run doctor report (without gc)
+        let mut idx_clone = idx.clone();
+        let reports = run_doctor_impl(false, false, &mut idx_clone, find_src).unwrap();
+
+        assert_eq!(reports.len(), 4);
+
+        let r_live = reports.iter().find(|r| r.source_id == "source-live").unwrap();
+        assert_eq!(r_live.status, DoctorStatus::Live);
+        assert_eq!(r_live.reason, "");
+
+        let r_tgone = reports.iter().find(|r| r.source_id == "source-tgone").unwrap();
+        assert_eq!(r_tgone.status, DoctorStatus::TargetGone);
+        assert_eq!(r_tgone.reason, "target file missing");
+
+        let r_supd = reports.iter().find(|r| r.source_id == "source-supd").unwrap();
+        assert_eq!(r_supd.status, DoctorStatus::SourceUpdated);
+        assert_eq!(r_supd.reason, "source session modified");
+
+        let r_sgone = reports.iter().find(|r| r.source_id == "source-sgone").unwrap();
+        assert_eq!(r_sgone.status, DoctorStatus::SourceGone);
+        assert_eq!(r_sgone.reason, "source session not found");
+
+        // Confirm no entries were removed during dry run
+        assert_eq!(idx_clone.entries.len(), 4);
+
+        // Run doctor report (with gc)
+        let reports_gc = run_doctor_impl(false, true, &mut idx, find_src).unwrap();
+        assert_eq!(reports_gc.len(), 4);
+
+        // Confirm only source-gone entries were removed (1 entry removed, 3 left)
+        assert_eq!(idx.entries.len(), 3);
+        assert!(idx.lookup("claude", "source-live", "pi").is_some());
+        assert!(idx.lookup("claude", "source-tgone", "pi").is_some());
+        assert!(idx.lookup("claude", "source-supd", "pi").is_some());
+        assert!(idx.lookup("claude", "source-sgone", "pi").is_none());
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -229,6 +229,10 @@ async fn run_sessions_action_async(
         crate::cli::SessionsAction::Name { target, title } => {
             set_session_title(&target, title.as_deref(), json).await
         }
+        crate::cli::SessionsAction::Doctor { gc } => {
+            crate::interchange::crossload_index::run_doctor(json, gc)?;
+            Ok(())
+        }
     }
 }
 

--- a/tests/doctor_integration_tests.rs
+++ b/tests/doctor_integration_tests.rs
@@ -1,0 +1,63 @@
+use std::process::Command;
+
+#[test]
+fn test_unleash_sessions_doctor_cli() {
+    let bin_path = env!("CARGO_BIN_EXE_unleash");
+    let tmp = tempfile::tempdir().unwrap();
+    let unleash_dir = tmp.path().join("unleash");
+    std::fs::create_dir_all(&unleash_dir).unwrap();
+
+    // Create a mock crossload-index.json. Since all sources will be gone,
+    // they should be classified as source-gone.
+    let index_data = serde_json::json!({
+        "entries": {
+            "claude:nonexistent-source->pi": {
+                "target_session_id": "target-123",
+                "target_path": "/tmp/nonexistent-target.jsonl",
+                "source_updated_at": "2026-05-27T12:00:00Z"
+            }
+        }
+    });
+    std::fs::write(
+        unleash_dir.join("crossload-index.json"),
+        serde_json::to_string_pretty(&index_data).unwrap(),
+    )
+    .unwrap();
+
+    // Run doctor command without gc (should report source-gone)
+    let output = Command::new(bin_path)
+        .args(["sessions", "doctor", "--json"])
+        .env("XDG_DATA_HOME", tmp.path())
+        .output()
+        .expect("failed to execute unleash");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let reports: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert!(reports.is_array());
+    let arr = reports.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["status"], "source-gone");
+    assert_eq!(arr[0]["source_id"], "nonexistent-source");
+
+    // Index file should still have the entry
+    let content = std::fs::read_to_string(unleash_dir.join("crossload-index.json")).unwrap();
+    assert!(content.contains("nonexistent-source"));
+
+    // Run doctor command with gc (should remove the entry)
+    let output_gc = Command::new(bin_path)
+        .args(["sessions", "doctor", "--gc", "--json"])
+        .env("XDG_DATA_HOME", tmp.path())
+        .output()
+        .expect("failed to execute unleash");
+
+    assert!(output_gc.status.success());
+    let stderr = String::from_utf8_lossy(&output_gc.stderr);
+    assert!(stderr.contains("Removed 1 source-gone entries."));
+
+    // Index file should now have 0 entries
+    let content_after = std::fs::read_to_string(unleash_dir.join("crossload-index.json")).unwrap();
+    let reloaded: serde_json::Value = serde_json::from_str(&content_after).unwrap();
+    let entries = reloaded["entries"].as_object().unwrap();
+    assert!(entries.is_empty());
+}


### PR DESCRIPTION
Implements the `unleash sessions doctor [--gc]` subcommand to diagnose and optionally garbage collect stale or dead entries in `crossload-index.json`. Built with pure dependency-injected unit tests to assert classification and GC logic.