### PR TITLE
ci: bump docker rust 1.91 → 1.95 (cfg_select! actually stable here)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@
 # ============================================================
 # Stage 1: Build unleash from Rust source
 # ============================================================
-FROM rust:1.91-bookworm AS rust-builder
+FROM rust:1.95-bookworm AS rust-builder
 
 WORKDIR /build
 

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -22,7 +22,7 @@
 # ============================================================
 # Stage 1: Build unleash from Rust source
 # ============================================================
-FROM rust:1.91-bookworm AS rust-builder
+FROM rust:1.95-bookworm AS rust-builder
 
 WORKDIR /build
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -284,7 +284,7 @@ Workaround for [anthropics/claude-code#8938](https://github.com/anthropics/claud
 
 Two-stage Docker build:
 
-1. **Rust builder** (`rust:1.91-bookworm`) — compiles unleash with dependency caching
+1. **Rust builder** (`rust:1.95-bookworm`) — compiles unleash with dependency caching
 2. **Runtime** (`ubuntu:24.04`) — GLIBC 2.39 (required by Codex prebuilt binaries), Node 22, GitHub CLI, all agent CLIs installed via `unleash update`
 
 ### CLI Install Paths


### PR DESCRIPTION
## Summary

- Bump `rust:1.91-bookworm` → `rust:1.95-bookworm` in both Dockerfiles
- Update README mention of the builder image version
- Unblocks #255 (rusqlite 0.39 → 0.40 → libsqlite3-sys 0.38.0)

## Why

PR #256 bumped to 1.91 on the assumption that `cfg_select!` was stabilized there. Empirically wrong: bisect across `rust:1.91 / 1.92 / 1.93 / 1.94 / 1.95-bookworm` shows the macro still emits **E0658 (unstable feature `cfg_select`, tracking issue #115585)** on 1.94, and only becomes stable on 1.95.

Verified with a minimal repro inside each image:

```rust
fn main() {
    let x = core::cfg_select! { unix => "unix", _ => "other" };
    println!("{}", x);
}
```

- `rust:1.91-bookworm` (rustc 1.91.1) — E0658
- `rust:1.92-bookworm` (rustc 1.92.0) — E0658
- `rust:1.93-bookworm` (rustc 1.93.1) — E0658
- `rust:1.94-bookworm` (rustc 1.94.x)  — E0658
- `rust:1.95-bookworm` (rustc 1.95.0) — clean
- `rust:1.96-bookworm` (rustc 1.96.0) — clean

## Test plan

- [ ] Docker build (Dockerfile) green
- [ ] Docker push (Dockerfile) green
- [ ] After this lands, rebase #255 and confirm rusqlite 0.40 Docker builds