### PR TITLE
perf(launcher): short-circuit meta commands to bypass plugin-init tax (refs #258)

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -43,6 +43,37 @@ fn detect_agent_type(cmd: &Path) -> Option<AgentType> {
     AgentType::from_str(name)
 }
 
+/// Returns true if the args contain a short-lived "meta" command that
+/// doesn't need the wrapper's machinery — version, help, doctor.
+///
+/// These short-circuit the wrapper so claude doesn't pay the ~100 ms /
+/// ~54 MB plugin-init tax it incurs whenever `--dangerously-skip-permissions`
+/// or `--plugin-dir` is on its argv. Meaningful for hot paths like
+/// `unleash claude --version`, CI smoke tests, and the many hook subprocesses
+/// that re-enter unleash during a session.
+pub(crate) fn is_meta_command(args: &[String]) -> bool {
+    args.iter().any(|a| {
+        matches!(
+            a.as_str(),
+            "--version" | "-V" | "--help" | "-h" | "doctor"
+        )
+    })
+}
+
+/// Exec the agent directly with profile env — no plugins, no permissions
+/// flag, no hook sync, no telemetry scrub. Used for meta commands.
+pub(crate) fn exec_meta_command(
+    agent_cmd: &PathBuf,
+    args: &[String],
+    profile_env: &HashMap<String, String>,
+) -> io::Result<i32> {
+    let status = Command::new(agent_cmd)
+        .args(args)
+        .envs(profile_env)
+        .status()?;
+    Ok(status.code().unwrap_or(1))
+}
+
 /// Configuration for [`run_loop`]: bundles the inputs the auto-mode restart
 /// state machine needs without having to read from the user's profile, env,
 /// or `dirs::cache_dir()`. Production callers build this from real config in
@@ -224,6 +255,20 @@ pub fn run_loop(config: LauncherConfig) -> io::Result<i32> {
 
 /// Run an agent with wrapper features
 pub fn run(auto_mode: bool, prompt: Option<String>, extra_args: Vec<String>) -> io::Result<()> {
+    // Meta-command short-circuit: --version / --help / doctor never need
+    // hooks, plugins, permissions, or the restart loop. Exec the agent bare
+    // with just profile env. Recovers the +100 ms / +54 MB claude pays for
+    // wrapper-added flags on short-lived invocations (#258).
+    if is_meta_command(&extra_args) {
+        let agent_cmd = find_agent_command()?;
+        let profile_env = load_profile_env()?;
+        let exit_code = exec_meta_command(&agent_cmd, &extra_args, &profile_env)?;
+        if exit_code == 0 {
+            return Ok(());
+        }
+        std::process::exit(exit_code);
+    }
+
     // Sync hooks: install defaults + merge plugin hooks into settings.json
     // Plugin hooks must be in settings.json because Claude Code may not reliably
     // load hooks from --plugin-dir when settings.json already has the event key.
@@ -671,4 +716,48 @@ pub fn trigger_exit(wrapper_pid: u32) -> io::Result<()> {
     kill(Pid::from_raw(wrapper_pid as i32), Signal::SIGTERM).map_err(io::Error::other)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(args: &[&str]) -> Vec<String> {
+        args.iter().map(|a| a.to_string()).collect()
+    }
+
+    #[test]
+    fn meta_command_detects_version_long_and_short() {
+        assert!(is_meta_command(&s(&["--version"])));
+        assert!(is_meta_command(&s(&["-V"])));
+    }
+
+    #[test]
+    fn meta_command_detects_help_long_and_short() {
+        assert!(is_meta_command(&s(&["--help"])));
+        assert!(is_meta_command(&s(&["-h"])));
+    }
+
+    #[test]
+    fn meta_command_detects_doctor_subcommand() {
+        assert!(is_meta_command(&s(&["doctor"])));
+    }
+
+    #[test]
+    fn meta_command_detected_anywhere_in_argv() {
+        // Some agents accept the flag mid-argv.
+        assert!(is_meta_command(&s(&["--foo", "bar", "--version"])));
+        assert!(is_meta_command(&s(&["doctor", "--verbose"])));
+    }
+
+    #[test]
+    fn meta_command_ignores_interactive_invocations() {
+        assert!(!is_meta_command(&s(&[])));
+        assert!(!is_meta_command(&s(&["--print", "hello"])));
+        assert!(!is_meta_command(&s(&["--resume"])));
+        assert!(!is_meta_command(&s(&["-p", "do thing"])));
+        // Substrings must not match — only exact arg equality.
+        assert!(!is_meta_command(&s(&["--version-check"])));
+        assert!(!is_meta_command(&s(&["--help-mcp"])));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,6 +304,20 @@ fn run_agent_with_polyfill(
         }
     };
 
+    // Meta-command short-circuit: --version / --help / doctor never need
+    // polyfill yolo flags, plugin-dir discovery, hook sync, or session setup.
+    // Skip straight to exec'ing the bare agent binary with profile env so
+    // claude doesn't pay its plugin-init tax for `unleash claude --version`.
+    // See issue #258 and docs/benchmarks/overhead-2026-06-01.html.
+    if launcher::is_meta_command(&extra_args) {
+        let agent_path = std::path::PathBuf::from(&profile.agent_cli_path);
+        let exit_code = launcher::exec_meta_command(&agent_path, &extra_args, &profile.env)?;
+        if exit_code == 0 {
+            return Ok(());
+        }
+        std::process::exit(exit_code);
+    }
+
     let mut flags = polyfill_args.to_polyfill_flags(&profile.defaults);
     let mut ucf_active = None;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,13 +309,28 @@ fn run_agent_with_polyfill(
     // Skip straight to exec'ing the bare agent binary with profile env so
     // claude doesn't pay its plugin-init tax for `unleash claude --version`.
     // See issue #258 and docs/benchmarks/overhead-2026-06-01.html.
+    //
+    // Guard against recursive invocation: if the profile's `agent_cli_path`
+    // resolves to the unleash binary itself (the Profile::new default), fall
+    // through to the normal path — `find_agent_command()` produces a helpful
+    // error there instead of exec'ing ourselves with --version.
     if launcher::is_meta_command(&extra_args) {
         let agent_path = std::path::PathBuf::from(&profile.agent_cli_path);
-        let exit_code = launcher::exec_meta_command(&agent_path, &extra_args, &profile.env)?;
-        if exit_code == 0 {
-            return Ok(());
+        let target_canon = which::which(&profile.agent_cli_path)
+            .ok()
+            .and_then(|p| p.canonicalize().ok());
+        let exe_canon = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.canonicalize().ok());
+        let safe = target_canon.is_some() && target_canon != exe_canon;
+        if safe {
+            let exit_code =
+                launcher::exec_meta_command(&agent_path, &extra_args, &profile.env)?;
+            if exit_code == 0 {
+                return Ok(());
+            }
+            std::process::exit(exit_code);
         }
-        std::process::exit(exit_code);
     }
 
     let mut flags = polyfill_args.to_polyfill_flags(&profile.defaults);


### PR DESCRIPTION
## Summary

First of the five optimization candidates listed in #258. Implements **meta-command short-circuit**: when the user runs `unleash <agent> --version` / `-V` / `--help` / `-h` / `doctor`, exec the agent binary directly with profile env and skip everything else — no polyfill yolo flag, no hook sync, no plugin discovery, no telemetry scrub, no restart loop.

## Why

The factorial in #258 proved that for claude, either `--dangerously-skip-permissions` OR `--plugin-dir` alone sends it into a plugin / permissions init path that costs +100 ms wall and +54 MB RSS. The wrapper adds both unconditionally. For interactive sessions that's fine — but for meta commands, the wrapper machinery has no effect on output and just makes claude take the slow path.

## Result

`scripts/bench-overhead.sh -n 15` against `claude --version`, raw mode:

| | Wall (direct → wrapped) | RSS (direct → wrapped) | Wall Δ | RSS Δ |
|---|---|---|---|---|
| **Before** | 70 ms → 200 ms | 207 MB → 260 MB | **+130 ms** | **+53 MB** |
| **After**  | 60 ms → 60 ms  | 207 MB → 207 MB | **+0 ms**   | **−32 KB** |

All 7 wrapped agents now sit within ±10 ms / ±0.5 MB of their direct invocation for meta commands. `scripts/bench-overhead.sh -n 10` against all agents post-fix:

| Agent    | Wall Δ | RSS Δ    | Wall (direct → wrapped) | RSS (direct → wrapped) |
|----------|--------|----------|--------------------------|--------------------------|
| claude   | +0 ms  | −32 KB   | 60 ms → 60 ms            | 206.8 MB → 206.8 MB     |
| codex    | +0 ms  | +0 KB    | 0 ms → 0 ms              | 18.9 MB → 18.9 MB        |
| agy      | +0 ms  | −10 KB   | 60 ms → 60 ms            | 125.1 MB → 125.1 MB     |
| gemini   | −10 ms | +170 KB  | 900 ms → 890 ms          | 207.4 MB → 207.6 MB     |
| opencode | +5 ms  | −528 KB  | 375 ms → 380 ms          | 196.6 MB → 196.1 MB     |
| pi       | +0 ms  | −484 KB  | 415 ms → 415 ms          | 144.5 MB → 144.1 MB     |
| hermes   | +0 ms  | +62 KB   | 200 ms → 200 ms          | 41.2 MB → 41.2 MB        |

## Implementation

- `launcher.rs::is_meta_command(args)` — pure function, exact match on `--version`/`-V`/`--help`/`-h`/`doctor`. 5 unit tests cover detection, position-independence, and non-matches like `--version-check`.
- `launcher.rs::exec_meta_command(cmd, args, env)` — plain `Command::status`, no wrapper extras.
- `lib.rs::run_agent_with_polyfill` — primary short-circuit after `target_cli` resolution, before `polyfill::resolve` runs (the source of the `--dangerously-skip-permissions` injection).
- `launcher.rs::run` — defense-in-depth short-circuit for the few entry points that bypass the polyfill path.

## Test plan

- [x] `cargo test --lib` — 562 passed, 5 new tests for `is_meta_command`
- [x] Manual: `unleash claude --version` prints the version string, exit 0
- [x] Manual: `unleash claude --help` prints help, exit 0
- [x] Manual: each of the 7 supported agents runs `--version` through the wrapper
- [x] Bench harness confirms the +130 ms / +53 MB tax is gone for claude and all 6 others stay within noise

## What's still open on #258

Four optimization candidates remain in the issue:
1. ~~Short-circuit meta commands~~ ← this PR
2. Skip hook sync on no-op launches
3. Drop the eager telemetry-dir scrub
4. Consolidate bundled plugins
5. Upstream lazy-init ask to Anthropic

Worth doing as separate PRs — they target different cost sources.