### PR TITLE
ci: widen clippy gate to --all-targets (cleans examples/poc_search.rs)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,10 +2,9 @@ name: Lint Rust
 
 # Gate PRs and main on clippy cleanliness.
 #
-# Scope: --lib --tests matches the baseline established by #239 and restored
-# by #242. examples/ (notably examples/poc_search.rs from the search PoC) is
-# intentionally excluded — it's exploration code and not held to the same bar
-# yet. Widen to --all-targets when those are cleaned up.
+# Scope: --all-targets covers lib, integration tests, examples, and benches.
+# Started narrower (--lib --tests, matching #239) and widened once
+# examples/poc_search.rs was cleaned — see #248.
 #
 # Why a dedicated workflow rather than piggybacking on coverage.yml:
 #   - Coverage builds with llvm-cov instrumentation (~10 min); clippy is ~1 min
@@ -18,12 +17,16 @@ on:
     branches: [main]
     paths:
       - 'src/**'
+      - 'examples/**'
+      - 'tests/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/lint.yml'
   pull_request:
     paths:
       - 'src/**'
+      - 'examples/**'
+      - 'tests/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/lint.yml'
@@ -37,7 +40,7 @@ concurrency:
 
 jobs:
   clippy:
-    name: cargo clippy --lib --tests
+    name: cargo clippy --all-targets
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -64,4 +67,4 @@ jobs:
             lint-${{ runner.os }}-
 
       - name: cargo clippy
-        run: cargo clippy --lib --tests --no-deps -- -D warnings
+        run: cargo clippy --all-targets --no-deps -- -D warnings

--- a/examples/poc_search.rs
+++ b/examples/poc_search.rs
@@ -8,12 +8,10 @@
 //! 1. Spin up an OpenAI-compatible server with an embedding model. Examples:
 //!
 //!    # llama.cpp with Granite Embedding small-r2 (preferred per plan):
-//!    llama-server -m ~/models/granite-embedding-small-en-r2.Q8_0.gguf \
-//!                 --embedding --port 8080 -ngl 99
+//!    llama-server -m ~/models/granite-embedding-small-en-r2.Q8_0.gguf --embedding --port 8080 -ngl 99
 //!
 //!    # Or EmbeddingGemma-300m (fallback if Granite GGUF is fiddly):
-//!    llama-server -m ~/models/embeddinggemma-300m.Q8_0.gguf \
-//!                 --embedding --port 8080 -ngl 99
+//!    llama-server -m ~/models/embeddinggemma-300m.Q8_0.gguf --embedding --port 8080 -ngl 99
 //!
 //!    # Or via ollama:
 //!    ollama serve  # then `ollama pull granite-embedding:30m`
@@ -245,7 +243,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 None => failed += 1,
             }
         }
-        if (done + failed) % 64 == 0 {
+        if (done + failed).is_multiple_of(64) {
             eprintln!(
                 "  embed progress: {}/{} ({} failed)",
                 done + failed,
@@ -291,7 +289,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // ── Step 5: run hybrid search ────────────────────────────────────────
     let t_q = Instant::now();
-    let qvec = embed_batch(&http, &oai_base, &embed_model, &[query.clone()]).await?;
+    let qvec = embed_batch(&http, &oai_base, &embed_model, std::slice::from_ref(&query)).await?;
     let qvec = qvec.into_iter().next().ok_or("empty query embedding")?;
     let qlit = vec_to_lit(&qvec);
 


### PR DESCRIPTION
## Summary
Followup to #247. Cleans the 4 outstanding clippy warnings in \`examples/poc_search.rs\` (the search PoC) and widens the lint gate from \`--lib --tests\` to \`--all-targets\` so integration tests and examples are also covered.

Path filter on the workflow extended to \`examples/**\` and \`tests/**\` so changes there actually fire the gate (previously only \`src/**\` and Cargo files did).

## Warnings cleaned
- 2× \`doc_overindented_list_items\` at lines 12 and 16: collapsed the multi-line \`llama-server\` invocations onto single lines — the backslash-continued lines were what clippy was reading as overindented list children.
- \`manual_is_multiple_of\` at line 248: \`% 64 == 0\` → \`.is_multiple_of(64)\`.
- \`cloned_ref_to_slice_refs\` at line 294: \`&[query.clone()]\` → \`std::slice::from_ref(&query)\`.

## Test plan
- [x] Local: \`cargo clippy --all-targets --no-deps -- -D warnings\` is clean on this branch.
- [x] Local actionlint passes.
- [ ] CI: confirm \`Lint Rust\` check passes on this PR.

## Notes
PoC docstring continues to render correctly in \`cargo doc\` — the single-line form is just less visually aligned in source.