### PR TITLE
docs(crossload): extend architecture diagrams + add Pi/Hermes/Agy support notes

### DIFF
--- a/docs/crossload-matrix.md
+++ b/docs/crossload-matrix.md
@@ -2,7 +2,11 @@
 
 Status of conversation history loading between all supported agent CLIs.
 
-**Last updated:** 2026-04-14
+**Last updated:** 2026-06-05
+
+> Coverage below is for the four CLIs with end-to-end synthetic-fixture
+> tests (`src/interchange/tests/fixtures/synthetic/*-10turn.*`). For the
+> other three see [Additional CLIs](#additional-clis) below.
 
 ## Usage
 
@@ -40,9 +44,17 @@ unleash convert --from codex session.jsonl --to claude -o output.jsonl
 
 **Legend:** :green_circle: Lossless (verified end-to-end) · :yellow_circle: Partial (works with known limitations) · :red_circle: Not working · :white_circle: Untested
 
+## Additional CLIs
+
+| CLI | Source discovery | Target injection | Round-trip coverage |
+|---|---|---|---|
+| **Pi** | ✓ `sessions.rs:776` | ✓ `inject_into_pi` | Bidirectional **portable-fields** unit tests in `cross_cli_tests.rs` against claude/codex/gemini/opencode. No 10-turn synthetic fixture yet → not in main matrix. |
+| **Hermes** | ✓ `sessions.rs:640` | ✓ `inject_into_hermes` | Untested — dispatch wired in, no round-trip tests yet. |
+| **Antigravity (`agy`)** | via Gemini storage layout (`sessions.rs` Gemini path; see `normalize_target_cli` in `inject.rs:130`) | via Gemini path | Inherits Gemini's matrix entries. |
+
 ## How It Works
 
-1. **Session discovery** (`unleash sessions`) scans all 4 CLI session stores
+1. **Session discovery** (`unleash sessions`) scans the configured CLI session stores (claude/codex/gemini/opencode/pi/hermes; agy shares the Gemini path)
 2. **Hub conversion** transforms the source format to the Unleash Conversation Format (.ucf.jsonl)
 3. **Target injection** converts from hub to the target CLI format and writes to its session directory
 4. **Resume** launches the target CLI with `--resume <session-id>`
@@ -52,10 +64,13 @@ unleash convert --from codex session.jsonl --to claude -o output.jsonl
 ```
 Claude JSONL  <-->  Hub (.ucf.jsonl)  <-->  Codex JSONL
                          |
-Gemini JSON   <---------|---------->  OpenCode SQLite
+                         |---->  Gemini JSON  (agy shares this path)
+                         |---->  OpenCode SQLite
+                         |---->  Pi JSON
+                         |---->  Hermes JSON
 ```
 
-Hub-and-spoke model: O(N) converters, not O(N^2) direct pairs.
+Hub-and-spoke model: O(N) converters, not O(N²) direct pairs.
 
 ## Known Limitations
 

--- a/docs/crossload.md
+++ b/docs/crossload.md
@@ -1,11 +1,12 @@
 # Cross-CLI Session Crossload
 
 Load conversation history from one agent CLI into another. Start a session in
-Codex, continue it in Claude, hand it to Gemini -- without losing context.
+Codex, continue it in Claude, hand it to Gemini, finish it in Pi — without
+losing context.
 
 ## How It Works
 
-1. **Discovery** -- `unleash sessions` scans session stores for all installed CLIs
+1. **Discovery** -- `unleash sessions` scans session stores for all installed CLIs (claude/codex/gemini/opencode/pi/hermes; agy shares the Gemini path)
 2. **Hub conversion** -- source format is converted to Universal Chat Format (`.ucf.jsonl`)
 3. **Target injection** -- hub format is converted to the target CLI's native format
 4. **Resume** -- target CLI launches with the injected session
@@ -15,10 +16,13 @@ Codex, continue it in Claude, hand it to Gemini -- without losing context.
 ```
 Claude JSONL  <-->  Hub (.ucf.jsonl)  <-->  Codex JSONL
                          |
-Gemini JSON   <---------|---------->  OpenCode SQLite
+                         |---->  Gemini JSON  (agy shares this path)
+                         |---->  OpenCode SQLite
+                         |---->  Pi JSON
+                         |---->  Hermes JSON
 ```
 
-O(N) converters instead of O(N^2) direct pairs. The hub format is JSONL for
+O(N) converters instead of O(N²) direct pairs. The hub format is JSONL for
 corruption recovery, with minimal extensions (~10% overhead).
 
 ## Usage


### PR DESCRIPTION
## Summary

\`docs/crossload.md\` and \`docs/crossload-matrix.md\` framed crossload as a 4-CLI feature (Claude / Codex / Gemini / OpenCode). The shipped code actually supports more — this PR documents what's wired vs verified vs untested, with code-path references.

What's actually wired:

- **Pi**: session discovery (\`sessions.rs:776\`) + target injection (\`inject_into_pi\`). Bidirectional portable-fields unit tests in \`cross_cli_tests.rs\` against claude/codex/gemini/opencode.
- **Hermes**: dispatch wired (\`sessions.rs:640\`, \`inject_into_hermes\`) but no round-trip tests yet.
- **Antigravity (\`agy\`)**: shares Gemini storage layout per \`normalize_target_cli\` (\`inject.rs:130\`). Inherits Gemini's matrix entries.

Changes:

| File | Change |
|------|--------|
| \`crossload-matrix.md\` | \`Last updated:\` → 2026-06-05 (was 2026-04-14, file mtime already May); top-of-doc note clarifying main table covers the 4 CLIs with synthetic-fixture tests; new **Additional CLIs** section for Pi/Hermes/Agy with code-path links; \"scans all 4 CLI session stores\" → enumerated 6 + agy; architecture diagram extended |
| \`crossload.md\` | Lead-in mentions Pi; discovery enumerates real list; architecture diagram extended (matches matrix doc) |

No changes to the main matrix rows — adding Pi/Hermes/Agy entries there would require end-to-end verification with synthetic-fixture tests (10-turn pattern), which doesn't exist for them yet. Tracked in the Additional-CLIs notes.

## Test plan

- [x] Code-path claims spot-checked against \`src/interchange/sessions.rs\` and \`src/interchange/inject.rs\`
- [x] Pi test coverage verified at \`src/interchange/cross_cli_tests.rs:404,413,422,431,440,449,458,467\`
- [ ] CI green (docs-only)