### PR TITLE
fix(hermes): also reset divergence on the CLI update path

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1258,7 +1258,23 @@ impl AgentManager {
     /// version pin argument. `--skip-setup` bypasses the interactive setup
     /// wizard, which the installer otherwise drives by reading from /dev/tty
     /// even when piped from curl.
+    ///
+    /// install.sh's update path does `git pull --ff-only`, which aborts when
+    /// the local clone has diverged from origin/main (upstream rebases,
+    /// stray local commits). We pre-reset to upstream so the ff-only pull
+    /// always succeeds — see `VersionManager::reset_diverged_hermes_clone`
+    /// for the rationale and `install_hermes_version_streaming` for the
+    /// TUI-side caller.
     fn update_hermes(&self) -> io::Result<String> {
+        if let Some(dir) = crate::version::VersionManager::hermes_install_dir() {
+            let branch = std::env::var("HERMES_BRANCH").unwrap_or_else(|_| "main".to_string());
+            crate::version::VersionManager::reset_diverged_hermes_clone(
+                &dir,
+                &branch,
+                &mut |msg| eprintln!("{}", msg),
+            );
+        }
+
         let output = Command::new("bash")
             .args([
                 "-c",

--- a/src/version.rs
+++ b/src/version.rs
@@ -1866,13 +1866,12 @@ impl VersionManager {
         // Reset the clone to origin/<branch> before invoking the installer
         // so the ff-only pull always succeeds. Uncommitted local edits are
         // still preserved — the installer's own stash logic handles those.
-        let install_dir = std::env::var("HERMES_INSTALL_DIR")
-            .ok()
-            .map(PathBuf::from)
-            .or_else(|| dirs::home_dir().map(|h| h.join(".hermes/hermes-agent")));
-        let branch = std::env::var("HERMES_BRANCH").unwrap_or_else(|_| "main".to_string());
-        if let Some(dir) = install_dir {
-            Self::reset_diverged_hermes_clone(&dir, &branch, &log_tx);
+        if let Some(dir) = Self::hermes_install_dir() {
+            let branch = std::env::var("HERMES_BRANCH").unwrap_or_else(|_| "main".to_string());
+            let tx = log_tx.clone();
+            Self::reset_diverged_hermes_clone(&dir, &branch, &mut |msg| {
+                let _ = tx.send(msg);
+            });
         }
 
         let _ = log_tx.send(
@@ -1906,6 +1905,15 @@ impl VersionManager {
         })
     }
 
+    /// Resolve the hermes install directory the same way install.sh does:
+    /// `HERMES_INSTALL_DIR` env override → `$HOME/.hermes/hermes-agent`.
+    pub(crate) fn hermes_install_dir() -> Option<PathBuf> {
+        std::env::var("HERMES_INSTALL_DIR")
+            .ok()
+            .map(PathBuf::from)
+            .or_else(|| dirs::home_dir().map(|h| h.join(".hermes/hermes-agent")))
+    }
+
     /// Reset the hermes clone to `origin/<branch>` if HEAD has diverged.
     ///
     /// install.sh's `git pull --ff-only` aborts on divergence; we paper over
@@ -1913,10 +1921,14 @@ impl VersionManager {
     /// installer then sees a clean fast-forward (no-op or a normal pull).
     /// No-op when the directory is missing or not a git checkout — fresh
     /// installs fall through to the normal clone path.
+    ///
+    /// Progress messages are routed through `log` so callers can wire them
+    /// into a TUI channel (`unleash` TUI install panel) or stderr (`unleash
+    /// agents update` CLI path).
     pub(crate) fn reset_diverged_hermes_clone(
         dir: &std::path::Path,
         branch: &str,
-        log_tx: &mpsc::Sender<String>,
+        log: &mut dyn FnMut(String),
     ) {
         if !dir.join(".git").exists() {
             return;
@@ -1955,7 +1967,7 @@ impl VersionManager {
             return;
         }
 
-        let _ = log_tx.send(format!(
+        log(format!(
             "Detected divergent hermes checkout at {} — resetting to {} so install can fast-forward",
             dir.display(),
             remote_ref
@@ -1968,17 +1980,17 @@ impl VersionManager {
             .output();
         match reset {
             Ok(out) if out.status.success() => {
-                let _ = log_tx.send(format!("Reset clone to {}", remote_ref));
+                log(format!("Reset clone to {}", remote_ref));
             }
             Ok(out) => {
-                let _ = log_tx.send(format!(
+                log(format!(
                     "git reset failed (status {}): {}",
                     out.status,
                     String::from_utf8_lossy(&out.stderr).trim()
                 ));
             }
             Err(e) => {
-                let _ = log_tx.send(format!("git reset could not run: {}", e));
+                log(format!("git reset could not run: {}", e));
             }
         }
     }
@@ -2440,10 +2452,11 @@ mod tests {
         let td = TempDir::new().unwrap();
         let (_origin, clone) = make_origin_and_clone(&td);
         let before = head_oid(&clone);
-        let (tx, _rx) = mpsc::channel();
-        VersionManager::reset_diverged_hermes_clone(&clone, "main", &tx);
+        let mut logs: Vec<String> = Vec::new();
+        VersionManager::reset_diverged_hermes_clone(&clone, "main", &mut |m| logs.push(m));
         // No divergence → HEAD unchanged.
         assert_eq!(head_oid(&clone), before);
+        assert!(logs.is_empty(), "should not log when in sync: {:?}", logs);
     }
 
     #[test]
@@ -2490,10 +2503,8 @@ mod tests {
         let local_before = head_oid(&clone);
         assert_ne!(local_before, upstream_tip);
 
-        let (tx, rx) = mpsc::channel();
-        VersionManager::reset_diverged_hermes_clone(&clone, "main", &tx);
-        drop(tx);
-        let logs: Vec<String> = rx.iter().collect();
+        let mut logs: Vec<String> = Vec::new();
+        VersionManager::reset_diverged_hermes_clone(&clone, "main", &mut |m| logs.push(m));
 
         // HEAD should now match the upstream tip, not the previous local commit.
         let after = head_oid(&clone);
@@ -2513,10 +2524,8 @@ mod tests {
         let td = TempDir::new().unwrap();
         // Pass a path that exists but has no `.git/` — should silently no-op
         // (fresh installs land here and the installer's clone path takes over).
-        let (tx, rx) = mpsc::channel();
-        VersionManager::reset_diverged_hermes_clone(td.path(), "main", &tx);
-        drop(tx);
-        let logs: Vec<String> = rx.iter().collect();
+        let mut logs: Vec<String> = Vec::new();
+        VersionManager::reset_diverged_hermes_clone(td.path(), "main", &mut |m| logs.push(m));
         assert!(logs.is_empty(), "should not log when no .git/ present: {:?}", logs);
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #250.

That PR patched only the TUI install path (`VersionManager::install_hermes_version_streaming`). The CLI command `unleash agents update hermes` dispatches through `AgentManager::update_hermes` in `agents.rs`, which calls `install.sh` directly and never went through the new pre-reset.

End-to-end verification of #250 on a real diverged clone reproduced the exact failure mode it was supposed to fix:
```
fatal: Not possible to fast-forward, aborting.
```
…meaning the user-facing CLI was still broken after #250.

## Fix

- Extracted `reset_diverged_hermes_clone` into a closure-based API (`&mut dyn FnMut(String)`) so both TUI (mpsc::Sender) and CLI (eprintln) call sites can adapt without duplicating logic.
- Extracted install-dir resolution into a small `hermes_install_dir()` helper so both call sites resolve it the same way (`HERMES_INSTALL_DIR` env → `~/.hermes/hermes-agent`).
- Wired the pre-reset into `agents.rs::update_hermes` alongside the existing TUI caller.

## End-to-end verification

Synthesized divergence with `git commit --allow-empty` in `~/.hermes/hermes-agent`, then:
```
$ unleash agents update hermes
Updating Hermes Agent...
Detected divergent hermes checkout at /home/me/.hermes/hermes-agent — resetting to origin/main so install can fast-forward
Reset clone to origin/main
Hermes Agent updated successfully
```
Total wall clock: under 30s; `hermes --version` still healthy at v0.15.1 (2026.5.29) after the run.

## Test plan

- [x] 3 existing `reset_diverged_hermes_clone*` unit tests still pass (refactored signature, same assertions)
- [x] `cargo test --lib` — 554 passed
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` — clean
- [x] End-to-end run on real diverged ~/.hermes/hermes-agent clone — passed