### PR TITLE
chore: collapse two clippy collapsible_match warnings in pixel_art

### DIFF
--- a/src/pixel_art.rs
+++ b/src/pixel_art.rs
@@ -486,18 +486,16 @@ fn parse_ansi_sequence_with(
                     i += 4;
                 }
             }
-            "48" => {
-                if i + 1 < parts.len() && parts[i + 1] == "2" && i + 4 < parts.len() {
-                    if let (Ok(r), Ok(g), Ok(b)) = (
-                        parts[i + 2].parse::<u8>(),
-                        parts[i + 3].parse::<u8>(),
-                        parts[i + 4].parse::<u8>(),
-                    ) {
-                        let (nr, ng, nb) = transform(r, g, b);
-                        style = style.bg(RatatuiColor::Rgb(nr, ng, nb));
-                    }
-                    i += 4;
+            "48" if i + 1 < parts.len() && parts[i + 1] == "2" && i + 4 < parts.len() => {
+                if let (Ok(r), Ok(g), Ok(b)) = (
+                    parts[i + 2].parse::<u8>(),
+                    parts[i + 3].parse::<u8>(),
+                    parts[i + 4].parse::<u8>(),
+                ) {
+                    let (nr, ng, nb) = transform(r, g, b);
+                    style = style.bg(RatatuiColor::Rgb(nr, ng, nb));
                 }
+                i += 4;
             }
             _ => {}
         }
@@ -668,17 +666,15 @@ fn parse_gradient_sequence_colors(seq: &str, mut fg: OptRgb, mut bg: OptRgb) -> 
                     i += 4;
                 }
             }
-            "48" => {
-                if i + 1 < parts.len() && parts[i + 1] == "2" && i + 4 < parts.len() {
-                    if let (Ok(r), Ok(g), Ok(b)) = (
-                        parts[i + 2].parse::<u8>(),
-                        parts[i + 3].parse::<u8>(),
-                        parts[i + 4].parse::<u8>(),
-                    ) {
-                        bg = Some((r, g, b));
-                    }
-                    i += 4;
+            "48" if i + 1 < parts.len() && parts[i + 1] == "2" && i + 4 < parts.len() => {
+                if let (Ok(r), Ok(g), Ok(b)) = (
+                    parts[i + 2].parse::<u8>(),
+                    parts[i + 3].parse::<u8>(),
+                    parts[i + 4].parse::<u8>(),
+                ) {
+                    bg = Some((r, g, b));
                 }
+                i += 4;
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary

Two `collapsible_match` lint failures slipped onto main after #239 (which had cleared all clippy warnings). Both are in `src/pixel_art.rs` — the `"48"` arms in `parse_ansi_sequence_with` and `parse_gradient_sequence_colors` guard their bodies with an inner `if i + 1 < parts.len() && ...`. Clippy wants the predicate folded into the match arm as a guard. Behaviorally identical: if the guard is false, both versions fall through to `_ => {}` and the outer loop's `i += 1` still runs.

## Why now

`cargo clippy --lib --tests --no-deps -- -D warnings` errors on main today. Restoring the baseline #239 established keeps the door open for a CI lint gate.

## Test plan

- [x] `cargo clippy --lib --tests --no-deps -- -D warnings` — clean
- [x] `cargo test --lib pixel_art` — all 23 tests green