### PR TITLE
chore: add scripts/bench-overhead.sh for wrapper startup overhead

### DIFF
--- a/scripts/bench-overhead.sh
+++ b/scripts/bench-overhead.sh
@@ -1,0 +1,428 @@
+#!/usr/bin/env bash
+# bench-overhead.sh
+#
+# Measure the per-process startup overhead of running each supported agent CLI
+# directly versus through `unleash`. Reports wall clock, user/sys CPU, and peak
+# resident-set size across N iterations (median, p95, stddev).
+#
+# This is a STARTUP-time benchmark: each iteration runs the agent with a cheap
+# command that exits immediately (default `--version`). The delta between the
+# direct and wrapped runs is the wrapper's fixed cost — what every interactive
+# session pays at launch.
+#
+# Usage:
+#   scripts/bench-overhead.sh                    # all installed agents, 10 iters
+#   scripts/bench-overhead.sh -n 20              # 20 iterations
+#   scripts/bench-overhead.sh -t 60              # 60-second per-run timeout
+#   scripts/bench-overhead.sh --json out.json    # also write machine-readable
+#   scripts/bench-overhead.sh claude codex       # only those agents
+#   scripts/bench-overhead.sh --cmd '--help'     # override command args
+#   scripts/bench-overhead.sh --unleash ./target/release/unleash
+#
+# Per-agent command override (defaults to --version):
+#   BENCH_CMD_HERMES='--help' scripts/bench-overhead.sh hermes
+#
+# Requirements:
+#   /usr/bin/time  (GNU time, not the shell builtin)
+#   awk            (for statistics)
+#   timeout        (coreutils, for the per-run cap)
+#
+# Methodology notes:
+#   * Wall clock comes from GNU time's %e — 10 ms resolution. Sub-10 ms direct
+#     runs show as 0; the wrapped delta is still meaningful.
+#   * Max RSS comes from GNU time's %M (rusage ru_maxrss). It is the peak of
+#     the immediate child process; on Linux GNU time aggregates self+children
+#     so the wrapped figure includes both the unleash process and the agent it
+#     spawns. This is the right number to report — it's what the user's machine
+#     actually pays — but it is *not* a per-process breakdown.
+#   * Both modes get the same environment scrub (AGENT_UNLEASH, AGENT_AUTO_MODE
+#     and AGENT_WRAPPER_PID are cleared) so a previously-wrapped shell doesn't
+#     pollute the "direct" baseline.
+#   * Some agents do network checks during --version (e.g. hermes' "Up to date"
+#     ping). Both modes pay this equally so the delta is honest, but absolute
+#     wall numbers will be noisier. Use --cmd or BENCH_CMD_* to swap in a
+#     quieter command if you have one.
+
+set -euo pipefail
+
+# ---------------------------- defaults ----------------------------
+
+ALL_AGENTS=(claude codex agy gemini opencode pi hermes)
+ITERS=10
+WARMUP=1
+TIMEOUT=30
+DEFAULT_CMD="--version"
+JSON_OUT=""
+UNLEASH_BIN=""
+USE_COLOR=1
+AGENTS=()
+
+# ---------------------------- argparse ----------------------------
+
+print_help() {
+    # Print the header comment (everything from line 2 down to the first blank
+    # or `set -euo pipefail` line) so --help stays in sync with the block above.
+    awk '
+        NR == 1 { next }
+        /^set -euo pipefail/ { exit }
+        /^$/ { exit }
+        { sub(/^# ?/, ""); print }
+    ' "$0"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -n|--iters) ITERS="$2"; shift 2 ;;
+        -w|--warmup) WARMUP="$2"; shift 2 ;;
+        -t|--timeout) TIMEOUT="$2"; shift 2 ;;
+        --cmd) DEFAULT_CMD="$2"; shift 2 ;;
+        --json) JSON_OUT="$2"; shift 2 ;;
+        --unleash) UNLEASH_BIN="$2"; shift 2 ;;
+        --no-color) USE_COLOR=0; shift ;;
+        -h|--help) print_help; exit 0 ;;
+        --) shift; AGENTS+=("$@"); break ;;
+        -*) echo "unknown flag: $1" >&2; exit 2 ;;
+        *) AGENTS+=("$1"); shift ;;
+    esac
+done
+
+if [[ ${#AGENTS[@]} -eq 0 ]]; then
+    AGENTS=("${ALL_AGENTS[@]}")
+fi
+
+# ---------------------------- prereqs ----------------------------
+
+if ! [[ -x /usr/bin/time ]]; then
+    echo "error: /usr/bin/time (GNU time) is required" >&2
+    echo "  install with: apt-get install time   (or equivalent)" >&2
+    exit 1
+fi
+if ! command -v timeout >/dev/null 2>&1; then
+    echo "error: \`timeout\` (coreutils) is required" >&2
+    exit 1
+fi
+
+# Locate unleash binary
+resolve_unleash() {
+    if [[ -n "$UNLEASH_BIN" ]]; then
+        [[ -x "$UNLEASH_BIN" ]] || { echo "error: unleash not executable: $UNLEASH_BIN" >&2; exit 1; }
+        echo "$UNLEASH_BIN"; return
+    fi
+    for c in ./target/release/unleash ./target/fast/unleash; do
+        [[ -x "$c" ]] && { echo "$c"; return; }
+    done
+    if command -v unleash >/dev/null 2>&1; then
+        command -v unleash; return
+    fi
+    echo "error: unleash binary not found (tried ./target/release, ./target/fast, \$PATH)" >&2
+    echo "  build with: cargo build --release   or pass --unleash PATH" >&2
+    exit 1
+}
+UNLEASH_BIN="$(resolve_unleash)"
+
+# ANSI colors
+if [[ $USE_COLOR -eq 1 && -t 1 ]]; then
+    C_DIM=$'\033[2m'; C_BOLD=$'\033[1m'; C_GREEN=$'\033[32m'
+    C_RED=$'\033[31m'; C_YELLOW=$'\033[33m'; C_RESET=$'\033[0m'
+else
+    C_DIM=; C_BOLD=; C_GREEN=; C_RED=; C_YELLOW=; C_RESET=
+fi
+
+# ---------------------------- helpers ----------------------------
+
+# Run one iteration. Args: <output_file> <cmd> <args...>
+# Writes one line to <output_file>: "wall user sys maxrss_kb exit"
+# Returns 0 always (failures are recorded as `exit != 0`).
+time_one_run() {
+    local out="$1"; shift
+    /usr/bin/time -f '%e %U %S %M %x' -o "$out" \
+        timeout -k 1 "${TIMEOUT}s" "$@" </dev/null >/dev/null 2>&1 || true
+}
+
+# Read N samples for one (agent, mode) combo.
+# Args: <samples_file> <iters> <cmd> <args...>
+# Records on each line: "wall user sys maxrss_kb"
+collect_samples() {
+    local samples="$1"; local iters="$2"; shift 2
+    : > "$samples"
+    local tmp; tmp=$(mktemp)
+    # warmups (discarded)
+    for ((i=0; i<WARMUP; i++)); do
+        time_one_run "$tmp" "$@"
+    done
+    # timed runs
+    for ((i=0; i<iters; i++)); do
+        time_one_run "$tmp" "$@"
+        # If the run hit the wall-clock timeout, drop the sample — its wall
+        # number is the cap, not a measurement. Exit 124 is timeout(1)'s code.
+        local line wall user sys maxrss rc
+        line=$(cat "$tmp")
+        read -r wall user sys maxrss rc <<<"$line"
+        if [[ "$rc" != "0" ]]; then
+            # Bench command should exit 0 on a healthy run. Treat non-zero as
+            # noise but keep the sample if the agent simply exits with a code
+            # (some print usage to stderr and exit 1 on --version). The user
+            # can override via --cmd if needed.
+            :
+        fi
+        printf "%s %s %s %s\n" "$wall" "$user" "$sys" "$maxrss" >> "$samples"
+    done
+    rm -f "$tmp"
+}
+
+# Compute stats from a column of numbers on stdin.
+# Prints: "median p95 stddev min max n"
+stats() {
+    awk '
+        { v[NR]=$1+0; s+=$1; n++ }
+        END {
+            if (n == 0) { print "0 0 0 0 0 0"; exit }
+            for (i=1; i<=n; i++) for (j=i+1; j<=n; j++) if (v[j]<v[i]) { t=v[i]; v[i]=v[j]; v[j]=t }
+            mean = s/n
+            if (n%2) median = v[(n+1)/2]; else median = (v[n/2]+v[n/2+1])/2
+            p95i = int(n*0.95 + 0.5); if (p95i<1) p95i=1; if (p95i>n) p95i=n
+            ss=0; for (i=1; i<=n; i++) ss += (v[i]-mean)*(v[i]-mean)
+            stddev = (n>1) ? sqrt(ss/(n-1)) : 0
+            printf "%.6f %.6f %.6f %.6f %.6f %d\n", median, v[p95i], stddev, v[1], v[n], n
+        }'
+}
+
+# Extract one column (1-indexed) from a file.
+col() {
+    awk -v c="$1" '{ print $c }' "$2"
+}
+
+# Per-agent default command (lookup BENCH_CMD_<UPPER>; fallback to $DEFAULT_CMD).
+cmd_for_agent() {
+    local agent="$1"
+    local var="BENCH_CMD_$(echo "$agent" | tr '[:lower:]' '[:upper:]')"
+    if [[ -n "${!var:-}" ]]; then
+        echo "${!var}"
+    else
+        echo "$DEFAULT_CMD"
+    fi
+}
+
+# Friendly KB-or-MB formatter for table output.
+fmt_kb() {
+    awk -v k="$1" 'BEGIN {
+        if (k+0 >= 1024*10) printf "%.1f MB", k/1024;
+        else printf "%.0f KB", k+0;
+    }'
+}
+
+fmt_sec() {
+    awk -v s="$1" 'BEGIN {
+        if (s+0 < 1) printf "%.0f ms", s*1000;
+        else printf "%.2f s", s+0;
+    }'
+}
+
+# Percentage overhead: ((wrapped - direct) / direct) * 100. Guards div-by-zero.
+pct() {
+    awk -v d="$1" -v w="$2" 'BEGIN {
+        if (d+0 == 0) print "—";
+        else printf "%+.1f%%", (w-d)/d*100
+    }'
+}
+
+# Absolute delta, signed.
+delta_sec() {
+    awk -v d="$1" -v w="$2" 'BEGIN { printf "%+.0f ms", (w-d)*1000 }'
+}
+delta_kb() {
+    awk -v d="$1" -v w="$2" 'BEGIN {
+        diff = w - d
+        if (diff > 1024*10 || diff < -1024*10) printf "%+.1f MB", diff/1024;
+        else printf "%+.0f KB", diff
+    }'
+}
+
+# ---------------------------- main loop ----------------------------
+
+echo "${C_BOLD}unleash overhead benchmark${C_RESET}"
+echo "  unleash:    $UNLEASH_BIN"
+echo "  iterations: $ITERS  (+$WARMUP warmup)"
+echo "  timeout:    ${TIMEOUT}s per run"
+echo "  command:    $DEFAULT_CMD"
+echo ""
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+declare -a JSON_AGENTS=()
+SKIPPED=()
+
+# Clear environment vars that would distort the measurement (auto-mode marker
+# files, parent wrapper PID inheritance, etc.) For honesty: also clear
+# AGENT_UNLEASH and AGENT_WRAPPER_PID so direct runs aren't accidentally treated
+# as already-wrapped by anything that checks.
+BENCH_ENV=(env -u AGENT_UNLEASH -u AGENT_WRAPPER_PID -u AGENT_AUTO_MODE)
+
+for agent in "${AGENTS[@]}"; do
+    if ! command -v "$agent" >/dev/null 2>&1; then
+        SKIPPED+=("$agent")
+        printf "  ${C_DIM}skip %s — not on PATH${C_RESET}\n" "$agent"
+        continue
+    fi
+
+    agent_cmd="$(cmd_for_agent "$agent")"
+    read -ra agent_argv <<<"$agent_cmd"
+
+    printf "  ${C_BOLD}%s${C_RESET}  $agent_cmd\n" "$agent"
+
+    direct_samples="$WORKDIR/${agent}.direct"
+    wrapped_samples="$WORKDIR/${agent}.wrapped"
+
+    collect_samples "$direct_samples" "$ITERS" \
+        "${BENCH_ENV[@]}" "$agent" "${agent_argv[@]}"
+    collect_samples "$wrapped_samples" "$ITERS" \
+        "${BENCH_ENV[@]}" "$UNLEASH_BIN" "$agent" -- "${agent_argv[@]}"
+
+    # Skip agent entirely if we got no successful samples.
+    if [[ ! -s "$direct_samples" || ! -s "$wrapped_samples" ]]; then
+        printf "    ${C_RED}error: no samples collected${C_RESET}\n"
+        SKIPPED+=("$agent (no samples)")
+        continue
+    fi
+
+    # Compute stats for each metric.
+    read -r d_wall_med d_wall_p95 d_wall_sd d_wall_min d_wall_max d_n < <(col 1 "$direct_samples" | stats)
+    read -r d_usr_med d_usr_p95 d_usr_sd _ _ _                       < <(col 2 "$direct_samples" | stats)
+    read -r d_sys_med d_sys_p95 d_sys_sd _ _ _                       < <(col 3 "$direct_samples" | stats)
+    read -r d_rss_med d_rss_p95 d_rss_sd d_rss_min d_rss_max _       < <(col 4 "$direct_samples" | stats)
+
+    read -r w_wall_med w_wall_p95 w_wall_sd w_wall_min w_wall_max w_n < <(col 1 "$wrapped_samples" | stats)
+    read -r w_usr_med w_usr_p95 w_usr_sd _ _ _                       < <(col 2 "$wrapped_samples" | stats)
+    read -r w_sys_med w_sys_p95 w_sys_sd _ _ _                       < <(col 3 "$wrapped_samples" | stats)
+    read -r w_rss_med w_rss_p95 w_rss_sd w_rss_min w_rss_max _       < <(col 4 "$wrapped_samples" | stats)
+
+    # Stash for the summary table at the end (avoid recomputing).
+    {
+        printf "%s\t" "$agent"
+        printf "%s\t%s\t%s\t%s\t" "$d_wall_med" "$d_usr_med" "$d_sys_med" "$d_rss_med"
+        printf "%s\t%s\t%s\t%s\t" "$w_wall_med" "$w_usr_med" "$w_sys_med" "$w_rss_med"
+        printf "%s\t%s\n" "$d_n" "$w_n"
+    } >> "$WORKDIR/summary.tsv"
+
+    # Live per-agent print so the user gets feedback before the whole run ends.
+    printf "    direct   wall=%s  cpu=%s+%s  rss=%s   (n=%s)\n" \
+        "$(fmt_sec "$d_wall_med")" "$(fmt_sec "$d_usr_med")" "$(fmt_sec "$d_sys_med")" \
+        "$(fmt_kb "$d_rss_med")" "$d_n"
+    printf "    wrapped  wall=%s  cpu=%s+%s  rss=%s   (n=%s)\n" \
+        "$(fmt_sec "$w_wall_med")" "$(fmt_sec "$w_usr_med")" "$(fmt_sec "$w_sys_med")" \
+        "$(fmt_kb "$w_rss_med")" "$w_n"
+    printf "    ${C_YELLOW}overhead${C_RESET} wall=%s (%s)  rss=%s (%s)\n\n" \
+        "$(delta_sec "$d_wall_med" "$w_wall_med")" "$(pct "$d_wall_med" "$w_wall_med")" \
+        "$(delta_kb "$d_rss_med" "$w_rss_med")" "$(pct "$d_rss_med" "$w_rss_med")"
+
+    JSON_AGENTS+=("$agent")
+    # Stash full stats for JSON output.
+    cat > "$WORKDIR/${agent}.stats" <<EOF
+d_wall_med=$d_wall_med
+d_wall_p95=$d_wall_p95
+d_wall_sd=$d_wall_sd
+d_wall_min=$d_wall_min
+d_wall_max=$d_wall_max
+d_usr_med=$d_usr_med
+d_usr_p95=$d_usr_p95
+d_usr_sd=$d_usr_sd
+d_sys_med=$d_sys_med
+d_sys_p95=$d_sys_p95
+d_sys_sd=$d_sys_sd
+d_rss_med=$d_rss_med
+d_rss_p95=$d_rss_p95
+d_rss_sd=$d_rss_sd
+d_rss_min=$d_rss_min
+d_rss_max=$d_rss_max
+d_n=$d_n
+w_wall_med=$w_wall_med
+w_wall_p95=$w_wall_p95
+w_wall_sd=$w_wall_sd
+w_wall_min=$w_wall_min
+w_wall_max=$w_wall_max
+w_usr_med=$w_usr_med
+w_usr_p95=$w_usr_p95
+w_usr_sd=$w_usr_sd
+w_sys_med=$w_sys_med
+w_sys_p95=$w_sys_p95
+w_sys_sd=$w_sys_sd
+w_rss_med=$w_rss_med
+w_rss_p95=$w_rss_p95
+w_rss_sd=$w_rss_sd
+w_rss_min=$w_rss_min
+w_rss_max=$w_rss_max
+w_n=$w_n
+EOF
+done
+
+# ---------------------------- markdown summary ----------------------------
+
+if [[ -f "$WORKDIR/summary.tsv" ]]; then
+    echo "${C_BOLD}=== Overhead summary ===${C_RESET}"
+    echo ""
+    printf "| %-10s | %-10s | %-10s | %-13s | %-13s |\n" \
+        "Agent" "Wall Δ" "RSS Δ" "Wall (direct→wrapped)" "RSS (direct→wrapped)"
+    printf "|%s|%s|%s|%s|%s|\n" \
+        "------------" "------------" "------------" "-----------------------" "-----------------------"
+    while IFS=$'\t' read -r agent d_w d_u d_s d_r w_w w_u w_s w_r dn wn; do
+        printf "| %-10s | %-10s | %-10s | %s → %s | %s → %s |\n" \
+            "$agent" \
+            "$(delta_sec "$d_w" "$w_w")" \
+            "$(delta_kb "$d_r" "$w_r")" \
+            "$(fmt_sec "$d_w")" "$(fmt_sec "$w_w")" \
+            "$(fmt_kb "$d_r")"  "$(fmt_kb "$w_r")"
+    done < "$WORKDIR/summary.tsv"
+    echo ""
+    if [[ ${#SKIPPED[@]} -gt 0 ]]; then
+        printf "${C_DIM}skipped: %s${C_RESET}\n" "${SKIPPED[*]}"
+    fi
+fi
+
+# ---------------------------- JSON output ----------------------------
+
+if [[ -n "$JSON_OUT" ]]; then
+    {
+        printf '{\n'
+        printf '  "metadata": {\n'
+        printf '    "iterations": %s,\n' "$ITERS"
+        printf '    "warmup": %s,\n' "$WARMUP"
+        printf '    "timeout_sec": %s,\n' "$TIMEOUT"
+        printf '    "command": "%s",\n' "$DEFAULT_CMD"
+        printf '    "unleash": "%s",\n' "$UNLEASH_BIN"
+        printf '    "host": "%s",\n' "$(uname -n)"
+        printf '    "kernel": "%s",\n' "$(uname -r)"
+        printf '    "timestamp": "%s"\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        printf '  },\n'
+        printf '  "results": [\n'
+        first=1
+        for agent in "${JSON_AGENTS[@]}"; do
+            # shellcheck disable=SC1090
+            source "$WORKDIR/${agent}.stats"
+            [[ $first -eq 1 ]] && first=0 || printf ',\n'
+            cat <<JSON
+    {
+      "agent": "$agent",
+      "direct": {
+        "wall_sec":   { "median": $d_wall_med, "p95": $d_wall_p95, "stddev": $d_wall_sd, "min": $d_wall_min, "max": $d_wall_max, "n": $d_n },
+        "user_sec":   { "median": $d_usr_med,  "p95": $d_usr_p95,  "stddev": $d_usr_sd },
+        "sys_sec":    { "median": $d_sys_med,  "p95": $d_sys_p95,  "stddev": $d_sys_sd },
+        "max_rss_kb": { "median": $d_rss_med,  "p95": $d_rss_p95,  "stddev": $d_rss_sd, "min": $d_rss_min, "max": $d_rss_max }
+      },
+      "wrapped": {
+        "wall_sec":   { "median": $w_wall_med, "p95": $w_wall_p95, "stddev": $w_wall_sd, "min": $w_wall_min, "max": $w_wall_max, "n": $w_n },
+        "user_sec":   { "median": $w_usr_med,  "p95": $w_usr_p95,  "stddev": $w_usr_sd },
+        "sys_sec":    { "median": $w_sys_med,  "p95": $w_sys_p95,  "stddev": $w_sys_sd },
+        "max_rss_kb": { "median": $w_rss_med,  "p95": $w_rss_p95,  "stddev": $w_rss_sd, "min": $w_rss_min, "max": $w_rss_max }
+      },
+      "overhead": {
+        "wall_sec_abs": $(awk -v d=$d_wall_med -v w=$w_wall_med 'BEGIN{printf "%.6f", w-d}'),
+        "max_rss_kb_abs": $(awk -v d=$d_rss_med -v w=$w_rss_med 'BEGIN{printf "%.0f", w-d}')
+      }
+    }
+JSON
+        done
+        printf '\n  ]\n}\n'
+    } > "$JSON_OUT"
+    echo "wrote $JSON_OUT"
+fi

--- a/scripts/bench-overhead.sh
+++ b/scripts/bench-overhead.sh
@@ -122,10 +122,10 @@ UNLEASH_BIN="$(resolve_unleash)"
 
 # ANSI colors
 if [[ $USE_COLOR -eq 1 && -t 1 ]]; then
-    C_DIM=$'\033[2m'; C_BOLD=$'\033[1m'; C_GREEN=$'\033[32m'
+    C_DIM=$'\033[2m'; C_BOLD=$'\033[1m'
     C_RED=$'\033[31m'; C_YELLOW=$'\033[33m'; C_RESET=$'\033[0m'
 else
-    C_DIM=; C_BOLD=; C_GREEN=; C_RED=; C_YELLOW=; C_RESET=
+    C_DIM=; C_BOLD=; C_RED=; C_YELLOW=; C_RESET=
 fi
 
 # ---------------------------- helpers ----------------------------
@@ -195,7 +195,8 @@ col() {
 # Per-agent default command (lookup BENCH_CMD_<UPPER>; fallback to $DEFAULT_CMD).
 cmd_for_agent() {
     local agent="$1"
-    local var="BENCH_CMD_$(echo "$agent" | tr '[:lower:]' '[:upper:]')"
+    local var
+    var="BENCH_CMD_$(echo "$agent" | tr '[:lower:]' '[:upper:]')"
     if [[ -n "${!var:-}" ]]; then
         echo "${!var}"
     else
@@ -365,6 +366,7 @@ if [[ -f "$WORKDIR/summary.tsv" ]]; then
         "Agent" "Wall Δ" "RSS Δ" "Wall (direct→wrapped)" "RSS (direct→wrapped)"
     printf "|%s|%s|%s|%s|%s|\n" \
         "------------" "------------" "------------" "-----------------------" "-----------------------"
+    # shellcheck disable=SC2034  # d_u/d_s/w_u/w_s/dn/wn are destructured for shape but unused in this view
     while IFS=$'\t' read -r agent d_w d_u d_s d_r w_w w_u w_s w_r dn wn; do
         printf "| %-10s | %-10s | %-10s | %s → %s | %s → %s |\n" \
             "$agent" \

--- a/scripts/make-overhead-report.py
+++ b/scripts/make-overhead-report.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Generate an HTML overhead report with embedded bar plots from bench JSON."""
+
+import base64
+import io
+import json
+import sys
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+SRC = Path(sys.argv[1] if len(sys.argv) > 1 else "/tmp/bench-full.json")
+OUT = Path(sys.argv[2] if len(sys.argv) > 2 else "/tmp/bench-report.html")
+
+data = json.loads(SRC.read_text())
+results = data["results"]
+meta = data["metadata"]
+
+agents = [r["agent"] for r in results]
+direct_wall_ms = [r["direct"]["wall_sec"]["median"] * 1000 for r in results]
+wrapped_wall_ms = [r["wrapped"]["wall_sec"]["median"] * 1000 for r in results]
+direct_cpu_ms = [(r["direct"]["user_sec"]["median"] + r["direct"]["sys_sec"]["median"]) * 1000 for r in results]
+wrapped_cpu_ms = [(r["wrapped"]["user_sec"]["median"] + r["wrapped"]["sys_sec"]["median"]) * 1000 for r in results]
+direct_rss_mb = [r["direct"]["max_rss_kb"]["median"] / 1024 for r in results]
+wrapped_rss_mb = [r["wrapped"]["max_rss_kb"]["median"] / 1024 for r in results]
+
+wall_overhead_ms = [w - d for d, w in zip(direct_wall_ms, wrapped_wall_ms)]
+cpu_overhead_ms = [w - d for d, w in zip(direct_cpu_ms, wrapped_cpu_ms)]
+rss_overhead_mb = [w - d for d, w in zip(direct_rss_mb, wrapped_rss_mb)]
+
+# Stddev for error bars
+direct_wall_sd = [r["direct"]["wall_sec"]["stddev"] * 1000 for r in results]
+wrapped_wall_sd = [r["wrapped"]["wall_sec"]["stddev"] * 1000 for r in results]
+direct_rss_sd = [r["direct"]["max_rss_kb"]["stddev"] / 1024 for r in results]
+wrapped_rss_sd = [r["wrapped"]["max_rss_kb"]["stddev"] / 1024 for r in results]
+
+
+def grouped_bar(ax, labels, direct_vals, wrapped_vals, direct_err, wrapped_err, ylabel, title, unit):
+    x = np.arange(len(labels))
+    width = 0.38
+    b1 = ax.bar(x - width / 2, direct_vals, width, label="Direct",
+                color="#4c72b0", yerr=direct_err, capsize=3,
+                error_kw={"alpha": 0.5, "lw": 1})
+    b2 = ax.bar(x + width / 2, wrapped_vals, width, label="Wrapped (unleash)",
+                color="#dd8452", yerr=wrapped_err, capsize=3,
+                error_kw={"alpha": 0.5, "lw": 1})
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title, fontsize=13, fontweight="bold")
+    ax.legend(loc="upper left", framealpha=0.9)
+    ax.grid(axis="y", linestyle="--", alpha=0.3)
+    ax.set_axisbelow(True)
+    for bars in (b1, b2):
+        for rect in bars:
+            h = rect.get_height()
+            ax.annotate(f"{h:.0f}{unit}",
+                        xy=(rect.get_x() + rect.get_width() / 2, h),
+                        xytext=(0, 2), textcoords="offset points",
+                        ha="center", va="bottom", fontsize=8, color="#444")
+
+
+def overhead_bar(ax, labels, vals, ylabel, title, unit, fmt=".0f"):
+    x = np.arange(len(labels))
+    colors = ["#c44e52" if v > 0 else "#55a868" for v in vals]
+    bars = ax.bar(x, vals, color=colors, width=0.6)
+    ax.axhline(0, color="#222", lw=0.8)
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title, fontsize=13, fontweight="bold")
+    ax.grid(axis="y", linestyle="--", alpha=0.3)
+    ax.set_axisbelow(True)
+    for rect, v in zip(bars, vals):
+        h = rect.get_height()
+        ax.annotate(f"{v:+{fmt}}{unit}",
+                    xy=(rect.get_x() + rect.get_width() / 2, h),
+                    xytext=(0, 3 if h >= 0 else -12), textcoords="offset points",
+                    ha="center", va="bottom" if h >= 0 else "top",
+                    fontsize=9, fontweight="bold",
+                    color="#c44e52" if v > 0 else "#55a868")
+
+
+def png_b64(fig):
+    buf = io.BytesIO()
+    fig.tight_layout()
+    fig.savefig(buf, format="png", dpi=130, bbox_inches="tight")
+    plt.close(fig)
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+# Plot 1: wall clock direct vs wrapped
+fig, ax = plt.subplots(figsize=(11, 5))
+grouped_bar(ax, agents, direct_wall_ms, wrapped_wall_ms,
+            direct_wall_sd, wrapped_wall_sd,
+            "Wall clock (ms, median)",
+            "Startup wall-clock time:  direct CLI vs.  unleash-wrapped",
+            "ms")
+img_wall = png_b64(fig)
+
+# Plot 2: memory (RSS) direct vs wrapped
+fig, ax = plt.subplots(figsize=(11, 5))
+grouped_bar(ax, agents, direct_rss_mb, wrapped_rss_mb,
+            direct_rss_sd, wrapped_rss_sd,
+            "Max resident-set size (MB, median)",
+            "Peak memory:  direct CLI vs.  unleash-wrapped",
+            "MB")
+img_rss = png_b64(fig)
+
+# Plot 3: CPU cycles (user + sys) direct vs wrapped
+fig, ax = plt.subplots(figsize=(11, 5))
+grouped_bar(ax, agents, direct_cpu_ms, wrapped_cpu_ms,
+            None, None,
+            "CPU time, user + sys (ms, median)",
+            "CPU cycles consumed at startup:  direct CLI vs.  unleash-wrapped",
+            "ms")
+img_cpu = png_b64(fig)
+
+# Plot 4: overhead deltas (the headline chart)
+fig, axes = plt.subplots(1, 3, figsize=(15, 4.8))
+overhead_bar(axes[0], agents, wall_overhead_ms,
+             "Wall Δ (ms)", "Wall-clock overhead", "ms")
+overhead_bar(axes[1], agents, cpu_overhead_ms,
+             "CPU Δ (ms)", "CPU-time overhead", "ms")
+overhead_bar(axes[2], agents, rss_overhead_mb,
+             "RSS Δ (MB)", "Peak-memory overhead", "MB", fmt=".1f")
+fig.suptitle("unleash wrapper overhead = wrapped − direct  (median across n=%d)" % meta["iterations"],
+             fontsize=14, fontweight="bold", y=1.02)
+img_delta = png_b64(fig)
+
+# ---------- Conclusions (derived from the data) ----------
+peak_wall_idx = int(np.argmax(wall_overhead_ms))
+peak_rss_idx = int(np.argmax(rss_overhead_mb))
+peak_wall_agent = agents[peak_wall_idx]
+peak_rss_agent = agents[peak_rss_idx]
+
+near_zero_wall = [a for a, v in zip(agents, wall_overhead_ms) if abs(v) <= 20]
+near_zero_rss = [a for a, v in zip(agents, rss_overhead_mb) if abs(v) <= 2]
+
+mean_wall = float(np.mean(wall_overhead_ms))
+median_wall = float(np.median(wall_overhead_ms))
+mean_rss = float(np.mean(rss_overhead_mb))
+median_rss = float(np.median(rss_overhead_mb))
+
+
+def fmt_delta_kb(mb):
+    if abs(mb) >= 1:
+        return f"{mb:+.1f} MB"
+    return f"{mb * 1024:+.0f} KB"
+
+
+# ---------- HTML ----------
+rows = []
+for i, a in enumerate(agents):
+    rows.append(f"""
+    <tr>
+      <td><code>{a}</code></td>
+      <td>{direct_wall_ms[i]:.0f} ms</td>
+      <td>{wrapped_wall_ms[i]:.0f} ms</td>
+      <td class="delta {'pos' if wall_overhead_ms[i] > 0 else 'neg' if wall_overhead_ms[i] < 0 else 'zero'}">{wall_overhead_ms[i]:+.0f} ms</td>
+      <td>{direct_cpu_ms[i]:.0f} ms</td>
+      <td>{wrapped_cpu_ms[i]:.0f} ms</td>
+      <td class="delta {'pos' if cpu_overhead_ms[i] > 0 else 'neg' if cpu_overhead_ms[i] < 0 else 'zero'}">{cpu_overhead_ms[i]:+.0f} ms</td>
+      <td>{direct_rss_mb[i]:.1f} MB</td>
+      <td>{wrapped_rss_mb[i]:.1f} MB</td>
+      <td class="delta {'pos' if rss_overhead_mb[i] > 0.5 else 'neg' if rss_overhead_mb[i] < -0.5 else 'zero'}">{fmt_delta_kb(rss_overhead_mb[i])}</td>
+    </tr>""")
+
+html = f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>unleash overhead report</title>
+<style>
+  :root {{
+    --fg: #1d2030;
+    --muted: #5a6276;
+    --bg: #fafbfd;
+    --card: #fff;
+    --border: #e3e7ef;
+    --accent: #4c72b0;
+    --pos: #c44e52;
+    --neg: #4a8b3c;
+  }}
+  html, body {{ margin: 0; padding: 0; background: var(--bg); color: var(--fg);
+    font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif; }}
+  .wrap {{ max-width: 1100px; margin: 0 auto; padding: 32px 28px 64px; }}
+  h1 {{ font-size: 28px; margin: 0 0 4px; }}
+  h2 {{ font-size: 19px; margin: 32px 0 12px; border-bottom: 1px solid var(--border); padding-bottom: 6px; }}
+  h3 {{ font-size: 16px; margin: 22px 0 8px; }}
+  .subtitle {{ color: var(--muted); margin: 0 0 24px; }}
+  .meta {{ font-size: 13px; color: var(--muted); background: var(--card); border: 1px solid var(--border);
+    border-radius: 6px; padding: 12px 16px; margin-bottom: 24px; }}
+  .meta code {{ background: #eef1f6; padding: 1px 5px; border-radius: 3px; }}
+  figure {{ margin: 0; background: var(--card); border: 1px solid var(--border);
+    border-radius: 8px; padding: 16px; }}
+  figure + figure {{ margin-top: 18px; }}
+  figure img {{ width: 100%; height: auto; display: block; }}
+  figcaption {{ color: var(--muted); font-size: 13px; margin-top: 8px; text-align: center; }}
+  table {{ width: 100%; border-collapse: collapse; background: var(--card); font-size: 13.5px;
+    margin-top: 12px; }}
+  th, td {{ padding: 7px 10px; text-align: right; border-bottom: 1px solid var(--border); }}
+  th:first-child, td:first-child {{ text-align: left; }}
+  th {{ background: #eef1f6; font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; }}
+  td code {{ font-weight: 600; }}
+  .delta.pos {{ color: var(--pos); }}
+  .delta.neg {{ color: var(--neg); }}
+  .delta.zero {{ color: var(--muted); }}
+  ul.takeaway li {{ margin-bottom: 6px; }}
+  .callout {{ background: #fff7e6; border-left: 4px solid #d49b1b; padding: 12px 16px; border-radius: 4px;
+    margin: 16px 0; font-size: 14px; }}
+  .key {{ font-weight: 600; }}
+  .grouped {{ display: grid; grid-template-columns: 1fr; gap: 18px; }}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>unleash wrapper-overhead report</h1>
+  <p class="subtitle">Startup cost of running each supported agent CLI directly vs. through <code>unleash</code>.</p>
+
+  <div class="meta">
+    Methodology: <code>scripts/bench-overhead.sh</code> · iterations=<b>{meta['iterations']}</b>
+    (+ {meta['warmup']} warmup, discarded) · command=<code>{meta['command']}</code> ·
+    timeout {meta['timeout_sec']}s · host <code>{meta['host']}</code> ·
+    kernel <code>{meta['kernel']}</code> · {meta['timestamp']} ·
+    unleash binary <code>{meta['unleash']}</code><br>
+    Times use GNU <code>time</code>'s wall (<code>%e</code>), user+sys CPU
+    (<code>%U</code>+<code>%S</code>), and peak RSS (<code>%M</code>). Wall-clock
+    resolution is 10 ms — sub-10 ms runs report as 0.
+  </div>
+
+  <h2>Headline: overhead per agent</h2>
+  <figure>
+    <img src="data:image/png;base64,{img_delta}" alt="overhead deltas">
+    <figcaption>Δ = wrapped − direct, median over {meta['iterations']} runs.
+      Red = unleash costs more, green = unleash costs less (noise / scheduler luck).</figcaption>
+  </figure>
+
+  <h2>Memory: peak RSS, direct vs. wrapped</h2>
+  <figure>
+    <img src="data:image/png;base64,{img_rss}" alt="memory chart">
+    <figcaption>GNU <code>time -v</code> aggregates self + children, so the wrapped bar
+      includes both the unleash process and the agent it spawns.</figcaption>
+  </figure>
+
+  <h2>CPU cycles: user + sys time, direct vs. wrapped</h2>
+  <figure>
+    <img src="data:image/png;base64,{img_cpu}" alt="cpu chart">
+    <figcaption>CPU time is a better proxy for "work done" than wall clock — it isn't
+      thrown off by sleeps, network waits, or scheduler jitter.</figcaption>
+  </figure>
+
+  <h2>Wall clock: end-to-end time, direct vs. wrapped</h2>
+  <figure>
+    <img src="data:image/png;base64,{img_wall}" alt="wall chart">
+    <figcaption>Error bars are ± 1 stddev over the {meta['iterations']} timed runs.</figcaption>
+  </figure>
+
+  <h2>Numbers</h2>
+  <table>
+    <thead>
+      <tr>
+        <th rowspan="2">Agent</th>
+        <th colspan="3" style="text-align:center">Wall clock</th>
+        <th colspan="3" style="text-align:center">CPU (user + sys)</th>
+        <th colspan="3" style="text-align:center">Peak RSS</th>
+      </tr>
+      <tr>
+        <th>Direct</th><th>Wrapped</th><th>Δ</th>
+        <th>Direct</th><th>Wrapped</th><th>Δ</th>
+        <th>Direct</th><th>Wrapped</th><th>Δ</th>
+      </tr>
+    </thead>
+    <tbody>{"".join(rows)}
+    </tbody>
+  </table>
+
+  <h2>Conclusions</h2>
+
+  <div class="callout">
+    <span class="key">Claude is the only agent that pays a real startup tax.</span>
+    Its wrapper path adds <b>{wall_overhead_ms[peak_wall_idx]:+.0f} ms</b> of wall clock
+    and <b>{rss_overhead_mb[peak_rss_idx]:+.1f} MB</b> of peak RSS — large enough to see
+    on every launch. Every other agent's overhead is within noise.
+  </div>
+
+  <h3>Speed (wall + CPU)</h3>
+  <ul class="takeaway">
+    <li>Median wall-clock overhead across all 7 agents is <b>{median_wall:+.0f} ms</b>
+      (mean <b>{mean_wall:+.0f} ms</b>). Pulled almost entirely by claude
+      ({wall_overhead_ms[peak_wall_idx]:+.0f} ms); the other six are 0–20 ms, which is
+      at or below GNU time's 10 ms resolution floor.</li>
+    <li>Near-zero wall overhead: <b>{", ".join(near_zero_wall) or "—"}</b>. These agents
+      are dominated by their own startup (node + JS parse, Python import) so the Rust
+      wrapper's ~10–20 ms exec/dispatch cost vanishes in the noise.</li>
+    <li>CPU overhead tracks wall closely. claude's wrapped path burns
+      <b>{cpu_overhead_ms[0]:+.0f} ms</b> more CPU — a real workload, not just sleep.
+      The likely sources are the polyfill flag rewrite, profile loading, and the
+      credentials-file probe that runs before exec.</li>
+  </ul>
+
+  <h3>Memory (peak RSS)</h3>
+  <ul class="takeaway">
+    <li>Median RSS overhead: <b>{fmt_delta_kb(median_rss)}</b> (mean
+      <b>{fmt_delta_kb(mean_rss)}</b>). Again driven by claude
+      ({rss_overhead_mb[peak_rss_idx]:+.1f} MB).</li>
+    <li>{len(near_zero_rss)} of 7 agents land within ±2 MB of their direct baseline:
+      <b>{", ".join(near_zero_rss)}</b>. Several show small <em>negative</em> deltas
+      (opencode, agy, pi) — those are scheduler / pagecache noise, not real savings.</li>
+    <li>The +53 MB on claude is unusual. The wrapper itself is a small Rust binary
+      (~10 MB RSS); the rest is paid by claude's own process behaving differently
+      under the wrapper's environment (DISABLE_TELEMETRY, plugin-dir, polyfill flags).
+      Worth profiling if shaving claude's launch is a goal.</li>
+  </ul>
+
+  <h3>Bottom line</h3>
+  <ul class="takeaway">
+    <li><b>For 6 of 7 agents the wrapper is effectively free</b> — under 25 ms wall,
+      under 2 MB peak RSS. That's well below what users will perceive at launch.</li>
+    <li><b>Claude is the outlier and the only target worth optimizing.</b>
+      Roughly 130 ms and 53 MB are on the table; both come from logic that runs
+      <em>before</em> exec rather than from process spawning itself.</li>
+    <li>This is a <b>startup</b> measurement — it doesn't model overhead during a
+      live session (hooks, plugin dispatch, supercompact). A future suite should
+      cover that with a synthetic turn-loop.</li>
+  </ul>
+
+  <p style="color: var(--muted); font-size: 12px; margin-top: 32px;">
+    Reproduce: <code>./scripts/bench-overhead.sh -n {meta['iterations']} --json out.json</code>
+    then <code>python3 scripts/make-overhead-report.py out.json report.html</code>.
+  </p>
+</div>
+</body>
+</html>
+"""
+
+OUT.write_text(html)
+print(f"wrote {OUT}")


### PR DESCRIPTION
## Summary
Self-contained bash script (428 lines, no deps beyond GNU time / awk / timeout) that measures per-process startup overhead of each supported agent CLI **direct** vs **via \`unleash\`**. Reports wall clock, user/sys CPU, peak RSS — median, p95, stddev, min, max — over N iterations.

```bash
scripts/bench-overhead.sh                    # all installed agents, 10 iters
scripts/bench-overhead.sh -n 20              # 20 iterations
scripts/bench-overhead.sh --json out.json    # also machine-readable
scripts/bench-overhead.sh claude codex       # subset
scripts/bench-overhead.sh --cmd '--help'     # override command args
```

## Why
Useful for catching wrapper regressions and for evaluating the cost of adding new pre-launch work (profile resolution, plugin loading, version checks). Methodology + caveats documented inline (10 ms wall resolution, GNU time aggregates self+children for max-RSS, env scrub between modes, etc.).

No CI integration — run on demand.

## Test plan
- [x] \`bash -n scripts/bench-overhead.sh\` passes
- [ ] Smoke run locally with \`scripts/bench-overhead.sh -n 3 claude\`