### PR TITLE
docs: extend flag-translation table to all 7 supported agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ unleash claude -m opus -- --effort max --verbose
 
 ### How Translation Works
 
-| unleash | Claude | Codex | Gemini | OpenCode | Pi | Hermes |
-|---------|--------|-------|--------|----------|----|--------|
-| `-p <prompt>` | `-p <prompt>` | `exec <prompt>` | `-p <prompt>` | `run <prompt>` | `-p <prompt>` | `-z <prompt>` |
-| `-c` | `--continue` | `resume --last` | `--resume latest` | `--continue` | `--continue` | `--continue` |
-| `-r [id]` | `--resume [id]` | `resume [id]` | `--resume [id]` | `-s <id>` | `--session <id>` | `--resume [id]` |
-| `--fork` | `--fork-session` | `fork` subcommand | *(unsupported)* | `--fork` | `--fork` | `--worktree` |
-| *(default)* | `--dangerously-skip-permissions` | `--dangerously-bypass-approvals-and-sandbox` | `--yolo` | *(no-op)* | *(no-op)* | `--yolo` |
+| unleash | Claude | Codex | Antigravity (`agy`) | Gemini | OpenCode | Pi | Hermes |
+|---------|--------|-------|---------------------|--------|----------|----|--------|
+| `-p <prompt>` | `-p <prompt>` | `exec <prompt>` | `-p <prompt>` | `-p <prompt>` | `run <prompt>` | `-p <prompt>` | `-z <prompt>` |
+| `-c` | `--continue` | `resume --last` | `--resume latest` | `--resume latest` | `--continue` | `--continue` | `--continue` |
+| `-r [id]` | `--resume [id]` | `resume [id]` | `--resume [id]` | `--resume [id]` | `-s <id>` | `--session <id>` | `--resume [id]` |
+| `--fork` | `--fork-session` | `fork` subcommand | *(unsupported)* | *(unsupported)* | `--fork` | `--fork` | `--worktree` |
+| *(default)* | `--dangerously-skip-permissions` | `--dangerously-bypass-approvals-and-sandbox` | `--dangerously-skip-permissions` | `--yolo` | *(no-op)* | *(no-op)* | `--yolo` |
 
 ### Management Commands
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
 # Unleash CLI Reference
 
-Unified CLI manager for AI code agents (Claude, Codex, Gemini, OpenCode).
+Unified CLI manager for AI code agents (Claude, Codex, Antigravity, Gemini, OpenCode, Pi, Hermes).
 
 ## Usage
 
@@ -39,14 +39,14 @@ unleash gemini -p "fix it"  # Headless Gemini prompt
 
 How unified flags map to each agent's native CLI:
 
-| unleash | Claude | Codex | Gemini | OpenCode |
-|---------|--------|-------|--------|----------|
-| `-p <prompt>` | `-p <prompt>` | `exec <prompt>` | `-p <prompt>` | `run <prompt>` |
-| `-c` | `--continue` | `resume --last` | `--resume latest` | `--continue` |
-| `-r [id]` | `--resume [id]` | `resume [id]` | `--resume [id]` | `--session <id>` |
-| `--fork` | `--fork-session` | `fork` subcommand | *(unsupported)* | `--fork` |
-| *(default)* | `--dangerously-skip-permissions` | `--dangerously-bypass-approvals-and-sandbox` | `--yolo` | *(no-op)* |
-| `--safe` | *(omits above)* | *(omits above)* | *(omits above)* | *(no-op)* |
+| unleash | Claude | Codex | Antigravity (`agy`) | Gemini | OpenCode | Pi | Hermes |
+|---------|--------|-------|---------------------|--------|----------|----|--------|
+| `-p <prompt>` | `-p <prompt>` | `exec <prompt>` | `-p <prompt>` | `-p <prompt>` | `run <prompt>` | `-p <prompt>` | `-z <prompt>` |
+| `-c` | `--continue` | `resume --last` | `--resume latest` | `--resume latest` | `--continue` | `--continue` | `--continue` |
+| `-r [id]` | `--resume [id]` | `resume [id]` | `--resume [id]` | `--resume [id]` | `-s <id>` | `--session <id>` | `--resume [id]` |
+| `--fork` | `--fork-session` | `fork` subcommand | *(unsupported)* | *(unsupported)* | `--fork` | `--fork` | `--worktree` |
+| *(default)* | `--dangerously-skip-permissions` | `--dangerously-bypass-approvals-and-sandbox` | `--dangerously-skip-permissions` | `--yolo` | *(no-op)* | *(no-op)* | `--yolo` |
+| `--safe` | *(omits above)* | *(omits above)* | *(omits above)* | *(omits above)* | *(no-op)* | *(no-op)* | *(omits above)* |
 
 ## Passthrough
 
@@ -152,11 +152,14 @@ unleash convert --from codex session.jsonl --verify                 # round-trip
 ```
 
 Required:
-- `--from <format>`: source format (`claude`, `codex`, `gemini`, `opencode`, `hub`)
+- `--from <format>`: source format. One of: `claude` (alias `claude-code`),
+  `codex`, `gemini` (aliases `gemini-cli`, `antigravity`, `antigravity-cli`,
+  `agy` — same JSON schema), `opencode`, `pi` (alias `pi-coding-agent`),
+  `hermes` (alias `hermes-agent`), or `hub` / `ucf`.
 - `<input>`: path to the input file (positional)
 
 Optional:
-- `--to <format>`: target format (default: `hub`)
+- `--to <format>`: target format (same set as `--from`; default: `hub`)
 - `--output <path>` / `-o <path>`: output file (default: stdout)
 - `--verify`: verify lossless round-trip instead of converting
 


### PR DESCRIPTION
## Summary

\`docs/cli-reference.md\` had a **4-column** flag-translation table (Claude, Codex, Gemini, OpenCode) and the README had a **6-column** one (added Pi/Hermes earlier but missed Antigravity). Both extended to **7 columns** covering every supported agent — sourced from the \`AgentDefinition::<agent>()\` polyfill constructors in \`src/agents.rs\`.

Three corrections vs the previously-shipped tables:

| | Before | After (verified against src) |
|---|---|---|
| **Antigravity** column | not present in either | added: \`-p\`, \`-c → --resume latest\`, \`-r → --resume\`, fork unsupported, yolo \`--dangerously-skip-permissions\` |
| **OpenCode \`-r\`** in cli-reference.md | said \`--session <id>\` | actual polyfill = \`-s <id>\` (README was already correct) |
| **cli-reference.md line 3** blurb | 4 agents | all 7 |

Also extends \`unleash convert --from <format>\` (and \`--to\`) format list — was missing \`pi\`, \`hermes\`, and the \`antigravity\`/\`agy\` aliases. Verified against \`CliFormat::from_str\` in \`src/interchange/mod.rs:50-57\`.

## Test plan

- [x] Each cell in the 7-column table cross-checked against the corresponding \`AgentDefinition::<agent>()\` constructor (claude/codex/antigravity/gemini/opencode/pi/hermes)
- [x] Convert-format list cross-checked against \`CliFormat::from_str\`
- [ ] CI green (docs-only — cargo-llvm-cov only)