### PR TITLE
docs: correct stale agent counts (four/six → seven default profiles)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Add a matching profile at `~/.config/unleash/profiles/aider.toml` (any built-in 
 unleash <profile> [unified flags] [-- agent-specific flags]
 ```
 
-The first argument is always a **profile name**. The six default profiles (`claude`, `codex`, `gemini`, `opencode`, `pi`, `hermes`) map to their respective agents. Custom profiles can target any agent with custom settings.
+The first argument is always a **profile name**. The seven default profiles (`claude`, `codex`, `agy`, `gemini`, `opencode`, `pi`, `hermes`) map to their respective agents. Custom profiles can target any agent with custom settings — see [`docs/custom-agents.md`](docs/custom-agents.md).
 
 ```bash
 unleash claude -m opus -c              # Continue last Claude session with Opus
@@ -136,10 +136,11 @@ unleash agents status      # Show all agent versions and update status
 
 ## Version Management
 
-unleash manages versions for all six built-in agent CLIs:
+unleash manages versions for all seven built-in agent CLIs:
 
 - **Claude Code**: Native binary (GCS) or npm install
 - **Codex**: Prebuilt binary from GitHub releases, cargo build fallback
+- **Antigravity CLI** (`agy`): AUR helper (`yay`/`paru`) on Arch; download from antigravity.google elsewhere
 - **Gemini CLI**: npm install
 - **OpenCode**: Built-in `opencode upgrade` command
 - **Pi**: npm install (`@mariozechner/pi-coding-agent`)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Unleash is a unified CLI manager for AI code agents — Claude Code, Codex, Gemini CLI, and OpenCode. It wraps these CLIs with a TUI, profiles, version management, and a plugin system.
+Unleash is a unified CLI manager for AI code agents — Claude Code, Codex, Antigravity (`agy`), Gemini CLI, OpenCode, Pi, and Hermes. It wraps these CLIs with a TUI, profiles, version management, and a plugin system.
 
 ## Prerequisites
 
@@ -40,23 +40,31 @@ Navigation:
 
 ## Pick a Profile
 
-Unleash ships with four default profiles:
+Unleash ships with seven default profiles:
 
 | Profile | Agent |
 |---------|-------|
 | `claude` | Claude Code |
 | `codex` | Codex CLI |
+| `agy` | Antigravity CLI |
 | `gemini` | Gemini CLI |
 | `opencode` | OpenCode |
+| `pi` | Pi coding agent |
+| `hermes` | Hermes Agent |
 
 Launch directly from the command line:
 
 ```bash
 unleash claude
 unleash codex
+unleash agy
 unleash gemini
 unleash opencode
+unleash pi
+unleash hermes
 ```
+
+To add a custom CLI (e.g. `aider`), see [Custom Agent CLIs](custom-agents.md).
 
 ## Key Concepts
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -4,14 +4,17 @@ Profiles control how Unleash launches agent CLIs. Each profile is a TOML file in
 
 ## Basics
 
-Unleash creates four default profiles on first run:
+Unleash creates seven default profiles on first run:
 
 | Profile    | Theme     |
 |------------|-----------|
 | `claude`   | `orange`  |
 | `codex`    | `#aaaaaa` |
+| `agy`      | `#9b51e0` |
 | `gemini`   | `#4285f4` |
 | `opencode` | `#10b981` |
+| `pi`       | `#a855f7` |
+| `hermes`   | `#4f46e5` |
 
 Select a profile from the TUI, or edit the TOML files directly.
 


### PR DESCRIPTION
## Summary

User-facing docs lagged the actual default-profile set by 1–3 agents. The canonical list is now seven: \`claude, codex, agy, gemini, opencode, pi, hermes\` (per \`AgentType\` in \`src/agents.rs:19-30\` and \`ProfileManager::default_profiles\` in \`src/config.rs\`).

Fixes:

- **README.md**
  - "six default profiles" / "six built-in agent CLIs" → seven (was missing \`agy\`/Antigravity)
  - Added an Antigravity row to the Version Management list (AUR helper on Arch; antigravity.google download elsewhere — matches the PR #259 install path)
  - Added a link from the profile-name paragraph to \`docs/custom-agents.md\` (the new doc from #268)
- **docs/getting-started.md**
  - Top blurb listed 4 agents → all 7
  - "Pick a Profile" table and code block listed 4 → all 7
  - Added a pointer to \`custom-agents.md\` for users who want a custom CLI
- **docs/profiles.md**
  - "four default profiles" → seven
  - Theme table extended with \`agy\`/\`pi\`/\`hermes\` (hex values verified against \`src/config.rs::default_profiles\`)

## How it was found

Repo-maintenance §7 docs-freshness re-sweep — the prior §7 only scanned for removed-alias drift (\`restart-claude\`/\`exit-claude\`, fixed in #266). Widened to agent-count + version-management completeness this round.

## Test plan

- [x] Hex theme values in \`docs/profiles.md\` confirmed against \`grep -A 12 'name: "pi"' src/config.rs\`: \`pi #a855f7\`, \`hermes #4f46e5\`
- [x] \`grep -nE "(four|five|six).*(profile|agent|CLI)" docs/ README.md\` now empty
- [ ] CI green