### PR TITLE
chore: cargo fmt + enforce rustfmt in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,6 +39,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  rustfmt:
+    name: cargo fmt --check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      CARGO_TERM_COLOR: always
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+
   clippy:
     name: cargo clippy --all-targets
     runs-on: ubuntu-latest

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -844,7 +844,8 @@ mod tests {
         )
         .unwrap();
 
-        mgr.sync_plugin_hooks(std::slice::from_ref(&plugin_dir)).unwrap();
+        mgr.sync_plugin_hooks(std::slice::from_ref(&plugin_dir))
+            .unwrap();
 
         let settings = mgr.read_settings().unwrap();
 
@@ -904,7 +905,8 @@ mod tests {
         .unwrap();
 
         // Sync twice
-        mgr.sync_plugin_hooks(std::slice::from_ref(&plugin_dir)).unwrap();
+        mgr.sync_plugin_hooks(std::slice::from_ref(&plugin_dir))
+            .unwrap();
         mgr.sync_plugin_hooks(&[plugin_dir]).unwrap();
 
         let settings = mgr.read_settings().unwrap();
@@ -935,7 +937,8 @@ mod tests {
             r#"{"hooks":{"PreCompact":[{"hooks":[{"type":"command","command":"${CLAUDE_PLUGIN_ROOT}/hook.sh"}]}]}}"#,
         )
         .unwrap();
-        mgr.sync_plugin_hooks(std::slice::from_ref(&new_dir)).unwrap();
+        mgr.sync_plugin_hooks(std::slice::from_ref(&new_dir))
+            .unwrap();
 
         let settings = mgr.read_settings().unwrap();
         let hooks = settings["hooks"]["PreCompact"].as_array().unwrap();
@@ -1039,7 +1042,8 @@ mod tests {
         let plugin_dir = root.join("plugins/bundled").join(name);
         fs::create_dir_all(plugin_dir.join("hooks")).unwrap();
         fs::write(plugin_dir.join("hooks/hooks.json"), hooks_json).unwrap();
-        mgr.sync_plugin_hooks(std::slice::from_ref(&plugin_dir)).unwrap();
+        mgr.sync_plugin_hooks(std::slice::from_ref(&plugin_dir))
+            .unwrap();
         plugin_dir
     }
 

--- a/src/interchange/claude.rs
+++ b/src/interchange/claude.rs
@@ -118,8 +118,7 @@ pub fn from_hub(records: &[HubRecord]) -> Result<Vec<Value>, ConvertError> {
     }
 
     // Attach the session passthrough to the first emitted line.
-    if let (Some(sess), Some(Value::Object(ref mut obj))) =
-        (session_passthrough, lines.first_mut())
+    if let (Some(sess), Some(Value::Object(ref mut obj))) = (session_passthrough, lines.first_mut())
     {
         let entry = obj
             .entry("_ucf_hub".to_string())

--- a/src/interchange/crossload_index.rs
+++ b/src/interchange/crossload_index.rs
@@ -147,7 +147,11 @@ pub struct DoctorReportItem {
 fn parse_key(key: &str) -> Option<(String, String, String)> {
     let (src, target_cli) = key.split_once("->")?;
     let (source_cli, source_id) = src.split_once(':')?;
-    Some((source_cli.to_string(), source_id.to_string(), target_cli.to_string()))
+    Some((
+        source_cli.to_string(),
+        source_id.to_string(),
+        target_cli.to_string(),
+    ))
 }
 
 pub fn run_doctor(json: bool, gc: bool) -> io::Result<()> {
@@ -438,7 +442,10 @@ mod tests {
         ];
 
         let find_src = |cli: &str, id: &str| {
-            mock_sessions.iter().find(|s| s.cli == cli && s.id == id).cloned()
+            mock_sessions
+                .iter()
+                .find(|s| s.cli == cli && s.id == id)
+                .cloned()
         };
 
         // Run doctor report (without gc)
@@ -447,19 +454,31 @@ mod tests {
 
         assert_eq!(reports.len(), 4);
 
-        let r_live = reports.iter().find(|r| r.source_id == "source-live").unwrap();
+        let r_live = reports
+            .iter()
+            .find(|r| r.source_id == "source-live")
+            .unwrap();
         assert_eq!(r_live.status, DoctorStatus::Live);
         assert_eq!(r_live.reason, "");
 
-        let r_tgone = reports.iter().find(|r| r.source_id == "source-tgone").unwrap();
+        let r_tgone = reports
+            .iter()
+            .find(|r| r.source_id == "source-tgone")
+            .unwrap();
         assert_eq!(r_tgone.status, DoctorStatus::TargetGone);
         assert_eq!(r_tgone.reason, "target file missing");
 
-        let r_supd = reports.iter().find(|r| r.source_id == "source-supd").unwrap();
+        let r_supd = reports
+            .iter()
+            .find(|r| r.source_id == "source-supd")
+            .unwrap();
         assert_eq!(r_supd.status, DoctorStatus::SourceUpdated);
         assert_eq!(r_supd.reason, "source session modified");
 
-        let r_sgone = reports.iter().find(|r| r.source_id == "source-sgone").unwrap();
+        let r_sgone = reports
+            .iter()
+            .find(|r| r.source_id == "source-sgone")
+            .unwrap();
         assert_eq!(r_sgone.status, DoctorStatus::SourceGone);
         assert_eq!(r_sgone.reason, "source session not found");
 

--- a/src/interchange/gemini.rs
+++ b/src/interchange/gemini.rs
@@ -1368,12 +1368,11 @@ mod tests {
             // Should have the original message stashed for lossless round-trip
             let orig = gc.get("_original_message").unwrap();
             assert_eq!(orig.get("id").unwrap().as_str().unwrap(), "msg-5");
-            assert!(
-                orig.get("renderOutputAsMarkdown")
-                    .unwrap()
-                    .as_bool()
-                    .unwrap()
-            );
+            assert!(orig
+                .get("renderOutputAsMarkdown")
+                .unwrap()
+                .as_bool()
+                .unwrap());
         }
     }
 }

--- a/src/interchange/hermes.rs
+++ b/src/interchange/hermes.rs
@@ -144,10 +144,7 @@ pub fn to_hub(json: &str) -> Result<Vec<HubRecord>, ConvertError> {
     let session: Value = serde_json::from_str(json)?;
     let mut records: Vec<HubRecord> = Vec::new();
 
-    let session_id = session["id"]
-        .as_str()
-        .unwrap_or("unknown")
-        .to_string();
+    let session_id = session["id"].as_str().unwrap_or("unknown").to_string();
     let model = session["model"].as_str().map(|s| s.to_string());
     let title = session["title"].as_str().map(|s| s.to_string());
 
@@ -165,9 +162,7 @@ pub fn to_hub(json: &str) -> Result<Vec<HubRecord>, ConvertError> {
         model: model.clone(),
         title: title.clone(),
         slug: None,
-        parent_session_id: session["parent_session_id"]
-            .as_str()
-            .map(|s| s.to_string()),
+        parent_session_id: session["parent_session_id"].as_str().map(|s| s.to_string()),
         extensions: Value::Object(Default::default()),
     }));
 
@@ -178,15 +173,15 @@ pub fn to_hub(json: &str) -> Result<Vec<HubRecord>, ConvertError> {
         let msg = &messages[i];
         let role = msg["role"].as_str().unwrap_or("user");
         let ts = msg["timestamp"].as_f64().unwrap_or(started_at);
-        let msg_id = msg["id"].as_u64().map(|n| n.to_string()).unwrap_or_default();
+        let msg_id = msg["id"]
+            .as_u64()
+            .map(|n| n.to_string())
+            .unwrap_or_default();
 
         if role == "tool" {
             // Orphaned tool result — emit as user ToolResult block
             let content = msg["content"].as_str().unwrap_or("").to_string();
-            let tool_use_id = msg["tool_call_id"]
-                .as_str()
-                .unwrap_or(&msg_id)
-                .to_string();
+            let tool_use_id = msg["tool_call_id"].as_str().unwrap_or(&msg_id).to_string();
             records.push(HubRecord::Message(HubMessage {
                 id: msg_id,
                 api_message_id: None,
@@ -215,9 +210,7 @@ pub fn to_hub(json: &str) -> Result<Vec<HubRecord>, ConvertError> {
         let content_text = msg["content"].as_str().unwrap_or("").to_string();
         let mut blocks: Vec<ContentBlock> = Vec::new();
         if !content_text.is_empty() {
-            blocks.push(ContentBlock::Text {
-                text: content_text,
-            });
+            blocks.push(ContentBlock::Text { text: content_text });
         }
 
         let mut result_blocks: Vec<ContentBlock> = Vec::new();
@@ -236,8 +229,8 @@ pub fn to_hub(json: &str) -> Result<Vec<HubRecord>, ConvertError> {
                         .as_str()
                         .or_else(|| call["arguments"].as_str())
                         .unwrap_or("{}");
-                    let input: Value = serde_json::from_str(raw_args)
-                        .unwrap_or(Value::Object(Default::default()));
+                    let input: Value =
+                        serde_json::from_str(raw_args).unwrap_or(Value::Object(Default::default()));
                     blocks.push(ContentBlock::ToolUse {
                         id: call_id.clone(),
                         name: fn_name,
@@ -370,7 +363,10 @@ pub fn from_hub(records: &[HubRecord]) -> Result<HermesOutput, ConvertError> {
             let calls: Vec<Value> = tool_use_blocks
                 .iter()
                 .filter_map(|b| {
-                    if let ContentBlock::ToolUse { id, name, input, .. } = b {
+                    if let ContentBlock::ToolUse {
+                        id, name, input, ..
+                    } = b
+                    {
                         Some(serde_json::json!({
                             "id": id,
                             "call_id": id,
@@ -535,7 +531,9 @@ mod tests {
         }
         if let HubRecord::Message(m) = &records[1] {
             assert_eq!(m.role, "user");
-            assert!(matches!(&m.content[0], ContentBlock::Text { text } if text == "Hello, world!"));
+            assert!(
+                matches!(&m.content[0], ContentBlock::Text { text } if text == "Hello, world!")
+            );
         }
     }
 
@@ -586,7 +584,10 @@ mod tests {
         assert_eq!(records.len(), 4);
         if let HubRecord::Message(m) = &records[2] {
             assert_eq!(m.role, "assistant");
-            assert!(m.content.iter().any(|b| matches!(b, ContentBlock::ToolUse { name, .. } if name == "bash")));
+            assert!(m
+                .content
+                .iter()
+                .any(|b| matches!(b, ContentBlock::ToolUse { name, .. } if name == "bash")));
         }
         if let HubRecord::Message(m) = &records[3] {
             assert_eq!(m.role, "user");

--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -2,7 +2,9 @@
 
 use crate::interchange::crossload_index::{self, entry_is_live};
 use crate::interchange::sessions::{find_session, SessionInfo};
-use crate::interchange::{claude, codex, gemini, hermes, hub::HubRecord, opencode, pi, ConvertError};
+use crate::interchange::{
+    claude, codex, gemini, hermes, hub::HubRecord, opencode, pi, ConvertError,
+};
 
 /// Result of injecting a session: the session ID to resume with and any extra args.
 pub struct InjectionResult {
@@ -166,12 +168,8 @@ fn estimate_block_chars(block: &crate::interchange::hub::ContentBlock) -> usize 
     use crate::interchange::hub::ContentBlock;
     match block {
         ContentBlock::Text { text } => text.len(),
-        ContentBlock::ToolUse { name, input, .. } => {
-            name.len() + input.to_string().len()
-        }
-        ContentBlock::ToolResult { content, .. } => {
-            content.iter().map(estimate_block_chars).sum()
-        }
+        ContentBlock::ToolUse { name, input, .. } => name.len() + input.to_string().len(),
+        ContentBlock::ToolResult { content, .. } => content.iter().map(estimate_block_chars).sum(),
         ContentBlock::Thinking { text, .. } => text.len(),
         ContentBlock::Image { .. } => 256,
         _ => 64,
@@ -182,17 +180,15 @@ fn estimate_block_chars(block: &crate::interchange::hub::ContentBlock) -> usize 
 /// the estimated token count fits within `max_tokens`.
 /// The session header (first record) is always kept.
 /// Returns (trimmed_records, num_messages_dropped).
-fn truncate_hub_to_budget(
-    records: Vec<HubRecord>,
-    max_tokens: usize,
-) -> (Vec<HubRecord>, usize) {
+fn truncate_hub_to_budget(records: Vec<HubRecord>, max_tokens: usize) -> (Vec<HubRecord>, usize) {
     if estimate_tokens(&records) <= max_tokens {
         return (records, 0);
     }
 
     // Separate the session header from the messages.
-    let (header, mut messages): (Vec<HubRecord>, Vec<HubRecord>) =
-        records.into_iter().partition(|r| matches!(r, HubRecord::Session(_)));
+    let (header, mut messages): (Vec<HubRecord>, Vec<HubRecord>) = records
+        .into_iter()
+        .partition(|r| matches!(r, HubRecord::Session(_)));
 
     let mut dropped = 0;
     while !messages.is_empty() {
@@ -2248,7 +2244,7 @@ mod tests {
     fn test_estimate_tokens_text() {
         let records = vec![
             make_session_header(),
-            make_text_message("user", "aaaa"),   // 4 chars = 1 token
+            make_text_message("user", "aaaa"), // 4 chars = 1 token
             make_text_message("assistant", "bbbbbbbb"), // 8 chars = 2 tokens
         ];
         assert_eq!(estimate_tokens(&records), 3);
@@ -2271,9 +2267,9 @@ mod tests {
         let long_text = "x".repeat(400); // 400 chars = 100 tokens each
         let records = vec![
             make_session_header(),
-            make_text_message("user", &long_text),      // oldest
+            make_text_message("user", &long_text), // oldest
             make_text_message("assistant", &long_text), // 2nd
-            make_text_message("user", &long_text),      // newest user
+            make_text_message("user", &long_text), // newest user
             make_text_message("assistant", &long_text), // newest assistant
         ];
         // 4 messages × 100 tokens = 400 tokens total; budget = 250 → must drop 2

--- a/src/interchange/mod.rs
+++ b/src/interchange/mod.rs
@@ -49,7 +49,9 @@ impl std::str::FromStr for CliFormat {
         match s {
             "claude" | "claude-code" => Ok(Self::ClaudeCode),
             "codex" => Ok(Self::Codex),
-            "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" | "agy" => Ok(Self::GeminiCli),
+            "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" | "agy" => {
+                Ok(Self::GeminiCli)
+            }
             "hermes" | "hermes-agent" => Ok(Self::Hermes),
             "opencode" => Ok(Self::OpenCode),
             "pi" | "pi-coding-agent" => Ok(Self::Pi),

--- a/src/interchange/opencode.rs
+++ b/src/interchange/opencode.rs
@@ -504,23 +504,22 @@ fn collect_message_parts(
     let mut collected = Vec::new();
 
     // If parts have _msg_idx (injected by from_hub for reliable round-tripping), use it
-    if *idx < total
-        && all_parts[*idx].get("_msg_idx").is_some() {
-            while *idx < total {
-                let part = &all_parts[*idx];
-                if part.get("_msg_idx").and_then(|v| v.as_u64()) == Some(_msg_i as u64) {
-                    let mut cleaned_part = part.clone();
-                    if let Some(obj) = cleaned_part.as_object_mut() {
-                        obj.remove("_msg_idx");
-                    }
-                    collected.push(cleaned_part);
-                    *idx += 1;
-                } else {
-                    break;
+    if *idx < total && all_parts[*idx].get("_msg_idx").is_some() {
+        while *idx < total {
+            let part = &all_parts[*idx];
+            if part.get("_msg_idx").and_then(|v| v.as_u64()) == Some(_msg_i as u64) {
+                let mut cleaned_part = part.clone();
+                if let Some(obj) = cleaned_part.as_object_mut() {
+                    obj.remove("_msg_idx");
                 }
+                collected.push(cleaned_part);
+                *idx += 1;
+            } else {
+                break;
             }
-            return collected;
         }
+        return collected;
+    }
 
     if role == "user" {
         // User messages typically have one text part, maybe tool results

--- a/src/interchange/sessions.rs
+++ b/src/interchange/sessions.rs
@@ -187,7 +187,10 @@ fn overlay_search_index_names(sessions: &mut [SessionInfo]) {
                 eprintln!("Warning: Failed to prepare search index query");
             }
         } else if debug_mode {
-            eprintln!("Warning: Failed to open search index database {}", db_path.display());
+            eprintln!(
+                "Warning: Failed to open search index database {}",
+                db_path.display()
+            );
         }
     }
 
@@ -992,7 +995,10 @@ mod tests {
         // Verify that the lock file is created as a result of detecting that the
         // third session is missing from the DB (triggering background reindexing).
         let lock_path = unleash_dir.join("search-index.lock");
-        assert!(lock_path.exists(), "search-index.lock should be created when reindexing is needed");
+        assert!(
+            lock_path.exists(),
+            "search-index.lock should be created when reindexing is needed"
+        );
         let content = std::fs::read_to_string(&lock_path).unwrap();
         let pid = content.trim().parse::<i32>().unwrap();
         assert!(pid > 0, "lock file should contain a valid PID");

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -52,12 +52,8 @@ fn detect_agent_type(cmd: &Path) -> Option<AgentType> {
 /// `unleash claude --version`, CI smoke tests, and the many hook subprocesses
 /// that re-enter unleash during a session.
 pub(crate) fn is_meta_command(args: &[String]) -> bool {
-    args.iter().any(|a| {
-        matches!(
-            a.as_str(),
-            "--version" | "-V" | "--help" | "-h" | "doctor"
-        )
-    })
+    args.iter()
+        .any(|a| matches!(a.as_str(), "--version" | "-V" | "--help" | "-h" | "doctor"))
 }
 
 /// Exec the agent directly with profile env — no plugins, no permissions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,8 +324,7 @@ fn run_agent_with_polyfill(
             .and_then(|p| p.canonicalize().ok());
         let safe = target_canon.is_some() && target_canon != exe_canon;
         if safe {
-            let exit_code =
-                launcher::exec_meta_command(&agent_path, &extra_args, &profile.env)?;
+            let exit_code = launcher::exec_meta_command(&agent_path, &extra_args, &profile.env)?;
             if exit_code == 0 {
                 return Ok(());
             }

--- a/src/pixel_art.rs
+++ b/src/pixel_art.rs
@@ -896,7 +896,12 @@ pub mod mascots {
         max_lines: usize,
         gradient: &crate::theme::GradientTheme,
     ) -> Vec<RatatuiLine<'static>> {
-        to_ratatui_gradient_with_width(art, max_lines, gradient, crate::pixel_art::mascots::HALF_WIDTH)
+        to_ratatui_gradient_with_width(
+            art,
+            max_lines,
+            gradient,
+            crate::pixel_art::mascots::HALF_WIDTH,
+        )
     }
 
     /// Helper: parse with diagonal gradient and custom width

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -939,7 +939,9 @@ pub fn run_agent(
 
     // Validate agent name — must match a CLI built into the sandbox image
     // (docker/Dockerfile) and a service in docker-compose.yml.
-    let valid_agents = ["claude", "codex", "gemini", "opencode", "pi", "bash", "unleash"];
+    let valid_agents = [
+        "claude", "codex", "gemini", "opencode", "pi", "bash", "unleash",
+    ];
     if !valid_agents.contains(&agent) {
         eprintln!(
             "\x1b[31merror:\x1b[0m Unknown agent '{}'. Valid agents: {}",

--- a/src/search.rs
+++ b/src/search.rs
@@ -229,8 +229,7 @@ async fn run_sessions_action_async(
             // parent passes the lock-file path so we can remove it on completion
             // (success, error, or panic). Without this, the stale lock persists
             // until the next reindex check notices the PID is dead.
-            let _lock_guard = std::env::var_os("UNLEASH_REINDEX_LOCK_PATH")
-                .map(ReindexLockGuard);
+            let _lock_guard = std::env::var_os("UNLEASH_REINDEX_LOCK_PATH").map(ReindexLockGuard);
             // Re-use the full search pipeline (probe → schema → discover → upsert
             // → embed → name) with no query and no TUI. Setting reindex=true
             // wipes embeddings + generated titles so everything regenerates.
@@ -2162,7 +2161,10 @@ mod tests {
         {
             let _g = ReindexLockGuard(lock_path.as_os_str().to_os_string());
         }
-        assert!(!lock_path.exists(), "guard should remove the lock file on drop");
+        assert!(
+            !lock_path.exists(),
+            "guard should remove the lock file on drop"
+        );
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -154,7 +154,7 @@ fn strip_ansi(s: &str) -> String {
     while let Some(c) = chars.next() {
         if c == '\x1b' && chars.peek() == Some(&'[') {
             chars.next(); // consume '['
-            // Skip parameter / intermediate bytes (0x20..=0x3f), then one final byte (0x40..=0x7e).
+                          // Skip parameter / intermediate bytes (0x20..=0x3f), then one final byte (0x40..=0x7e).
             while let Some(&nc) = chars.peek() {
                 let nu = nc as u32;
                 if (0x40..=0x7e).contains(&nu) {
@@ -191,11 +191,7 @@ const SANDBOX_MENU: &[(SandboxMenuItem, &str, &str)] = &[
         "Teardown",
         "Remove sandbox network + firewall rules (requires sudo)",
     ),
-    (
-        SandboxMenuItem::Back,
-        "Back",
-        "Return to the main menu",
-    ),
+    (SandboxMenuItem::Back, "Back", "Return to the main menu"),
 ];
 
 /// Main menu items — order here defines display order in the TUI.
@@ -404,8 +400,7 @@ impl SandboxStepStatus {
 }
 
 /// What the user picked for a single env-var key in the wizard.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum EnvKeyChoice {
     /// Don't store; pass `-e KEY` at `docker run` time so the host value flows in.
     Passthrough,
@@ -444,7 +439,6 @@ impl EnvKeyChoice {
         }
     }
 }
-
 
 /// One row in the env-config step.
 #[derive(Debug, Clone)]
@@ -630,9 +624,7 @@ impl SetupStep {
             SetupStep::DetectState => {
                 "Check for existing config, installed agents, and anything unusual."
             }
-            SetupStep::PickAgents => {
-                "Choose which agent CLIs you want installed."
-            }
+            SetupStep::PickAgents => "Choose which agent CLIs you want installed.",
             SetupStep::CheckPrereqs => {
                 "Verify npm, cargo, or other prerequisites needed by your chosen agents."
             }
@@ -721,7 +713,8 @@ impl SetupWizardState {
                     self.statuses[self.step] = SetupStepStatus::Skipped;
                     // Surface them as pre-recorded results so the UI shows them.
                     for name in already {
-                        self.install_results.push((format!("{name} (already installed)"), true));
+                        self.install_results
+                            .push((format!("{name} (already installed)"), true));
                     }
                 }
             }
@@ -2977,39 +2970,33 @@ impl App {
                     _ => {}
                 }
             }
-            VersionFocus::AgentPicker => {
-                match action {
-                    NavAction::Up | NavAction::Down => {
-                        let current_idx = self
-                            .available_agents
-                            .iter()
-                            .position(|a| *a == self.version_agent)
-                            .unwrap_or(0);
-                        let new_idx = match action {
-                            NavAction::Down => {
-                                (current_idx + 1).min(self.available_agents.len() - 1)
-                            }
-                            NavAction::Up => {
-                                current_idx.saturating_sub(1)
-                            }
-                            _ => unreachable!(),
-                        };
-                        if new_idx != current_idx {
-                            self.switch_to_agent_index(new_idx);
-                        }
+            VersionFocus::AgentPicker => match action {
+                NavAction::Up | NavAction::Down => {
+                    let current_idx = self
+                        .available_agents
+                        .iter()
+                        .position(|a| *a == self.version_agent)
+                        .unwrap_or(0);
+                    let new_idx = match action {
+                        NavAction::Down => (current_idx + 1).min(self.available_agents.len() - 1),
+                        NavAction::Up => current_idx.saturating_sub(1),
+                        _ => unreachable!(),
+                    };
+                    if new_idx != current_idx {
+                        self.switch_to_agent_index(new_idx);
                     }
-                    NavAction::Tab | NavAction::Select => {
-                        self.version_focus = VersionFocus::VersionList;
-                    }
-                    NavAction::BackTab => {
-                        self.version_focus = VersionFocus::Unleash;
-                    }
-                    NavAction::Back | NavAction::Quit => {
-                        self.version_focus = VersionFocus::Unleash;
-                    }
-                    _ => {}
                 }
-            }
+                NavAction::Tab | NavAction::Select => {
+                    self.version_focus = VersionFocus::VersionList;
+                }
+                NavAction::BackTab => {
+                    self.version_focus = VersionFocus::Unleash;
+                }
+                NavAction::Back | NavAction::Quit => {
+                    self.version_focus = VersionFocus::Unleash;
+                }
+                _ => {}
+            },
             VersionFocus::VersionList => {
                 match action {
                     NavAction::Up | NavAction::Down => {
@@ -3701,14 +3688,12 @@ impl App {
                         self.trigger_screen_animation(true, Screen::Sandbox);
                         self.pending_screen = Some(Screen::Sandbox);
                     }
-                    Some(SandboxMenuItem::Status) => self.run_sandbox_action_capture(
-                        "Sandbox Status",
-                        &["sandbox", "status"],
-                    ),
-                    Some(SandboxMenuItem::List) => self.run_sandbox_action_capture(
-                        "Running Sandboxes",
-                        &["sandbox", "list"],
-                    ),
+                    Some(SandboxMenuItem::Status) => {
+                        self.run_sandbox_action_capture("Sandbox Status", &["sandbox", "status"])
+                    }
+                    Some(SandboxMenuItem::List) => {
+                        self.run_sandbox_action_capture("Running Sandboxes", &["sandbox", "list"])
+                    }
                     Some(SandboxMenuItem::Teardown) => {
                         self.status_message = Some(
                             "Teardown needs sudo — run `sudo unleash sandbox teardown` from a shell."
@@ -3743,8 +3728,11 @@ impl App {
         let output = match Command::new(&exe).args(args).output() {
             Ok(o) => o,
             Err(e) => {
-                self.sandbox_action_output
-                    .push(format!("error: failed to spawn `unleash {}`: {}", args.join(" "), e));
+                self.sandbox_action_output.push(format!(
+                    "error: failed to spawn `unleash {}`: {}",
+                    args.join(" "),
+                    e
+                ));
                 return;
             }
         };
@@ -3759,8 +3747,7 @@ impl App {
                 .push(format!("[exited with status {}]", output.status));
         }
         if self.sandbox_action_output.is_empty() {
-            self.sandbox_action_output
-                .push("(no output)".to_string());
+            self.sandbox_action_output.push("(no output)".to_string());
         }
     }
 
@@ -4658,17 +4645,14 @@ impl App {
                 } else {
                     ("✗", Style::default().fg(Color::Red))
                 };
-                detail_lines.push(Line::from(Span::styled(
-                    format!(" {icon} {name}"),
-                    style,
-                )));
+                detail_lines.push(Line::from(Span::styled(format!(" {icon} {name}"), style)));
             }
             // Show active install
             let is_installing = self.install_state.is_some();
             if is_installing {
                 if let Some(state) = &self.install_state {
-                    let frame_idx =
-                        (state.start_time.elapsed().as_millis() / 100) as usize % SPINNER_FRAMES.len();
+                    let frame_idx = (state.start_time.elapsed().as_millis() / 100) as usize
+                        % SPINNER_FRAMES.len();
                     detail_lines.push(Line::from(Span::styled(
                         format!(
                             " {} Installing {}…",
@@ -4905,7 +4889,10 @@ impl App {
 
             let max_lines = figure_rect.height as usize;
             let agent_type = self.selected_profile.as_ref().and_then(|p| p.agent_type());
-            let mascot_name = agent_type.as_ref().map(|t| t.mascot_name()).unwrap_or("claude");
+            let mascot_name = agent_type
+                .as_ref()
+                .map(|t| t.mascot_name())
+                .unwrap_or("claude");
             let shift = self.theme_color.theme_shift();
             let art_lines: Vec<Line> = if let Some(gradient) = self.profile_gradient() {
                 mascots::full_ratatui_gradient(mascot_name, max_lines, &gradient)
@@ -4995,13 +4982,17 @@ impl App {
         }
     }
 
-
     /// Get the gradient theme for the current profile if it uses a gradient
     fn profile_gradient(&self) -> Option<crate::theme::GradientTheme> {
-        let t = self.selected_profile.as_ref().and_then(|p| p.agent_type())?;
+        let t = self
+            .selected_profile
+            .as_ref()
+            .and_then(|p| p.agent_type())?;
         match t {
             crate::agents::AgentType::Gemini => Some(crate::theme::GradientTheme::gemini()),
-            crate::agents::AgentType::Antigravity => Some(crate::theme::GradientTheme::antigravity()),
+            crate::agents::AgentType::Antigravity => {
+                Some(crate::theme::GradientTheme::antigravity())
+            }
             _ => None,
         }
     }
@@ -5011,7 +5002,10 @@ impl App {
         // Lava lamp mode is an easter egg triggered by Konami code (idea by cac taurus)
         let max_lines = area.height as usize;
         let agent_type = self.selected_profile.as_ref().and_then(|p| p.agent_type());
-        let mascot_name = agent_type.as_ref().map(|t| t.mascot_name()).unwrap_or("claude");
+        let mascot_name = agent_type
+            .as_ref()
+            .map(|t| t.mascot_name())
+            .unwrap_or("claude");
         let shift = self.theme_color.theme_shift();
         let art_lines: Vec<Line> = if self.lava_mode {
             mascots::right_ratatui_lava(mascot_name, max_lines, self.animation_frame)
@@ -5031,7 +5025,10 @@ impl App {
         // Lava lamp mode is an easter egg triggered by Konami code (idea by cac taurus)
         let max_lines = area.height as usize;
         let agent_type = self.selected_profile.as_ref().and_then(|p| p.agent_type());
-        let mascot_name = agent_type.as_ref().map(|t| t.mascot_name()).unwrap_or("claude");
+        let mascot_name = agent_type
+            .as_ref()
+            .map(|t| t.mascot_name())
+            .unwrap_or("claude");
         let shift = self.theme_color.theme_shift();
         let art_lines: Vec<Line> = if self.lava_mode {
             mascots::left_ratatui_lava(mascot_name, max_lines, self.animation_frame)
@@ -5100,10 +5097,9 @@ impl App {
                         "Sandbox Mode: ON  [●]".to_string(),
                         "Next Start Session will run inside the gVisor sandbox".to_string(),
                     ),
-                    MainMenuItem::SandboxMode => (
-                        "Sandbox Mode: OFF [○]".to_string(),
-                        (*desc).to_string(),
-                    ),
+                    MainMenuItem::SandboxMode => {
+                        ("Sandbox Mode: OFF [○]".to_string(), (*desc).to_string())
+                    }
                     _ => ((*name).to_string(), (*desc).to_string()),
                 };
                 let style = if i == self.main_menu.selected {
@@ -7174,7 +7170,10 @@ mod tests {
         assert_eq!(app.screen, Screen::Main, "toggle should not navigate away");
 
         let _ = app.handle_main_input(NavAction::Select);
-        assert!(!app.sandbox_armed, "second Select should disarm sandbox mode");
+        assert!(
+            !app.sandbox_armed,
+            "second Select should disarm sandbox mode"
+        );
     }
 
     #[test]

--- a/src/version.rs
+++ b/src/version.rs
@@ -1186,7 +1186,9 @@ impl VersionManager {
                         return Ok(v_list.clone());
                     }
                 }
-                Err(io::Error::other("Failed to query available versions for Gemini CLI"))
+                Err(io::Error::other(
+                    "Failed to query available versions for Gemini CLI",
+                ))
             }
         }
     }
@@ -1260,7 +1262,9 @@ impl VersionManager {
                         return Ok(v_list.clone());
                     }
                 }
-                Err(io::Error::other("Failed to query available versions for Pi"))
+                Err(io::Error::other(
+                    "Failed to query available versions for Pi",
+                ))
             }
         }
     }
@@ -2362,9 +2366,7 @@ pub fn install_latest_streaming(
             Ok((v, r))
         }
         AgentType::Codex => {
-            let installed = which::which("codex")
-                .ok()
-                .and(None::<String>); // just need presence
+            let installed = which::which("codex").ok().and(None::<String>); // just need presence
             let versions = vm.get_codex_version_list(installed.as_deref());
             let v = versions
                 .into_iter()
@@ -2597,7 +2599,11 @@ mod tests {
         // (fresh installs land here and the installer's clone path takes over).
         let mut logs: Vec<String> = Vec::new();
         VersionManager::reset_diverged_hermes_clone(td.path(), "main", &mut |m| logs.push(m));
-        assert!(logs.is_empty(), "should not log when no .git/ present: {:?}", logs);
+        assert!(
+            logs.is_empty(),
+            "should not log when no .git/ present: {:?}",
+            logs
+        );
     }
 
     /// Cached `antigravity = ["2.0.1"]` is the bogus value earlier builds


### PR DESCRIPTION
## Summary

Closes the §3 lint-enforcement gap surfaced in the 2026-06-04 repo-maintenance sweep: `cargo clippy` was already gated with `-D warnings`, but `cargo fmt --check` was enforced nowhere. Result: 16 `src/` files had quietly drifted from rustfmt-canonical.

This PR does both halves of the fix:

1. **One-shot bulk format** — `cargo fmt --all` across the tree. 16 source files touched, ~197 insertions / 163 deletions, pure formatting. Verified `cargo clippy --all-targets -- -D warnings` and `cargo test --lib` (565 tests, 562 pass, 3 ignored, 0 fail) both still green after the format pass.

2. **Forward-looking enforcement** — adds a `rustfmt` job to `.github/workflows/lint.yml` that runs `cargo fmt --all -- --check` on every push to main and every PR touching `src/`/`examples/`/`tests/`/`Cargo.toml`/`Cargo.lock`/`lint.yml`. Runs in parallel with the existing clippy job under the same workflow.

The rustfmt job uses stable + the rustfmt component, no cache (~30 s cold, fast enough not to need one).

## Why now

Was held off when first proposed (2026-06-04 §3 sweep) because PRs #262/#263/#264/#265 were in flight and a bulk format would have conflicted. All four landed earlier today (plus #266, #268), so the conflict window is closed.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean
- [x] `cargo test --lib` — 562/562 pass (3 pre-existing ignored)
- [ ] CI: new `rustfmt` job is green
- [ ] CI: existing `clippy` job stays green