### PR TITLE
fix(tests): serialize UNLEASH_REINDEX_BINARY env mutation in sessions tests

### DIFF
--- a/src/interchange/sessions.rs
+++ b/src/interchange/sessions.rs
@@ -863,6 +863,17 @@ fn discover_ucf() -> Vec<SessionInfo> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Multiple tests in this module mutate UNLEASH_REINDEX_BINARY (and
+    // related env) around a `trigger_background_reindex` fork+exec. Cargo
+    // runs tests on a thread pool by default, so two such tests racing can
+    // leave the spawned child reading the OTHER test's env. We saw this as
+    // intermittent flake-check failures on
+    // `test_trigger_background_reindex_sets_lock_path_env_var`.
+    // Acquire this mutex at the start of any test that mutates the shared
+    // env to serialize them.
+    static ENV_MUTATION_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_find_session_with_cli_prefix() {
@@ -883,6 +894,7 @@ mod tests {
 
     #[test]
     fn test_overlay_search_index_fills_missing_name() {
+        let _env_lock = ENV_MUTATION_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let mut sessions = vec![
             SessionInfo {
                 cli: "claude".into(),
@@ -993,6 +1005,7 @@ mod tests {
 
     #[test]
     fn test_trigger_background_reindex_sets_lock_path_env_var() {
+        let _env_lock = ENV_MUTATION_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // The child process needs UNLEASH_REINDEX_LOCK_PATH to clean up the lock
         // file on exit. We stub the child with a tiny shell script that asserts
         // the env var is set and points at the expected file. If the env var is


### PR DESCRIPTION
## Summary

Yesterday's flake-check job (run [26677660336](https://github.com/heiervang-technologies/unleash/actions/runs/26677660336)) caught `test_trigger_background_reindex_sets_lock_path_env_var` flipping ok → FAILED on iteration 5 of 5.

Root cause: two tests in `src/interchange/sessions.rs` mutate the process-global `UNLEASH_REINDEX_BINARY` env var around a `trigger_background_reindex` call (which fork+execs a child that reads that env var). Cargo's default test parallelism lets them race — whichever child execs second can see the OTHER test's env value, fail to write the expected marker, and the assertion misses.

Fix: a module-local `Mutex<()>` acquired at the top of any test that mutates the shared env. Poison-safe (`unwrap_or_else(|e| e.into_inner())` so a panicked sibling doesn't take down the whole suite).

## Verification

- **Reproduced the original flake** (with mutex stashed): full lib suite × 10 iters → 1/10 fails with the exact same signature as CI (`test_trigger_background_reindex_sets_lock_path_env_var ... FAILED`).
- **Verified the fix**: full lib suite × 10 iters with mutex → 0/10 fails.
- 1/10 vs 0/10 is consistent with the ~1/5 CI signal; the mutex is causal.

## Test plan

- [x] `cargo test --lib interchange::sessions` — green
- [x] `cargo test --lib` × 10 iters — all green
- [x] `cargo clippy --lib --tests --no-deps -- -D warnings` — clean