### PR TITLE
docs: index custom-agents.md and crossload-matrix.md in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,9 +7,11 @@
 | [Getting Started](getting-started.md) | Install, first run, pick a profile |
 | [CLI Reference](cli-reference.md) | All flags, subcommands, and translation tables |
 | [Profiles](profiles.md) | Create and configure named agent profiles |
+| [Custom Agent CLIs](custom-agents.md) | Add your own agent CLI as a first-class profile |
 | [Configuration](configuration.md) | Global settings (`config.toml`) |
 | [Environment Variables](environment-variables.md) | All env vars unleash sets or reads |
 | [Crossload](crossload.md) | Portable conversation histories across CLIs |
+| [Crossload Matrix](crossload-matrix.md) | Per-pair lossless/partial status across all agents |
 | [Docker](docker.md) | Sandboxed containers and multi-agent mesh |
 | [Plugins](plugins.md) | Bundled plugin index and custom plugin pointers |
 


### PR DESCRIPTION
## Summary

Two existing user-facing docs were missing from `docs/README.md`'s User Guide index:

- **`custom-agents.md`** — added in #268 today, the full schema reference for the `[[custom_agents]]` config section
- **`crossload-matrix.md`** — existed before today, just never indexed, freshly refreshed in #276 to cover all 7 agents

Two-row addition to the User Guide table. No other docs touched.

## How it was found

Followup scan after Markus's docs-drift streak (#271–#274, #276). `grep` confirmed all links in `docs/README.md` resolve (no broken refs) — the only drift was missing-from-index, not stale-content.

## Test plan

- [x] Both target files exist (`docs/custom-agents.md`, `docs/crossload-matrix.md`)
- [x] `grep -oE '\([a-zA-Z0-9_/.-]+\.md\)' docs/README.md` — every link resolves