### PR TITLE
docs: refresh configuration.md + environment-variables.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,11 +9,21 @@ Unleash uses a minimal global config file. Most settings live in
 
 ```toml
 current_profile = "claude"   # Which profile loads by default
-animations = false            # TUI animations (lava color cycling)
+animations = false           # TUI animations (lava color cycling)
+enabled_plugins = []         # Empty = all bundled plugins enabled (default)
+                             # Non-empty = only-these list
+
+# Custom agent CLI definitions (zero or more `[[custom_agents]]` blocks).
+# See docs/custom-agents.md for the full schema.
+[[custom_agents]]
+name = "aider"
+binary = "aider"
+# ... polyfill, description, optional fields
 ```
 
-That's it -- just two fields. Everything else (agent path, theme, flags,
-environment variables, plugin settings) is configured per-profile.
+Per-agent settings (path, theme, flags, env vars, stop_prompt) live in
+[profile TOMLs](profiles.md), not here. Per-plugin settings live in each
+plugin's manifest with TUI controls.
 
 ## Directory Layout
 
@@ -23,9 +33,17 @@ environment variables, plugin settings) is configured per-profile.
 └── profiles/                # One TOML file per profile
     ├── claude.toml
     ├── codex.toml
+    ├── agy.toml
     ├── gemini.toml
-    └── opencode.toml
+    ├── opencode.toml
+    ├── pi.toml
+    └── hermes.toml
 ```
+
+`profiles/` is seeded with the seven default profiles on first run. Add
+extra `<name>.toml` files for custom profiles or custom agents — the
+filename (without `.toml`) becomes the subcommand name (e.g.
+`aider.toml` → `unleash aider`).
 
 ## Changing the Default Profile
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -12,6 +12,11 @@ These can be set before launching `unleash` to change behavior.
 | `EDITOR` / `VISUAL` | Editor for TUI text input fields | system default |
 | `AGENT_UNLEASH_ROOT` | Path to the unleash installation directory (read by plugins and hooks) | unset |
 | `CODEX_HOME` | Override Codex home directory (used to locate Codex sessions and history) | `~/.codex` |
+| `OAI_BASE` | Base URL of the OpenAI-compatible server `unleash search` uses for embeddings (and chat unless `OAI_CHAT_BASE` is set) | `http://127.0.0.1:18000/v1` |
+| `OAI_EMBED_MODEL` | Embedding model name (`/v1/embeddings`) | `lco-omni-3b` |
+| `OAI_CHAT_BASE` | Optional separate base URL for chat completions (title regeneration) | falls back to `OAI_BASE` |
+| `OAI_CHAT_MODEL` | Chat model used for `sessions name` title generation. **Unset = skip naming** | unset |
+| `ALPHA` | Hybrid-search rank fusion: dense-vs-BM25 weight (0–1, higher = more dense) | `0.4` |
 
 ### Examples
 
@@ -37,7 +42,7 @@ runtime environment.
 
 | Variable | Purpose |
 |----------|---------|
-| `AGENT_CMD` | Which agent binary is running (`claude`, `codex`, `gemini`, `opencode`) |
+| `AGENT_CMD` | Which agent binary is running (`claude`, `codex`, `agy`, `gemini`, `opencode`, `pi`, `hermes`, or a custom-agent name) |
 | `AGENT_UNLEASH` | Set to `1` when running under the unleash wrapper |
 | `AGENT_WRAPPER_PID` | PID of the wrapper process (used by plugins and Hyprland focus) |
 | `UNLEASH_POLYFILL_ACTIVE` | Set to `1` when polyfill flag translation is active |


### PR DESCRIPTION
## Summary

Two real drifts from repo-maintenance §7 widening:

**\`docs/configuration.md\`** (last touched 2026-03-30):
- Claimed \`AppConfig\` has "two fields"; actual struct in \`src/config.rs\` has **four** — \`current_profile\`, \`animations\`, \`enabled_plugins\`, \`custom_agents\`. Updated the example to show all four (with pointer to \`docs/custom-agents.md\` for the \`[[custom_agents]]\` schema added in #268).
- Directory layout showed 4 default profile TOMLs; \`ProfileManager::default_profiles\` seeds **seven** (adds \`agy\`, \`pi\`, \`hermes\`). Same fix pattern as #271.
- Reworded "plugin settings are per-profile" — the enabled set is actually global (\`enabled_plugins\` in \`config.toml\`); per-plugin settings live in each plugin's manifest with TUI controls.

**\`docs/environment-variables.md\`** (last touched 2026-04-01):
- \`AGENT_CMD\` row listed 4 agents → all 7 + custom-agent names.
- Added the \`OAI_*\` and \`ALPHA\` env vars used by \`unleash search\`. Defaults verified against \`src/search.rs::resolve\`:
  - \`OAI_BASE\` = \`http://127.0.0.1:18000/v1\`
  - \`OAI_EMBED_MODEL\` = \`lco-omni-3b\`
  - \`ALPHA\` = \`0.4\`
  - \`OAI_CHAT_MODEL\` = unset (skip naming)
  - \`OAI_CHAT_BASE\` = falls back to \`OAI_BASE\`

  Previously only mentioned in passing under \`unleash search\` in cli-reference.md — not in the env-vars table.

## Test plan

- [x] Default values cross-checked against \`src/search.rs\` \`resolve\` function (lines around the env::var calls)
- [x] AppConfig struct verified at \`src/config.rs\` \`pub struct AppConfig\`
- [x] Default profile names verified against \`ProfileManager::default_profiles\`
- [ ] CI green (docs-only)