### PR TITLE
docs(tests): correct stale docstring on interchange::lossless_tests

### DIFF
--- a/src/interchange/lossless_tests.rs
+++ b/src/interchange/lossless_tests.rs
@@ -7,11 +7,9 @@
 //!
 //! Idempotence: `to_hub(from_hub(to_hub(x))) == to_hub(x)` for every CLI.
 //!
-//! These tests are expected to fail until foreign-extension passthrough is
-//! implemented in each converter. They document the target behavior.
-//!
-//! Tests are gated behind `#[ignore]` until the passthrough lands. Run with:
-//!   cargo test --lib interchange::lossless_tests -- --ignored --nocapture
+//! Foreign-extension passthrough is implemented in every converter (codex,
+//! claude, gemini, opencode), so all tests in this module run by default;
+//! one diagnostic test is `#[ignore]`d and runs only with `--ignored`.
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

`src/interchange/lossless_tests.rs` file-level docstring claimed the tests were *"gated behind \`#[ignore]\` until the passthrough lands"* and pointed at `cargo test ... -- --ignored` as the invocation. Both claims are stale:

- Foreign-extension passthrough shipped in #110 (block-level `_ucf_hub.message` passthrough) plus the per-converter `feat()` commits before it (codex, claude, gemini, opencode)
- **20 of 21 tests now run by default**; only one diagnostic test remains `#[ignore]`d for manual investigation

Verified with `cargo test --lib interchange::lossless_tests`:
```
test result: ok. 20 passed; 0 failed; 1 ignored; 0 measured
```

Rewrite the trailing two paragraphs of the module doc-comment to describe current reality. No behavior change — docstring only.

## How it was found

Surfaced during a `repo-maintenance` §6 (test-quality) sweep on 2026-06-04. Logged as "minor finding, will bundle next time something touches that file" — but nothing else touched it, and it's actively misleading to anyone navigating the test suite by file-level comments.

## Test plan

- [x] `cargo test --lib interchange::lossless_tests` — 20 passed / 1 ignored (unchanged)
- [x] No code changed; doc-comment only