### PR TITLE
chore: clear all lib + test clippy warnings

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -75,6 +75,9 @@ impl AgentType {
         }
     }
 
+    // Public API since 0.1.x; signature returns Option, not Result as
+    // std::str::FromStr requires. Renaming would break callers.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "claude" | "claude-code" => Some(AgentType::Claude),

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -844,7 +844,7 @@ mod tests {
         )
         .unwrap();
 
-        mgr.sync_plugin_hooks(&[plugin_dir.clone()]).unwrap();
+        mgr.sync_plugin_hooks(std::slice::from_ref(&plugin_dir)).unwrap();
 
         let settings = mgr.read_settings().unwrap();
 
@@ -904,7 +904,7 @@ mod tests {
         .unwrap();
 
         // Sync twice
-        mgr.sync_plugin_hooks(&[plugin_dir.clone()]).unwrap();
+        mgr.sync_plugin_hooks(std::slice::from_ref(&plugin_dir)).unwrap();
         mgr.sync_plugin_hooks(&[plugin_dir]).unwrap();
 
         let settings = mgr.read_settings().unwrap();
@@ -935,7 +935,7 @@ mod tests {
             r#"{"hooks":{"PreCompact":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/hook.sh"}]}]}}"#,
         )
         .unwrap();
-        mgr.sync_plugin_hooks(&[new_dir.clone()]).unwrap();
+        mgr.sync_plugin_hooks(std::slice::from_ref(&new_dir)).unwrap();
 
         let settings = mgr.read_settings().unwrap();
         let hooks = settings["hooks"]["PreCompact"].as_array().unwrap();
@@ -1039,7 +1039,7 @@ mod tests {
         let plugin_dir = root.join("plugins/bundled").join(name);
         fs::create_dir_all(plugin_dir.join("hooks")).unwrap();
         fs::write(plugin_dir.join("hooks/hooks.json"), hooks_json).unwrap();
-        mgr.sync_plugin_hooks(&[plugin_dir.clone()]).unwrap();
+        mgr.sync_plugin_hooks(std::slice::from_ref(&plugin_dir)).unwrap();
         plugin_dir
     }
 
@@ -1097,8 +1097,9 @@ mod tests {
         );
 
         let before = fs::read_to_string(&mgr.installation.settings_path).unwrap();
+        let plugins = [plugin_a.clone()];
         let changed = mgr
-            .prune_hooks_for_disabled_plugins(&[plugin_a.clone()], &[plugin_a])
+            .prune_hooks_for_disabled_plugins(&plugins, &[plugin_a])
             .unwrap();
         let after = fs::read_to_string(&mgr.installation.settings_path).unwrap();
 

--- a/src/interchange/claude.rs
+++ b/src/interchange/claude.rs
@@ -118,14 +118,14 @@ pub fn from_hub(records: &[HubRecord]) -> Result<Vec<Value>, ConvertError> {
     }
 
     // Attach the session passthrough to the first emitted line.
-    if let (Some(sess), Some(first)) = (session_passthrough, lines.first_mut()) {
-        if let Value::Object(ref mut obj) = first {
-            let entry = obj
-                .entry("_ucf_hub".to_string())
-                .or_insert_with(|| Value::Object(serde_json::Map::new()));
-            if let Value::Object(ref mut inner) = entry {
-                inner.insert("session".to_string(), sess);
-            }
+    if let (Some(sess), Some(Value::Object(ref mut obj))) =
+        (session_passthrough, lines.first_mut())
+    {
+        let entry = obj
+            .entry("_ucf_hub".to_string())
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+        if let Value::Object(ref mut inner) = entry {
+            inner.insert("session".to_string(), sess);
         }
     }
 

--- a/src/interchange/codex.rs
+++ b/src/interchange/codex.rs
@@ -844,14 +844,12 @@ fn hub_event_to_codex(evt: &HubEvent) -> Result<Value, ConvertError> {
     // Check if we stored the original outer type
     let outer_type = cc.get("_outer_type").and_then(|v| v.as_str()).unwrap_or("");
 
+    // turn_context is the only Codex outer type that's not event_msg; everything
+    // else (token_count, codex_*, plus the catch-all) lands as event_msg.
     let codex_type = if !outer_type.is_empty() {
         outer_type.to_string()
     } else if evt.event_type == "turn_context" {
         "turn_context".to_string()
-    } else if evt.event_type == "token_count" {
-        "event_msg".to_string()
-    } else if evt.event_type.starts_with("codex_") {
-        "event_msg".to_string()
     } else {
         "event_msg".to_string()
     };

--- a/src/interchange/crossload_index.rs
+++ b/src/interchange/crossload_index.rs
@@ -221,7 +221,7 @@ where
         let serialized = serde_json::to_string_pretty(&reports)?;
         println!("{}", serialized);
     } else {
-        println!("{:<15} {:<30} {:<30} {}", "STATUS", "SOURCE", "TARGET", "REASON");
+        println!("{:<15} {:<30} {:<30} REASON", "STATUS", "SOURCE", "TARGET");
         for r in &reports {
             println!(
                 "{:<15} {:<30} {:<30} {}",

--- a/src/interchange/gemini.rs
+++ b/src/interchange/gemini.rs
@@ -1103,7 +1103,7 @@ mod tests {
             "timestamp": "2026-03-29T12:00:00.000Z"
         });
 
-        let data = gemini_session_json(&[msg.clone()]);
+        let data = gemini_session_json(std::slice::from_ref(&msg));
         let hub = to_hub(&data).unwrap();
         let back = from_hub(&hub).unwrap();
         let back_messages = back.get("messages").unwrap().as_array().unwrap();
@@ -1359,7 +1359,7 @@ mod tests {
             "timestamp": "2026-03-29T12:00:00.000Z"
         });
 
-        let data = gemini_session_json(&[msg.clone()]);
+        let data = gemini_session_json(std::slice::from_ref(&msg));
         let hub = to_hub(&data).unwrap();
 
         if let HubRecord::Message(ref hub_msg) = hub[1] {
@@ -1368,12 +1368,11 @@ mod tests {
             // Should have the original message stashed for lossless round-trip
             let orig = gc.get("_original_message").unwrap();
             assert_eq!(orig.get("id").unwrap().as_str().unwrap(), "msg-5");
-            assert_eq!(
+            assert!(
                 orig.get("renderOutputAsMarkdown")
                     .unwrap()
                     .as_bool()
-                    .unwrap(),
-                true
+                    .unwrap()
             );
         }
     }

--- a/src/interchange/hermes.rs
+++ b/src/interchange/hermes.rs
@@ -247,12 +247,12 @@ pub fn to_hub(json: &str) -> Result<Vec<HubRecord>, ConvertError> {
                     });
 
                     // Collect matching tool result from following tool-role msgs
-                    for j in (i + 1)..messages.len() {
-                        if messages[j]["role"].as_str() != Some("tool") {
+                    for next in messages.iter().skip(i + 1) {
+                        if next["role"].as_str() != Some("tool") {
                             break;
                         }
-                        if messages[j]["tool_call_id"].as_str() == Some(&call_id) {
-                            let res = messages[j]["content"].as_str().unwrap_or("").to_string();
+                        if next["tool_call_id"].as_str() == Some(&call_id) {
+                            let res = next["content"].as_str().unwrap_or("").to_string();
                             result_blocks.push(ContentBlock::ToolResult {
                                 tool_use_id: call_id.clone(),
                                 content: vec![ContentBlock::Text { text: res }],

--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -153,7 +153,7 @@ fn estimate_tokens(records: &[HubRecord]) -> usize {
         .iter()
         .filter_map(|r| {
             if let HubRecord::Message(m) = r {
-                Some(m.content.iter().map(|b| estimate_block_chars(b)).sum::<usize>())
+                Some(m.content.iter().map(estimate_block_chars).sum::<usize>())
             } else {
                 None
             }
@@ -170,7 +170,7 @@ fn estimate_block_chars(block: &crate::interchange::hub::ContentBlock) -> usize 
             name.len() + input.to_string().len()
         }
         ContentBlock::ToolResult { content, .. } => {
-            content.iter().map(|b| estimate_block_chars(b)).sum()
+            content.iter().map(estimate_block_chars).sum()
         }
         ContentBlock::Thinking { text, .. } => text.len(),
         ContentBlock::Image { .. } => 256,

--- a/src/interchange/lossless_tests.rs
+++ b/src/interchange/lossless_tests.rs
@@ -257,7 +257,8 @@ mod tests {
     #[test]
     #[ignore = "diagnostic — run manually"]
     fn diagnostic_all_pairs() {
-        let clis: Vec<(&str, &dyn Fn(&[HubRecord]) -> Vec<HubRecord>)> = vec![
+        type RoundTrip = dyn Fn(&[HubRecord]) -> Vec<HubRecord>;
+        let clis: Vec<(&str, &RoundTrip)> = vec![
             ("claude", &via_claude),
             ("codex", &via_codex),
             ("gemini", &via_gemini),

--- a/src/interchange/opencode.rs
+++ b/src/interchange/opencode.rs
@@ -504,8 +504,8 @@ fn collect_message_parts(
     let mut collected = Vec::new();
 
     // If parts have _msg_idx (injected by from_hub for reliable round-tripping), use it
-    if *idx < total {
-        if all_parts[*idx].get("_msg_idx").is_some() {
+    if *idx < total
+        && all_parts[*idx].get("_msg_idx").is_some() {
             while *idx < total {
                 let part = &all_parts[*idx];
                 if part.get("_msg_idx").and_then(|v| v.as_u64()) == Some(_msg_i as u64) {
@@ -521,7 +521,6 @@ fn collect_message_parts(
             }
             return collected;
         }
-    }
 
     if role == "user" {
         // User messages typically have one text part, maybe tool results

--- a/src/interchange/sessions.rs
+++ b/src/interchange/sessions.rs
@@ -70,11 +70,12 @@ fn trigger_background_reindex(db_path: &std::path::Path) {
     let already_running = if lock_path.exists() {
         if let Ok(content) = std::fs::read_to_string(&lock_path) {
             if let Ok(pid) = content.trim().parse::<i32>() {
-                match nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None) {
-                    Ok(_) => true,
-                    Err(nix::errno::Errno::EPERM) => true,
-                    _ => false,
-                }
+                // EPERM means the PID exists but is owned by another user — still
+                // a live process for our purposes.
+                matches!(
+                    nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None),
+                    Ok(_) | Err(nix::errno::Errno::EPERM)
+                )
             } else {
                 false
             }
@@ -153,7 +154,9 @@ fn overlay_search_index_names(sessions: &mut [SessionInfo]) {
     };
 
     let mut needs_reindex = !db_path.exists();
-    let mut overlay: std::collections::HashMap<(String, String), (Option<String>, Option<String>, i64)> =
+    // (cli, source_id) → (generated_title, native_title, db_mtime_ns)
+    type OverlayRow = (Option<String>, Option<String>, i64);
+    let mut overlay: std::collections::HashMap<(String, String), OverlayRow> =
         std::collections::HashMap::new();
 
     if db_path.exists() {
@@ -710,6 +713,153 @@ fn format_epoch_ms(ms: u64) -> String {
     format!("{year:04}-{month:02}-{day:02}T00:00:00Z")
 }
 
+// === Pi discovery ===
+
+fn discover_pi() -> Vec<SessionInfo> {
+    let mut sessions = Vec::new();
+    let pi_dir = match dirs::home_dir() {
+        Some(h) => h.join(".pi").join("agent").join("sessions"),
+        None => return sessions,
+    };
+
+    if !pi_dir.exists() {
+        return sessions;
+    }
+
+    let Ok(project_dirs) = std::fs::read_dir(&pi_dir) else {
+        return sessions;
+    };
+
+    for project in project_dirs.flatten() {
+        if !project.file_type().is_ok_and(|ft| ft.is_dir()) {
+            continue;
+        }
+        let project_path = project.path();
+        // Pi encodes the project dir as --<path-with-slashes-as-hyphens>--
+        let raw = project.file_name().to_string_lossy().to_string();
+        let decoded = raw
+            .strip_prefix("--")
+            .and_then(|s| s.strip_suffix("--"))
+            .map(|s| format!("/{}", s.replace('-', "/")))
+            .unwrap_or(raw.clone());
+
+        let Ok(files) = std::fs::read_dir(&project_path) else {
+            continue;
+        };
+
+        for file in files.flatten() {
+            let path = file.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+
+            let session_id = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string();
+
+            let updated_at = file
+                .metadata()
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .map(|t| {
+                    let duration = t.duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
+                    format_epoch_ms(duration.as_millis() as u64)
+                })
+                .unwrap_or_default();
+
+            sessions.push(SessionInfo {
+                cli: "pi".to_string(),
+                id: session_id,
+                name: None,
+                title: None,
+                directory: decoded.clone(),
+                path,
+                updated_at,
+                message_count: None,
+            });
+        }
+    }
+
+    sessions
+}
+
+// === UCF (Native Hub) discovery ===
+
+fn discover_ucf() -> Vec<SessionInfo> {
+    let mut sessions = Vec::new();
+    let ucf_dir = match dirs::data_dir() {
+        Some(d) => d.join("unleash").join("sessions"),
+        None => return sessions,
+    };
+
+    if !ucf_dir.exists() {
+        return sessions;
+    }
+
+    let Ok(entries) = std::fs::read_dir(&ucf_dir) else {
+        return sessions;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+
+        let file_name = path.file_name().unwrap_or_default().to_string_lossy();
+        if !file_name.ends_with(".ucf.jsonl") {
+            continue;
+        }
+
+        let id = file_name
+            .strip_suffix(".ucf.jsonl")
+            .unwrap_or(&file_name)
+            .to_string();
+
+        let Ok(file) = std::fs::File::open(&path) else {
+            continue;
+        };
+
+        use std::io::BufRead;
+        let reader = std::io::BufReader::new(file);
+        let mut lines = reader.lines();
+
+        if let Some(Ok(first_line)) = lines.next() {
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(&first_line) {
+                if val.get("type").and_then(|t| t.as_str()) == Some("session") {
+                    let updated_at = val
+                        .get("updated_at")
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("1970-01-01T00:00:00.000Z")
+                        .to_string();
+                    let title = val
+                        .get("title")
+                        .and_then(|t| t.as_str())
+                        .map(|s| s.to_string());
+
+                    // remaining lines after header (messages + events)
+                    let message_count = lines.filter(|l| l.is_ok()).count();
+
+                    sessions.push(SessionInfo {
+                        cli: "ucf".to_string(),
+                        id: id.clone(),
+                        name: Some(id),
+                        title,
+                        directory: ucf_dir.to_string_lossy().to_string(),
+                        path,
+                        updated_at,
+                        message_count: Some(message_count),
+                    });
+                }
+            }
+        }
+    }
+
+    sessions
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -935,7 +1085,7 @@ mod tests {
         let ts = format_epoch_ms(31_104_000_000);
         let month: u32 = ts[5..7].parse().unwrap();
         assert!(
-            month >= 1 && month <= 12,
+            (1..=12).contains(&month),
             "month={} out of range in '{}'",
             month,
             ts
@@ -945,157 +1095,10 @@ mod tests {
         let ts2 = format_epoch_ms(1_735_603_200_000); // ~2024-12-31
         let month2: u32 = ts2[5..7].parse().unwrap();
         assert!(
-            month2 >= 1 && month2 <= 12,
+            (1..=12).contains(&month2),
             "month={} out of range in '{}'",
             month2,
             ts2
         );
     }
-}
-
-// === Pi discovery ===
-
-fn discover_pi() -> Vec<SessionInfo> {
-    let mut sessions = Vec::new();
-    let pi_dir = match dirs::home_dir() {
-        Some(h) => h.join(".pi").join("agent").join("sessions"),
-        None => return sessions,
-    };
-
-    if !pi_dir.exists() {
-        return sessions;
-    }
-
-    let Ok(project_dirs) = std::fs::read_dir(&pi_dir) else {
-        return sessions;
-    };
-
-    for project in project_dirs.flatten() {
-        if !project.file_type().is_ok_and(|ft| ft.is_dir()) {
-            continue;
-        }
-        let project_path = project.path();
-        // Pi encodes the project dir as --<path-with-slashes-as-hyphens>--
-        let raw = project.file_name().to_string_lossy().to_string();
-        let decoded = raw
-            .strip_prefix("--")
-            .and_then(|s| s.strip_suffix("--"))
-            .map(|s| format!("/{}", s.replace('-', "/")))
-            .unwrap_or(raw.clone());
-
-        let Ok(files) = std::fs::read_dir(&project_path) else {
-            continue;
-        };
-
-        for file in files.flatten() {
-            let path = file.path();
-            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-                continue;
-            }
-
-            let session_id = path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("")
-                .to_string();
-
-            let updated_at = file
-                .metadata()
-                .ok()
-                .and_then(|m| m.modified().ok())
-                .map(|t| {
-                    let duration = t.duration_since(std::time::UNIX_EPOCH).unwrap_or_default();
-                    format_epoch_ms(duration.as_millis() as u64)
-                })
-                .unwrap_or_default();
-
-            sessions.push(SessionInfo {
-                cli: "pi".to_string(),
-                id: session_id,
-                name: None,
-                title: None,
-                directory: decoded.clone(),
-                path,
-                updated_at,
-                message_count: None,
-            });
-        }
-    }
-
-    sessions
-}
-
-// === UCF (Native Hub) discovery ===
-
-fn discover_ucf() -> Vec<SessionInfo> {
-    let mut sessions = Vec::new();
-    let ucf_dir = match dirs::data_dir() {
-        Some(d) => d.join("unleash").join("sessions"),
-        None => return sessions,
-    };
-
-    if !ucf_dir.exists() {
-        return sessions;
-    }
-
-    let Ok(entries) = std::fs::read_dir(&ucf_dir) else {
-        return sessions;
-    };
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
-            continue;
-        }
-
-        let file_name = path.file_name().unwrap_or_default().to_string_lossy();
-        if !file_name.ends_with(".ucf.jsonl") {
-            continue;
-        }
-
-        let id = file_name
-            .strip_suffix(".ucf.jsonl")
-            .unwrap_or(&file_name)
-            .to_string();
-
-        let Ok(file) = std::fs::File::open(&path) else {
-            continue;
-        };
-
-        use std::io::BufRead;
-        let reader = std::io::BufReader::new(file);
-        let mut lines = reader.lines();
-
-        if let Some(Ok(first_line)) = lines.next() {
-            if let Ok(val) = serde_json::from_str::<serde_json::Value>(&first_line) {
-                if val.get("type").and_then(|t| t.as_str()) == Some("session") {
-                    let updated_at = val
-                        .get("updated_at")
-                        .and_then(|t| t.as_str())
-                        .unwrap_or("1970-01-01T00:00:00.000Z")
-                        .to_string();
-                    let title = val
-                        .get("title")
-                        .and_then(|t| t.as_str())
-                        .map(|s| s.to_string());
-
-                    // remaining lines after header (messages + events)
-                    let message_count = lines.filter(|l| l.is_ok()).count();
-
-                    sessions.push(SessionInfo {
-                        cli: "ucf".to_string(),
-                        id: id.clone(),
-                        name: Some(id),
-                        title,
-                        directory: ucf_dir.to_string_lossy().to_string(),
-                        path,
-                        updated_at,
-                        message_count: Some(message_count),
-                    });
-                }
-            }
-        }
-    }
-
-    sessions
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1177,6 +1177,129 @@ pub fn run() -> io::Result<()> {
     }
 }
 
+fn handle_config(action: ConfigAction) -> io::Result<()> {
+    match action {
+        ConfigAction::IsPluginEnabled { name } => {
+            let manager = ProfileManager::new()?;
+            let path = manager.config_dir().join("config.toml");
+            // No config file = first run before TUI write = treat as all enabled.
+            if !path.exists() {
+                return Ok(());
+            }
+            let cfg = manager.load_app_config()?;
+            // Empty enabled_plugins = "all enabled" (backwards compat).
+            if cfg.enabled_plugins.is_empty() || cfg.enabled_plugins.contains(&name) {
+                Ok(())
+            } else {
+                std::process::exit(1);
+            }
+        }
+    }
+}
+
+fn setup_ucf_session(ucf_name: &str, target_cli: &str) -> io::Result<(String, Vec<String>)> {
+    let ucf_path = dirs::data_dir()
+        .unwrap_or_else(|| {
+            std::path::PathBuf::from(env::var("HOME").unwrap_or_default()).join(".local/share")
+        })
+        .join("unleash")
+        .join("sessions")
+        .join(format!("{}.ucf.jsonl", ucf_name));
+
+    let ucf_query = format!("ucf:{}", ucf_name);
+
+    if !ucf_path.exists() {
+        eprintln!("\x1b[34minfo:\x1b[0m Starting new native UCF session: {ucf_name}");
+        std::fs::create_dir_all(ucf_path.parent().unwrap())?;
+        let now_iso = std::process::Command::new("date")
+            .arg("-u")
+            .arg("+%Y-%m-%dT%H:%M:%SZ")
+            .output()
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
+
+        let header = interchange::hub::SessionHeader {
+            ucf_version: interchange::hub::UCF_VERSION.to_string(),
+            session_id: ucf_name.to_string(),
+            created_at: now_iso.clone(),
+            updated_at: now_iso.clone(),
+            source_cli: "ucf".to_string(),
+            source_version: "1.0.0".to_string(),
+            project: None,
+            model: None,
+            title: Some(ucf_name.to_string()),
+            slug: Some(ucf_name.to_string()),
+            parent_session_id: None,
+            extensions: serde_json::json!({}),
+        };
+        let msg = interchange::hub::HubMessage {
+            id: format!("init-{ucf_name}"),
+            api_message_id: None,
+            parent_id: None,
+            timestamp: now_iso.clone(),
+            completed_at: Some(now_iso),
+            role: "user".to_string(),
+            content: vec![interchange::hub::ContentBlock::Text {
+                text: "[UCF Session Initialized]".to_string(),
+            }],
+            metadata: Default::default(),
+            extensions: serde_json::json!({}),
+        };
+
+        let record_session = interchange::hub::HubRecord::Session(header);
+        let record_msg = interchange::hub::HubRecord::Message(msg);
+        let data = serde_json::to_string(&record_session).unwrap()
+            + "\n"
+            + &serde_json::to_string(&record_msg).unwrap()
+            + "\n";
+        std::fs::write(&ucf_path, data)?;
+    } else {
+        eprintln!("\x1b[34minfo:\x1b[0m Loading native UCF session: {ucf_name} into {target_cli}");
+    }
+
+    match interchange::inject::inject_session(&ucf_query, target_cli) {
+        Ok(result) => {
+            eprintln!("\x1b[32m✓\x1b[0m {}", result.message);
+            Ok((result.session_id, result.resume_args))
+        }
+        Err(e) => {
+            eprintln!("\x1b[31m✗\x1b[0m UCF initialization failed: {e}");
+            Err(io::Error::other(e.to_string()))
+        }
+    }
+}
+
+fn sync_ucf_session(ucf_name: &str, target_cli: &str, session_id: &str) {
+    let query = format!("{}:{}", target_cli, session_id);
+    if let Some(session) = interchange::sessions::find_session(&query) {
+        if let Ok(records) = interchange::inject::source_to_hub(&session) {
+            let ucf_path = dirs::data_dir()
+                .unwrap_or_else(|| {
+                    std::path::PathBuf::from(env::var("HOME").unwrap_or_default())
+                        .join(".local/share")
+                })
+                .join("unleash")
+                .join("sessions")
+                .join(format!("{}.ucf.jsonl", ucf_name));
+
+            let mut out = String::new();
+            for r in records {
+                out.push_str(&serde_json::to_string(&r).unwrap());
+                out.push('\n');
+            }
+            if let Err(e) = std::fs::write(&ucf_path, out) {
+                eprintln!(
+                    "Warning: Failed to save UCF session back to {}: {}",
+                    ucf_path.display(),
+                    e
+                );
+            } else {
+                eprintln!("\x1b[32m✓\x1b[0m Saved native UCF session: {}", ucf_name);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1327,128 +1450,5 @@ mod tests {
         assert!(!is_known_subcommand("invalid-subcommand"));
         assert!(!is_known_subcommand(""));
         assert!(!is_known_subcommand("VERSION")); // case sensitive
-    }
-}
-
-fn handle_config(action: ConfigAction) -> io::Result<()> {
-    match action {
-        ConfigAction::IsPluginEnabled { name } => {
-            let manager = ProfileManager::new()?;
-            let path = manager.config_dir().join("config.toml");
-            // No config file = first run before TUI write = treat as all enabled.
-            if !path.exists() {
-                return Ok(());
-            }
-            let cfg = manager.load_app_config()?;
-            // Empty enabled_plugins = "all enabled" (backwards compat).
-            if cfg.enabled_plugins.is_empty() || cfg.enabled_plugins.contains(&name) {
-                Ok(())
-            } else {
-                std::process::exit(1);
-            }
-        }
-    }
-}
-
-fn setup_ucf_session(ucf_name: &str, target_cli: &str) -> io::Result<(String, Vec<String>)> {
-    let ucf_path = dirs::data_dir()
-        .unwrap_or_else(|| {
-            std::path::PathBuf::from(env::var("HOME").unwrap_or_default()).join(".local/share")
-        })
-        .join("unleash")
-        .join("sessions")
-        .join(format!("{}.ucf.jsonl", ucf_name));
-
-    let ucf_query = format!("ucf:{}", ucf_name);
-
-    if !ucf_path.exists() {
-        eprintln!("\x1b[34minfo:\x1b[0m Starting new native UCF session: {ucf_name}");
-        std::fs::create_dir_all(ucf_path.parent().unwrap())?;
-        let now_iso = std::process::Command::new("date")
-            .arg("-u")
-            .arg("+%Y-%m-%dT%H:%M:%SZ")
-            .output()
-            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-            .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
-
-        let header = interchange::hub::SessionHeader {
-            ucf_version: interchange::hub::UCF_VERSION.to_string(),
-            session_id: ucf_name.to_string(),
-            created_at: now_iso.clone(),
-            updated_at: now_iso.clone(),
-            source_cli: "ucf".to_string(),
-            source_version: "1.0.0".to_string(),
-            project: None,
-            model: None,
-            title: Some(ucf_name.to_string()),
-            slug: Some(ucf_name.to_string()),
-            parent_session_id: None,
-            extensions: serde_json::json!({}),
-        };
-        let msg = interchange::hub::HubMessage {
-            id: format!("init-{ucf_name}"),
-            api_message_id: None,
-            parent_id: None,
-            timestamp: now_iso.clone(),
-            completed_at: Some(now_iso),
-            role: "user".to_string(),
-            content: vec![interchange::hub::ContentBlock::Text {
-                text: "[UCF Session Initialized]".to_string(),
-            }],
-            metadata: Default::default(),
-            extensions: serde_json::json!({}),
-        };
-
-        let record_session = interchange::hub::HubRecord::Session(header);
-        let record_msg = interchange::hub::HubRecord::Message(msg);
-        let data = serde_json::to_string(&record_session).unwrap()
-            + "\n"
-            + &serde_json::to_string(&record_msg).unwrap()
-            + "\n";
-        std::fs::write(&ucf_path, data)?;
-    } else {
-        eprintln!("\x1b[34minfo:\x1b[0m Loading native UCF session: {ucf_name} into {target_cli}");
-    }
-
-    match interchange::inject::inject_session(&ucf_query, target_cli) {
-        Ok(result) => {
-            eprintln!("\x1b[32m✓\x1b[0m {}", result.message);
-            Ok((result.session_id, result.resume_args))
-        }
-        Err(e) => {
-            eprintln!("\x1b[31m✗\x1b[0m UCF initialization failed: {e}");
-            Err(io::Error::other(e.to_string()))
-        }
-    }
-}
-
-fn sync_ucf_session(ucf_name: &str, target_cli: &str, session_id: &str) {
-    let query = format!("{}:{}", target_cli, session_id);
-    if let Some(session) = interchange::sessions::find_session(&query) {
-        if let Ok(records) = interchange::inject::source_to_hub(&session) {
-            let ucf_path = dirs::data_dir()
-                .unwrap_or_else(|| {
-                    std::path::PathBuf::from(env::var("HOME").unwrap_or_default())
-                        .join(".local/share")
-                })
-                .join("unleash")
-                .join("sessions")
-                .join(format!("{}.ucf.jsonl", ucf_name));
-
-            let mut out = String::new();
-            for r in records {
-                out.push_str(&serde_json::to_string(&r).unwrap());
-                out.push('\n');
-            }
-            if let Err(e) = std::fs::write(&ucf_path, out) {
-                eprintln!(
-                    "Warning: Failed to save UCF session back to {}: {}",
-                    ucf_path.display(),
-                    e
-                );
-            } else {
-                eprintln!("\x1b[32m✓\x1b[0m Saved native UCF session: {}", ucf_name);
-            }
-        }
     }
 }

--- a/src/pixel_art.rs
+++ b/src/pixel_art.rs
@@ -1367,7 +1367,7 @@ mod tests {
             while let Some(ch) = chars.next() {
                 if ch == '\x1b' {
                     // Skip until 'm'
-                    while let Some(c) = chars.next() {
+                    for c in chars.by_ref() {
                         if c == 'm' {
                             break;
                         }
@@ -1406,7 +1406,7 @@ mod tests {
             let mut chars = line.chars().peekable();
             while let Some(ch) = chars.next() {
                 if ch == '\x1b' {
-                    while let Some(c) = chars.next() {
+                    for c in chars.by_ref() {
                         if c == 'm' {
                             break;
                         }

--- a/src/search.rs
+++ b/src/search.rs
@@ -581,7 +581,7 @@ async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
             }
             Err(_) => emb_failed += 1,
         }
-        if !args.json && (emb_done + emb_failed) % 32 == 0 {
+        if !args.json && (emb_done + emb_failed).is_multiple_of(32) {
             eprintln!("  embed: {}/{}", emb_done + emb_failed, total_embed);
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -405,6 +405,7 @@ impl SandboxStepStatus {
 
 /// What the user picked for a single env-var key in the wizard.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default)]
 pub enum EnvKeyChoice {
     /// Don't store; pass `-e KEY` at `docker run` time so the host value flows in.
     Passthrough,
@@ -413,6 +414,7 @@ pub enum EnvKeyChoice {
     /// Open `$EDITOR` on `docker/.env` when the user hits Enter.
     Editor,
     /// Neither — skip this key entirely.
+    #[default]
     Skip,
 }
 
@@ -443,13 +445,6 @@ impl EnvKeyChoice {
     }
 }
 
-impl Default for EnvKeyChoice {
-    fn default() -> Self {
-        // Default to passthrough when the host env already has the key set
-        // (decided per-row at draft creation); fall back to Skip otherwise.
-        EnvKeyChoice::Skip
-    }
-}
 
 /// One row in the env-config step.
 #[derive(Debug, Clone)]
@@ -7036,7 +7031,7 @@ mod tests {
         let (app, _temp) = test_app();
         let width = app.content_width();
         // Main menu width is driven by the longest description line.
-        assert!(width >= 30 && width <= 80);
+        assert!((30..=80).contains(&width));
     }
 
     #[test]

--- a/src/version.rs
+++ b/src/version.rs
@@ -2187,7 +2187,7 @@ pub fn install_latest_streaming(
         AgentType::Codex => {
             let installed = which::which("codex")
                 .ok()
-                .and_then(|_| None::<String>); // just need presence
+                .and(None::<String>); // just need presence
             let versions = vm.get_codex_version_list(installed.as_deref());
             let v = versions
                 .into_iter()


### PR DESCRIPTION
## Summary

\`cargo clippy --lib --tests --no-deps -- -D warnings\` was firing 44 warnings across 12 files. All cleared.

**No behavior changes** — every fix is a clippy-suggested pattern equivalence (matches! macro, \`std::slice::from_ref\`, collapsed nested \`if let\`, \`is_multiple_of\`, type aliases, etc.) or an \`#[allow]\` where the lint conflicts with a deliberate API contract.

## Notable manual fixes

| File | Fix | Why manual |
|------|-----|------------|
| \`agents.rs\` | \`#[allow(should_implement_trait)]\` on \`AgentType::from_str\` | Returns \`Option\`, not \`Result\`; would need a breaking signature change to use std::str::FromStr |
| \`codex.rs\` | Collapsed 3 identical branches to one catch-all | Was \`else if ... { "event_msg" } else if ... { "event_msg" } else { "event_msg" }\` — added comment naming what falls through |
| \`hooks.rs\` (test) | Hoisted \`&[plugin_a.clone()]\` to local let binding | Sibling argument consumes \`plugin_a\` — \`slice::from_ref(&plugin_a)\` would conflict |
| \`sessions.rs\` | \`type OverlayRow = (Option<String>, Option<String>, i64)\` | Refactor of a long HashMap value type |

Item-reordering in \`lib.rs\`, \`sessions.rs\`, \`pixel_art.rs\`, \`tui/app.rs\` is from clippy's \`items_after_test_module\` autofix — pure movement, identical code.

## Test plan

- [x] \`cargo test --lib\` — 537 passing, 0 failed
- [x] \`cargo clippy --lib --tests --no-deps -- -D warnings\` — clean
- [x] Manual verification of the 3 fixes that required judgment (each annotated above)

This unblocks adding a CI step that fails on new clippy warnings, should we want one.