### PR TITLE
ci: pin ludeeus/action-shellcheck to 2.0.0 (from @master)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,14 +37,14 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@2.0.0
         with:
           scandir: './scripts'
           severity: warning
           ignore_paths: ''
 
       - name: ShellCheck tests
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@2.0.0
         with:
           scandir: './tests'
           severity: warning


### PR DESCRIPTION
Surfaced by the §9 sweep (workflow & action hygiene) on 2026-06-04.

\`ludeeus/action-shellcheck@master\` re-resolves on every CI run. If the upstream repo is ever compromised, malicious shellcheck-action code lands in our CI on the next push. Pinning to a released tag (\`2.0.0\`, published 2023-01-29) closes that risk.

Two call sites in \`integration-tests.yml\`, both updated. No behavior change — shellcheck still runs against the same paths with the same args.

## Test plan

- [x] Workflow YAML valid (\`actionlint\` passes locally)
- [ ] CI on this PR runs the ShellCheck job successfully — reviewer confirm