### PR TITLE
fix(sessions): clean up reindex lock file when child exits

### DIFF
--- a/src/interchange/sessions.rs
+++ b/src/interchange/sessions.rs
@@ -97,8 +97,12 @@ fn trigger_background_reindex(db_path: &std::path::Path) {
         if let Some(parent) = lock_path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
+        // UNLEASH_REINDEX_LOCK_PATH lets the child clean up its own lock file on
+        // exit (see run_sessions_action_async). Without it, the stale lock persists
+        // until the next reindex check finds the PID is dead via kill(pid, 0).
         if let Ok(child) = std::process::Command::new(&exe)
             .args(["sessions", "reindex", "--json"])
+            .env("UNLEASH_REINDEX_LOCK_PATH", &lock_path)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
@@ -834,6 +838,68 @@ mod tests {
         assert!(
             nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_ok(),
             "the spawned process PID should be active"
+        );
+    }
+
+    #[test]
+    fn test_trigger_background_reindex_sets_lock_path_env_var() {
+        // The child process needs UNLEASH_REINDEX_LOCK_PATH to clean up the lock
+        // file on exit. We stub the child with a tiny shell script that asserts
+        // the env var is set and points at the expected file. If the env var is
+        // missing or wrong, the script exits non-zero and we can detect it via
+        // the absence of the marker file it writes.
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("search-index.db");
+        let unleash_dir = tmp.path();
+        let lock_path = unleash_dir.join("search-index.lock");
+        let marker = tmp.path().join("env-was-set.marker");
+
+        // Wait at the end of script body so trigger_background_reindex writes
+        // the lock file before we check the marker contents.
+        let script_path = tmp.path().join("fake-unleash.sh");
+        std::fs::write(
+            &script_path,
+            format!(
+                "#!/bin/sh\necho \"$UNLEASH_REINDEX_LOCK_PATH\" > {:?}\n",
+                marker
+            ),
+        )
+        .unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        let mut perm = std::fs::metadata(&script_path).unwrap().permissions();
+        perm.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perm).unwrap();
+
+        let saved_reindex_binary = std::env::var_os("UNLEASH_REINDEX_BINARY");
+        // SAFETY: env mutation in tests; restored below.
+        unsafe {
+            std::env::set_var("UNLEASH_REINDEX_BINARY", &script_path);
+        }
+
+        trigger_background_reindex(&db_path);
+
+        // Restore env before assertions
+        match saved_reindex_binary {
+            Some(v) => unsafe { std::env::set_var("UNLEASH_REINDEX_BINARY", v) },
+            None => unsafe { std::env::remove_var("UNLEASH_REINDEX_BINARY") },
+        }
+
+        // Give the spawned child a moment to flush its echo. The script is
+        // trivial; even on slow runners it completes in milliseconds.
+        for _ in 0..20 {
+            if marker.exists() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        assert!(marker.exists(), "fake child should have written the marker");
+        let content = std::fs::read_to_string(&marker).unwrap();
+        let received_path = content.trim();
+        assert_eq!(
+            received_path,
+            lock_path.to_string_lossy(),
+            "child must receive UNLEASH_REINDEX_LOCK_PATH pointing at the parent's lock file"
         );
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -197,6 +197,16 @@ pub fn run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     rt.block_on(run_async(args))
 }
 
+/// RAII guard that removes a lock file when dropped. Used by the reindex
+/// action when it's invoked as a background child (lock path arrives via the
+/// UNLEASH_REINDEX_LOCK_PATH env var set by trigger_background_reindex).
+struct ReindexLockGuard(std::ffi::OsString);
+impl Drop for ReindexLockGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(std::path::Path::new(&self.0));
+    }
+}
+
 /// Synchronous entry point for `unleash sessions reindex` / `unleash sessions name`.
 /// Same tokio-containment pattern as `run()`.
 pub fn run_sessions_action(
@@ -215,6 +225,12 @@ async fn run_sessions_action_async(
 ) -> Result<(), Box<dyn std::error::Error>> {
     match action {
         crate::cli::SessionsAction::Reindex => {
+            // When spawned in the background by trigger_background_reindex, the
+            // parent passes the lock-file path so we can remove it on completion
+            // (success, error, or panic). Without this, the stale lock persists
+            // until the next reindex check notices the PID is dead.
+            let _lock_guard = std::env::var_os("UNLEASH_REINDEX_LOCK_PATH")
+                .map(ReindexLockGuard);
             // Re-use the full search pipeline (probe → schema → discover → upsert
             // → embed → name) with no query and no TUI. Setting reindex=true
             // wipes embeddings + generated titles so everything regenerates.
@@ -2135,5 +2151,28 @@ mod tests {
         let out = truncate("αβγδε ζηθικ", 6);
         assert_eq!(out.chars().count(), 6);
         assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn reindex_lock_guard_removes_file_on_drop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock_path = tmp.path().join("search-index.lock");
+        std::fs::write(&lock_path, "12345").unwrap();
+        assert!(lock_path.exists());
+        {
+            let _g = ReindexLockGuard(lock_path.as_os_str().to_os_string());
+        }
+        assert!(!lock_path.exists(), "guard should remove the lock file on drop");
+    }
+
+    #[test]
+    fn reindex_lock_guard_drop_is_silent_when_file_missing() {
+        // If something else already removed the lock (e.g. a concurrent reindex
+        // attempt cleaned up), Drop must not panic — std::fs::remove_file returns
+        // an error we deliberately ignore.
+        let tmp = tempfile::tempdir().unwrap();
+        let lock_path = tmp.path().join("does-not-exist.lock");
+        let _g = ReindexLockGuard(lock_path.as_os_str().to_os_string());
+        // dropping at end of scope — no panic expected
     }
 }


### PR DESCRIPTION
## Summary

- Background reindexer left its `search-index.lock` file behind after completing — functionally harmless (next reindex check sees stale PID via `kill(pid, 0)` and proceeds) but persists on disk indefinitely.
- Pass lock path to child via `UNLEASH_REINDEX_LOCK_PATH` env var so the child's `Reindex` action installs a `Drop` guard that removes the file on exit (success, error, or panic).
- Followup parked from #229 / #231 sweep.

## Test plan

- [x] `cargo test --lib reindex_lock_guard` — 2 new unit tests for the guard
- [x] `cargo test --lib trigger_background_reindex` — 1 new end-to-end test that the env var is set on the spawned child
- [x] Full `cargo test --lib` — 535 passing, no regressions
- [x] `cargo fmt --check` on changed files — clean
- [x] `cargo clippy` on changed files — clean (pre-existing warnings in other files unrelated)