### PR TITLE
ci: bump docker rust to 1.91 for libsqlite3-sys 0.38

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@
 # ============================================================
 # Stage 1: Build unleash from Rust source
 # ============================================================
-FROM rust:1.90-bookworm AS rust-builder
+FROM rust:1.91-bookworm AS rust-builder
 
 WORKDIR /build
 

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -22,7 +22,7 @@
 # ============================================================
 # Stage 1: Build unleash from Rust source
 # ============================================================
-FROM rust:1.90-bookworm AS rust-builder
+FROM rust:1.91-bookworm AS rust-builder
 
 WORKDIR /build
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -284,7 +284,7 @@ Workaround for [anthropics/claude-code#8938](https://github.com/anthropics/claud
 
 Two-stage Docker build:
 
-1. **Rust builder** (`rust:1.88-bookworm`) — compiles unleash with dependency caching
+1. **Rust builder** (`rust:1.91-bookworm`) — compiles unleash with dependency caching
 2. **Runtime** (`ubuntu:24.04`) — GLIBC 2.39 (required by Codex prebuilt binaries), Node 22, GitHub CLI, all agent CLIs installed via `unleash update`
 
 ### CLI Install Paths


### PR DESCRIPTION
## Summary
- Bumps `rust:1.90-bookworm` → `rust:1.91-bookworm` in both `docker/Dockerfile` and `docker/Dockerfile.cuda`
- Also updates the stale `1.88` mention in `docker/README.md`

## Why
Dependabot PR #255 (rusqlite 0.39 → 0.40) pulls `libsqlite3-sys 0.38.0`, which uses the `cfg_select!` macro. That macro stabilized in Rust 1.91, so the current 1.90-pinned Docker base fails both Docker jobs:

```
error[E0658]: use of unstable library feature `cfg_select`
   --> .../libsqlite3-sys-0.38.0/build.rs:110:9
```

Once this is in, #255 should go green and be safe to merge.

## Test plan
- [ ] Docker Build & CLI Install Test job passes on this PR
- [ ] Docker Publish job passes on this PR
- [ ] Rebase #255 onto main after merge → confirm its Docker jobs also pass