### PR TITLE
docs: drop references to removed restart-claude/exit-claude aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Features that unleash adds on top of the base agent CLIs:
 
 ### Available Now
 
-- **Self-restart**: Restart the agent while preserving session state (`unleash-refresh`, also available as `restart-claude`)
+- **Self-restart**: Restart the agent while preserving session state (`unleash-refresh`)
 - **Auto-mode**: Autonomous operation via Stop hook + flag file system
 - **Plugin system**: Custom functionality loaded via `--plugin-dir`
 - **MCP refresh**: Detect MCP configuration changes and trigger reload

--- a/docs/extensions/configuration.md
+++ b/docs/extensions/configuration.md
@@ -142,7 +142,7 @@ When auto-mode is active, the stop hook delivers a message to the agent each tim
 Set `stop_prompt` in the profile TOML:
 
 ```toml
-stop_prompt = "Complete all tests before stopping. Use exit-claude when truly done."
+stop_prompt = "Complete all tests before stopping. Use unleash-exit when truly done."
 ```
 
 ### Priority Order


### PR DESCRIPTION
## Summary

The `restart-claude` and `exit-claude` aliases were removed in favor of `unleash-refresh` / `unleash-exit` (see CLAUDE.md deprecation note, line 29). Two user-facing references still pointed at the old names:

- **`README.md:159`** "Self-restart" bullet claimed `restart-claude` is still available as an alias — it isn't.
- **`docs/extensions/configuration.md:145`** auto-mode example used `exit-claude` in a `stop_prompt` sample.

Both updated to the current names.

## How it was found

Found during a §7 / §11 doc-drift sweep (repo-maintenance skill). Grep:

```bash
grep -rn 'restart-claude\|exit-claude' docs/ *.md
```

Now returns only the intentional deprecation note in `CLAUDE.md`.

## Test plan

- [x] `grep -rn 'restart-claude\|exit-claude' docs/ *.md` returns only the CLAUDE.md deprecation note
- [x] No code (only docs) touched — no build/test impact