### PR TITLE
fix(updater): fall back to embedded versions when live latest-check fails

### DIFF
--- a/src/updater.rs
+++ b/src/updater.rs
@@ -529,7 +529,7 @@ fn get_latest_version(agent_type: AgentType) -> io::Result<Option<String>> {
     if let AgentType::Custom(_) = &agent_type {
         return Ok(None); // custom agents don't support version detection yet
     }
-    let def = AgentDefinition::from_type(agent_type);
+    let def = AgentDefinition::from_type(agent_type.clone());
 
     // Prefer npm registry for agents that have an npm package.
     if let Some(ref package) = def.npm_package {
@@ -539,12 +539,39 @@ fn get_latest_version(agent_type: AgentType) -> io::Result<Option<String>> {
         // npm not available or returned nothing — fall through to GitHub
     }
 
-    // Fall back to GitHub releases.
+    // Try GitHub releases.
     if let Some(ref repo) = def.github_repo {
-        return get_latest_github_version(repo);
+        if let Some(version) = get_latest_github_version(repo)? {
+            return Ok(Some(version));
+        }
     }
 
-    Ok(None)
+    // Both live lookups failed (npm down, GitHub rate-limited, no network,
+    // etc.) — fall back to the embedded version list compiled into the
+    // binary. Without this, the check phase emits "not installed (up to
+    // date)" and the install loop silently skips the agent, leaving the
+    // user with no install and no error. Embedded versions may be slightly
+    // behind upstream but are always installable.
+    Ok(latest_embedded_version(&agent_type))
+}
+
+/// First (newest) version for `agent_type` from the embedded versions
+/// list, or None for agents not represented there (Custom, Unleash).
+fn latest_embedded_version(agent_type: &AgentType) -> Option<String> {
+    let key = match agent_type {
+        AgentType::Claude => "claude",
+        AgentType::Codex => "codex",
+        AgentType::Antigravity => "antigravity",
+        AgentType::Gemini => "gemini",
+        AgentType::OpenCode => "opencode",
+        AgentType::Pi => "pi",
+        AgentType::Hermes => "hermes",
+        AgentType::Unleash | AgentType::Custom(_) => return None,
+    };
+    crate::version::load_embedded_versions()
+        .get(key)
+        .and_then(|v| v.first())
+        .cloned()
 }
 
 fn get_latest_npm_version(package: &str) -> io::Result<Option<String>> {
@@ -1546,5 +1573,42 @@ mod tests {
     fn parse_release_tag_returns_none_for_missing_tag_name() {
         let body = br#"{"name":"Release","id":12345}"#;
         assert_eq!(parse_release_tag(body), None);
+    }
+
+    #[test]
+    fn latest_embedded_version_returns_first_for_bundled_agents() {
+        // data/versions.json is compiled into the binary via include_str! —
+        // these agents must always have at least one fallback entry or the
+        // CUDA Dockerfile / any offline install will silently skip them.
+        // Pi and Hermes are NPM-only at build time and not bundled; their
+        // live install path doesn't depend on this fallback.
+        for agent in [
+            AgentType::Claude,
+            AgentType::Codex,
+            AgentType::Gemini,
+            AgentType::OpenCode,
+            AgentType::Antigravity,
+        ] {
+            let v = latest_embedded_version(&agent);
+            assert!(
+                v.is_some(),
+                "embedded versions must include {:?} (data/versions.json)",
+                agent
+            );
+            assert!(
+                !v.as_deref().unwrap_or("").is_empty(),
+                "{:?} embedded version must be non-empty",
+                agent
+            );
+        }
+    }
+
+    #[test]
+    fn latest_embedded_version_returns_none_for_custom_and_unleash() {
+        assert_eq!(latest_embedded_version(&AgentType::Unleash), None);
+        assert_eq!(
+            latest_embedded_version(&AgentType::Custom("foo".into())),
+            None
+        );
     }
 }


### PR DESCRIPTION
## Why

Docker Publish on \`main\` started failing today (run 26642549118): the CUDA Dockerfile's \`unleash install claude codex gemini pi\` silently dropped \`codex\`, then the next-step verify hit \`/bin/sh: codex: not found\` with exit 127.

Root cause: the regular Dockerfile build (which ran ~10 minutes earlier on the same runner IP) consumed the GitHub API's 60/hr unauthenticated quota. The CUDA build's \`curl https://api.github.com/repos/openai/codex/releases/latest\` then returned a rate-limit body with no \`tag_name\`, so \`get_latest_version\` returned \`None\`, \`update_available\` became \`false\`, and the install filter silently skipped Codex. The log line:

\`\`\`
  . Codex             not installed (up to date)
\`\`\`

…is what you see when \`installed=None, latest=None, update_available=false\`. Surfaces as success but does nothing.

## What

When \`get_latest_version\` exhausts both the npm and GitHub paths, fall back to \`data/versions.json\` (compiled into the binary via \`include_str!\`). Mirror what the install-path lookups (\`get_codex_available_versions\`, \`get_gemini_available_versions\`, etc.) already do.

Embedded versions may lag upstream by a few releases but are always installable, so the install proceeds with a working version instead of silently skipping the agent.

## Behavior matrix

| Scenario | Before | After |
|----------|--------|-------|
| Live npm/GitHub returns latest | install latest | install latest (unchanged) |
| Live lookup fails, embedded has versions | silently skip, "up to date" | install latest from embedded |
| Live lookup fails, no embedded entry | silently skip | silently skip (unchanged — no fallback available) |

## Test plan

- [x] \`cargo test --lib latest_embedded_version\` — 2 new tests covering bundled-agents-present invariant and Custom/Unleash returning None
- [x] \`cargo test --lib\` — 539 passing, no regressions
- [x] CI: the CUDA Dockerfile build on this PR will validate the fallback end-to-end