### PR TITLE
fix(install): render ANSI in install log + reset diverged hermes clone

### DIFF
--- a/src/ansi.rs
+++ b/src/ansi.rs
@@ -1,0 +1,320 @@
+//! Minimal ANSI escape parser for the install log panel.
+//!
+//! The hermes/pi/opencode installers stream colored output via `\x1b[...m`
+//! SGR sequences. Rendering those raw produces lines like `[0;32m✓[0m` —
+//! readable but ugly. This module parses SGR codes (colors, bold, italic,
+//! underline) into ratatui spans and silently strips non-SGR CSI/OSC
+//! sequences (cursor movement, clear-screen, hyperlinks) that aren't useful
+//! in a scrolling log.
+//!
+//! Per-line state only — colors set on one log line do not carry into the
+//! next. Installers occasionally split a styled multi-line banner across
+//! several stdout lines, so the middle rows render in `base_style`; this is
+//! a known tradeoff against the complexity of cross-line state.
+//!
+//! Not a full terminal emulator. We accept whatever subset of SGR the
+//! installer scripts actually emit and ignore the rest.
+//!
+//! The `nu_ansi_term`/`vte` crates would do more, but adding a dependency
+//! for ~80 lines of straightforward parsing isn't worth it.
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+
+/// Parse a single log line and produce styled spans.
+///
+/// `base_style` is applied to every span and may be overlaid by SGR codes
+/// found in the line (fg/bg/modifiers). Non-SGR escape sequences are
+/// stripped.
+pub fn parse_line(line: &str, base_style: Style) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut current = base_style;
+    let mut buf = String::new();
+    let bytes = line.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+        // ESC = 0x1b
+        if b == 0x1b && i + 1 < bytes.len() {
+            // Flush buffered text under current style.
+            if !buf.is_empty() {
+                spans.push(Span::styled(std::mem::take(&mut buf), current));
+            }
+            match bytes[i + 1] {
+                b'[' => {
+                    // CSI: ESC [ <params> <final>
+                    let mut j = i + 2;
+                    while j < bytes.len() {
+                        let c = bytes[j];
+                        // Final byte: 0x40..=0x7e
+                        if (0x40..=0x7e).contains(&c) {
+                            if c == b'm' {
+                                let params = &line[i + 2..j];
+                                apply_sgr(params, &mut current, base_style);
+                            }
+                            // Drop the whole sequence whether SGR or not.
+                            j += 1;
+                            break;
+                        }
+                        j += 1;
+                    }
+                    i = j;
+                }
+                b']' => {
+                    // OSC: ESC ] ... (BEL | ESC \)
+                    let mut j = i + 2;
+                    while j < bytes.len() {
+                        if bytes[j] == 0x07 {
+                            j += 1;
+                            break;
+                        }
+                        if bytes[j] == 0x1b && j + 1 < bytes.len() && bytes[j + 1] == b'\\' {
+                            j += 2;
+                            break;
+                        }
+                        j += 1;
+                    }
+                    i = j;
+                }
+                _ => {
+                    // Two-byte sequences (ESC <letter>) and anything else:
+                    // drop the ESC and the next byte.
+                    i += 2;
+                }
+            }
+            continue;
+        }
+        // Skip stray carriage returns; they confuse line rendering when the
+        // installer uses \r for progress redraws.
+        if b == b'\r' {
+            i += 1;
+            continue;
+        }
+        // Pull a full UTF-8 codepoint so multi-byte chars (✓, →, ⚕) survive.
+        let ch_len = utf8_char_len(b);
+        let end = (i + ch_len).min(bytes.len());
+        if let Ok(s) = std::str::from_utf8(&bytes[i..end]) {
+            buf.push_str(s);
+        }
+        i = end;
+    }
+
+    if !buf.is_empty() {
+        spans.push(Span::styled(buf, current));
+    }
+    if spans.is_empty() {
+        spans.push(Span::styled(String::new(), base_style));
+    }
+    Line::from(spans)
+}
+
+fn utf8_char_len(first: u8) -> usize {
+    if first < 0x80 {
+        1
+    } else if first < 0xc0 {
+        // Continuation byte in isolation — treat as one to keep progress.
+        1
+    } else if first < 0xe0 {
+        2
+    } else if first < 0xf0 {
+        3
+    } else {
+        4
+    }
+}
+
+fn apply_sgr(params: &str, current: &mut Style, base_style: Style) {
+    // Empty params (`ESC [ m`) is shorthand for reset.
+    if params.is_empty() {
+        *current = base_style;
+        return;
+    }
+    let codes: Vec<u16> = params
+        .split(';')
+        .map(|s| s.trim().parse::<u16>().unwrap_or(0))
+        .collect();
+
+    let mut i = 0;
+    while i < codes.len() {
+        let code = codes[i];
+        match code {
+            0 => *current = base_style,
+            1 => *current = current.add_modifier(Modifier::BOLD),
+            2 => *current = current.add_modifier(Modifier::DIM),
+            3 => *current = current.add_modifier(Modifier::ITALIC),
+            4 => *current = current.add_modifier(Modifier::UNDERLINED),
+            7 => *current = current.add_modifier(Modifier::REVERSED),
+            22 => {
+                *current = current
+                    .remove_modifier(Modifier::BOLD)
+                    .remove_modifier(Modifier::DIM)
+            }
+            23 => *current = current.remove_modifier(Modifier::ITALIC),
+            24 => *current = current.remove_modifier(Modifier::UNDERLINED),
+            27 => *current = current.remove_modifier(Modifier::REVERSED),
+            30..=37 => *current = current.fg(basic_color(code as u8 - 30, false)),
+            38 => {
+                if let Some((color, consumed)) = parse_extended_color(&codes[i + 1..]) {
+                    *current = current.fg(color);
+                    i += consumed;
+                }
+            }
+            39 => *current = current.fg(base_style.fg.unwrap_or(Color::Reset)),
+            40..=47 => *current = current.bg(basic_color(code as u8 - 40, false)),
+            48 => {
+                if let Some((color, consumed)) = parse_extended_color(&codes[i + 1..]) {
+                    *current = current.bg(color);
+                    i += consumed;
+                }
+            }
+            49 => *current = current.bg(base_style.bg.unwrap_or(Color::Reset)),
+            90..=97 => *current = current.fg(basic_color(code as u8 - 90, true)),
+            100..=107 => *current = current.bg(basic_color(code as u8 - 100, true)),
+            _ => {}
+        }
+        i += 1;
+    }
+}
+
+/// Parse the tail of a 38/48 SGR: either `5;N` (256-color) or `2;r;g;b`
+/// (truecolor). Returns the resolved color and how many params were
+/// consumed *after* the leading 38/48.
+fn parse_extended_color(rest: &[u16]) -> Option<(Color, usize)> {
+    match rest.first()? {
+        5 => {
+            let n = *rest.get(1)? as u8;
+            Some((Color::Indexed(n), 2))
+        }
+        2 => {
+            let r = *rest.get(1)? as u8;
+            let g = *rest.get(2)? as u8;
+            let b = *rest.get(3)? as u8;
+            Some((Color::Rgb(r, g, b), 4))
+        }
+        _ => None,
+    }
+}
+
+fn basic_color(idx: u8, bright: bool) -> Color {
+    match (idx, bright) {
+        (0, false) => Color::Black,
+        (1, false) => Color::Red,
+        (2, false) => Color::Green,
+        (3, false) => Color::Yellow,
+        (4, false) => Color::Blue,
+        (5, false) => Color::Magenta,
+        (6, false) => Color::Cyan,
+        (7, false) => Color::Gray,
+        (0, true) => Color::DarkGray,
+        (1, true) => Color::LightRed,
+        (2, true) => Color::LightGreen,
+        (3, true) => Color::LightYellow,
+        (4, true) => Color::LightBlue,
+        (5, true) => Color::LightMagenta,
+        (6, true) => Color::LightCyan,
+        (7, true) => Color::White,
+        _ => Color::Reset,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flat_text(line: &Line<'_>) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn plain_text_passes_through() {
+        let line = parse_line("hello world", Style::default());
+        assert_eq!(flat_text(&line), "hello world");
+        assert_eq!(line.spans.len(), 1);
+    }
+
+    #[test]
+    fn basic_color_codes_become_styled_spans() {
+        // Hermes installer:  \x1b[0;32m✓\x1b[0m Detected: linux
+        let line = parse_line("\x1b[0;32m✓\x1b[0m Detected: linux", Style::default());
+        assert_eq!(flat_text(&line), "✓ Detected: linux");
+        let colored = line
+            .spans
+            .iter()
+            .find(|s| s.content == "✓")
+            .expect("checkmark span exists");
+        assert_eq!(colored.style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn bold_and_color_combine() {
+        let line = parse_line("\x1b[1;35mhi\x1b[0m", Style::default());
+        let span = &line.spans[0];
+        assert_eq!(span.content, "hi");
+        assert_eq!(span.style.fg, Some(Color::Magenta));
+        assert!(span.style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn reset_returns_to_base_style() {
+        let base = Style::default().fg(Color::DarkGray);
+        let line = parse_line("\x1b[31mred\x1b[0m gray", base);
+        assert_eq!(line.spans.len(), 2);
+        assert_eq!(line.spans[0].style.fg, Some(Color::Red));
+        assert_eq!(line.spans[1].style.fg, Some(Color::DarkGray));
+    }
+
+    #[test]
+    fn empty_params_are_treated_as_reset() {
+        // Some shell scripts emit a bare `\x1b[m` to reset.
+        let base = Style::default().fg(Color::DarkGray);
+        let line = parse_line("\x1b[31mred\x1b[m gray", base);
+        assert_eq!(line.spans.last().unwrap().style.fg, Some(Color::DarkGray));
+    }
+
+    #[test]
+    fn non_sgr_csi_sequences_are_stripped() {
+        // ESC[2K = erase line, ESC[H = cursor home.
+        let line = parse_line("\x1b[2K\x1b[Hclean", Style::default());
+        assert_eq!(flat_text(&line), "clean");
+    }
+
+    #[test]
+    fn osc_sequences_are_stripped() {
+        // ESC]0;title\x07 — set terminal title; should leave no trace.
+        let line = parse_line("\x1b]0;the title\x07payload", Style::default());
+        assert_eq!(flat_text(&line), "payload");
+    }
+
+    #[test]
+    fn truecolor_rgb_is_parsed() {
+        let line = parse_line("\x1b[38;2;10;20;30mhi", Style::default());
+        assert_eq!(line.spans[0].style.fg, Some(Color::Rgb(10, 20, 30)));
+    }
+
+    #[test]
+    fn indexed_256_color_is_parsed() {
+        let line = parse_line("\x1b[38;5;208morange", Style::default());
+        assert_eq!(line.spans[0].style.fg, Some(Color::Indexed(208)));
+    }
+
+    #[test]
+    fn carriage_returns_are_stripped() {
+        // Installers often emit \r for progress; we want clean log lines.
+        let line = parse_line("downloading...\rdone", Style::default());
+        assert_eq!(flat_text(&line), "downloading...done");
+    }
+
+    #[test]
+    fn malformed_escape_at_end_does_not_panic() {
+        let _ = parse_line("\x1b[", Style::default());
+        let _ = parse_line("\x1b", Style::default());
+        let _ = parse_line("\x1b]0;unterminated", Style::default());
+    }
+
+    #[test]
+    fn bright_colors_use_light_variants() {
+        let line = parse_line("\x1b[91mbright red\x1b[0m", Style::default());
+        assert_eq!(line.spans[0].style.fg, Some(Color::LightRed));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 //!
 
 pub mod agents;
+#[cfg(feature = "tui")]
+mod ansi;
 mod auth;
 mod cli;
 pub mod config;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -6729,7 +6729,11 @@ impl App {
         let visible_lines: Vec<Line> = self.install_log_lines[start..]
             .iter()
             .map(|line| {
-                let style = if line.starts_with("---") {
+                // Our own `---` status markers (emitted from the install
+                // pipeline) keep their existing semantic coloring. Installer
+                // output is parsed for ANSI SGR so green checkmarks, magenta
+                // banners, etc. survive the trip through our log channel.
+                let base_style = if line.starts_with("---") {
                     if line.contains("successfully") {
                         Style::default().fg(Color::Green)
                     } else if line.contains("failed") || line.contains("Failed") {
@@ -6740,7 +6744,13 @@ impl App {
                 } else {
                     Style::default().fg(Color::DarkGray)
                 };
-                Line::from(Span::styled(format!(" {}", line), style))
+                let parsed = crate::ansi::parse_line(line, base_style);
+                // Prepend the leading space the previous renderer used so the
+                // log content does not butt up against the panel border.
+                let mut spans: Vec<Span<'static>> = Vec::with_capacity(parsed.spans.len() + 1);
+                spans.push(Span::styled(" ".to_string(), base_style));
+                spans.extend(parsed.spans);
+                Line::from(spans)
             })
             .collect();
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -1858,6 +1858,23 @@ impl VersionManager {
             ));
         }
 
+        // The installer's update path runs `git pull --ff-only` and aborts
+        // when the local clone has diverged from origin/main (e.g. after an
+        // upstream squash/rebase). We hit this exact failure mode in the
+        // wild: the local checkout had 1 stale commit on top of an older
+        // main, so install.sh died with "Not possible to fast-forward".
+        // Reset the clone to origin/<branch> before invoking the installer
+        // so the ff-only pull always succeeds. Uncommitted local edits are
+        // still preserved — the installer's own stash logic handles those.
+        let install_dir = std::env::var("HERMES_INSTALL_DIR")
+            .ok()
+            .map(PathBuf::from)
+            .or_else(|| dirs::home_dir().map(|h| h.join(".hermes/hermes-agent")));
+        let branch = std::env::var("HERMES_BRANCH").unwrap_or_else(|_| "main".to_string());
+        if let Some(dir) = install_dir {
+            Self::reset_diverged_hermes_clone(&dir, &branch, &log_tx);
+        }
+
         let _ = log_tx.send(
             "Running: curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup".to_string(),
         );
@@ -1887,6 +1904,83 @@ impl VersionManager {
                 ))
             },
         })
+    }
+
+    /// Reset the hermes clone to `origin/<branch>` if HEAD has diverged.
+    ///
+    /// install.sh's `git pull --ff-only` aborts on divergence; we paper over
+    /// that by hard-resetting to the upstream branch tip first. The
+    /// installer then sees a clean fast-forward (no-op or a normal pull).
+    /// No-op when the directory is missing or not a git checkout — fresh
+    /// installs fall through to the normal clone path.
+    pub(crate) fn reset_diverged_hermes_clone(
+        dir: &std::path::Path,
+        branch: &str,
+        log_tx: &mpsc::Sender<String>,
+    ) {
+        if !dir.join(".git").exists() {
+            return;
+        }
+        let remote_ref = format!("origin/{}", branch);
+
+        let fetch_ok = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(["fetch", "origin", branch])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !fetch_ok {
+            // Network failure or no remote yet — let the installer handle it.
+            return;
+        }
+
+        // `git merge-base --is-ancestor HEAD origin/<branch>` exits 0 when
+        // HEAD is reachable from upstream (clean ff possible), nonzero
+        // otherwise. We only reset on the nonzero case.
+        let is_ancestor = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(["merge-base", "--is-ancestor", "HEAD", &remote_ref])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(true);
+        if is_ancestor {
+            return;
+        }
+
+        let _ = log_tx.send(format!(
+            "Detected divergent hermes checkout at {} — resetting to {} so install can fast-forward",
+            dir.display(),
+            remote_ref
+        ));
+        let reset = Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(["reset", "--hard", &remote_ref])
+            .stdin(Stdio::null())
+            .output();
+        match reset {
+            Ok(out) if out.status.success() => {
+                let _ = log_tx.send(format!("Reset clone to {}", remote_ref));
+            }
+            Ok(out) => {
+                let _ = log_tx.send(format!(
+                    "git reset failed (status {}): {}",
+                    out.status,
+                    String::from_utf8_lossy(&out.stderr).trim()
+                ));
+            }
+            Err(e) => {
+                let _ = log_tx.send(format!("git reset could not run: {}", e));
+            }
+        }
     }
 
     /// Install OpenCode with streaming log output.
@@ -2259,6 +2353,172 @@ mod tests {
     use super::*;
     use std::time::Instant;
     use tempfile::TempDir;
+
+    /// Build a self-contained "origin + clone" pair in a tempdir for the
+    /// hermes divergence test. Returns (origin_dir, clone_dir).
+    ///
+    /// Tests must NEVER touch the real ~/.hermes checkout — every git op
+    /// stays inside the tempdir.
+    fn make_origin_and_clone(td: &TempDir) -> (PathBuf, PathBuf) {
+        use std::fs;
+        let origin = td.path().join("origin.git");
+        let clone = td.path().join("clone");
+        fs::create_dir_all(&origin).unwrap();
+
+        // Bare origin repo with an initial commit on `main`.
+        let work = td.path().join("seed");
+        fs::create_dir_all(&work).unwrap();
+        for args in [
+            vec!["init", "--initial-branch=main", "-q"],
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "user.name", "Test"],
+            vec!["commit", "--allow-empty", "-m", "initial", "-q"],
+        ] {
+            let ok = Command::new("git")
+                .arg("-C")
+                .arg(&work)
+                .args(&args)
+                .status()
+                .unwrap()
+                .success();
+            assert!(ok, "seed setup failed: {:?}", args);
+        }
+        let ok = Command::new("git")
+            .args(["clone", "--bare", "-q"])
+            .arg(&work)
+            .arg(&origin)
+            .status()
+            .unwrap()
+            .success();
+        assert!(ok);
+        let ok = Command::new("git")
+            .args(["clone", "-q"])
+            .arg(&origin)
+            .arg(&clone)
+            .status()
+            .unwrap()
+            .success();
+        assert!(ok);
+        for args in [
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "user.name", "Test"],
+        ] {
+            Command::new("git")
+                .arg("-C")
+                .arg(&clone)
+                .args(&args)
+                .status()
+                .unwrap();
+        }
+        (origin, clone)
+    }
+
+    fn head_oid(repo: &std::path::Path) -> String {
+        let out = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+        String::from_utf8(out.stdout).unwrap().trim().to_string()
+    }
+
+    fn add_commit(repo: &std::path::Path, message: &str) {
+        let ok = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(["commit", "--allow-empty", "-m", message, "-q"])
+            .status()
+            .unwrap()
+            .success();
+        assert!(ok);
+    }
+
+    #[test]
+    fn reset_diverged_hermes_clone_is_noop_when_in_sync() {
+        let td = TempDir::new().unwrap();
+        let (_origin, clone) = make_origin_and_clone(&td);
+        let before = head_oid(&clone);
+        let (tx, _rx) = mpsc::channel();
+        VersionManager::reset_diverged_hermes_clone(&clone, "main", &tx);
+        // No divergence → HEAD unchanged.
+        assert_eq!(head_oid(&clone), before);
+    }
+
+    #[test]
+    fn reset_diverged_hermes_clone_resets_diverged_head() {
+        let td = TempDir::new().unwrap();
+        let (origin, clone) = make_origin_and_clone(&td);
+
+        // Advance origin/main beyond what the clone has, by pushing a new
+        // commit from a second worktree.
+        let advance = td.path().join("advance");
+        let ok = Command::new("git")
+            .args(["clone", "-q"])
+            .arg(&origin)
+            .arg(&advance)
+            .status()
+            .unwrap()
+            .success();
+        assert!(ok);
+        for args in [
+            vec!["config", "user.email", "test@example.com"],
+            vec!["config", "user.name", "Test"],
+        ] {
+            Command::new("git")
+                .arg("-C")
+                .arg(&advance)
+                .args(&args)
+                .status()
+                .unwrap();
+        }
+        add_commit(&advance, "upstream commit");
+        let ok = Command::new("git")
+            .arg("-C")
+            .arg(&advance)
+            .args(["push", "-q", "origin", "main"])
+            .status()
+            .unwrap()
+            .success();
+        assert!(ok);
+        let upstream_tip = head_oid(&advance);
+
+        // Now make the original clone diverge with its own local commit
+        // (not present upstream) so HEAD is no longer an ancestor of origin/main.
+        add_commit(&clone, "diverging local commit");
+        let local_before = head_oid(&clone);
+        assert_ne!(local_before, upstream_tip);
+
+        let (tx, rx) = mpsc::channel();
+        VersionManager::reset_diverged_hermes_clone(&clone, "main", &tx);
+        drop(tx);
+        let logs: Vec<String> = rx.iter().collect();
+
+        // HEAD should now match the upstream tip, not the previous local commit.
+        let after = head_oid(&clone);
+        assert_eq!(after, upstream_tip, "clone should be reset to origin/main");
+
+        // And we should have emitted a clear log line so the user sees why
+        // their local commit went away.
+        assert!(
+            logs.iter().any(|l| l.contains("Detected divergent")),
+            "expected divergence log line, got: {:?}",
+            logs
+        );
+    }
+
+    #[test]
+    fn reset_diverged_hermes_clone_skips_when_not_a_git_dir() {
+        let td = TempDir::new().unwrap();
+        // Pass a path that exists but has no `.git/` — should silently no-op
+        // (fresh installs land here and the installer's clone path takes over).
+        let (tx, rx) = mpsc::channel();
+        VersionManager::reset_diverged_hermes_clone(td.path(), "main", &tx);
+        drop(tx);
+        let logs: Vec<String> = rx.iter().collect();
+        assert!(logs.is_empty(), "should not log when no .git/ present: {:?}", logs);
+    }
 
     #[test]
     fn test_version_compare() {


### PR DESCRIPTION
## Summary

Two correctness fixes for `unleash install` / `unleash agents update`:

### 1. ANSI escape codes now render properly in the install log panel

The hermes / pi / opencode installers stream colored output via `\x1b[...m` SGR sequences. Before this change, those rendered as raw `[0;32m✓[0m` garbage in the TUI install log. Now we parse them into ratatui spans.

The parser handles:
- Basic 16 colors (`30-37`, `40-47`) and bright variants (`90-97`, `100-107`)
- 256-color (`38;5;N` / `48;5;N`) and truecolor (`38;2;r;g;b`)
- Modifiers: bold, dim, italic, underline, reverse
- Stripping non-SGR CSI sequences (cursor moves, clear screen) and OSC (terminal title) — these aren't useful in a scrolling log
- Per-line state only; cross-line state is documented as a known limitation (banners split across stdout newlines render the middle rows in the base style)

12 unit tests in `src/ansi.rs::tests` cover SGR variants, malformed escapes, CR stripping, OSC, etc.

### 2. Hermes install/update no longer fails on diverged local checkout

**The bug:** the hermes installer (`install.sh`) updates an existing clone with `git pull --ff-only`. When the local clone has diverged from `origin/main` — e.g. after an upstream squash/rebase, or any stray local commit — the pull aborts:

```
Your branch and 'origin/main' have diverged,
and have 1 and 961 different commits each, respectively.
fatal: Not possible to fast-forward, aborting.
```

This was happening in the wild on my own machine and bricks all `unleash agents update hermes` runs until the user manually intervenes.

**The fix:** before invoking `install.sh`, locate the hermes clone (`HERMES_INSTALL_DIR` env → `~/.hermes/hermes-agent`), `git fetch origin`, and if `git merge-base --is-ancestor HEAD origin/<branch>` returns nonzero, hard-reset to the upstream tip. The installer then sees a clean fast-forward. Uncommitted local edits are still preserved by `install.sh`'s own stash logic (we only blow away divergent committed history, which is almost always an artifact of an upstream rebase rather than user work).

3 unit tests in `src/version.rs::tests` cover the divergence-reset path:
- No-op when in sync with upstream
- No-op when directory lacks `.git/` (fresh-install path)
- Resets HEAD to `origin/main` when diverged, emits clear log line

End-to-end manual verification on the real `~/.hermes/hermes-agent` checkout: pre-fix HEAD was a stale local commit failing `git pull --ff-only`; running the equivalent shell ops resolved cleanly, and `hermes --version` advanced from `2026.5.16` to `2026.5.29`.

## Test plan

- [x] `cargo test --lib` — 557 passed, 0 failed
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` — clean
- [x] Manual verification of git reset path on real diverged hermes checkout
- [ ] Run `unleash agents update hermes` interactively to watch the new log lines render with colors