### PR TITLE
docs(README): drop shipped 'custom agents' from roadmap + link Additional-CLIs note

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,10 @@ unleash claude -x                    # Interactive session picker
 
 :green_circle: Lossless · :yellow_circle: Partial · :white_circle: Pending — [Full matrix](docs/crossload-matrix.md)
 
+Pi / Hermes / Antigravity (`agy`) are wired but not in the headline matrix yet — see [Additional CLIs](docs/crossload-matrix.md#additional-clis).
+
 ### On the Roadmap
 
-- Custom agent CLI support (bring your own agent binary with unified flag mapping)
 - Directory navigation and workspace management
 - PTY terminal middleware for session scripting
 


### PR DESCRIPTION
## Summary

Two small README fixes from the §7 docs-drift widening:

- **"Custom agent CLI support"** was listed under "On the Roadmap". It has shipped (`CustomAgentConfig` at `src/config.rs:270`, `AgentType::Custom` at `src/agents.rs:29`, integration tests at `tests/custom_agents.rs`, user docs at `docs/custom-agents.md` from #268, indexed in docs/README.md via #277). Removed from the roadmap list.
- Remaining roadmap items (directory navigation, PTY terminal middleware) **verified** still unimplemented via grep — kept as-is.
- **Crossload section** now mentions Pi/Hermes/Antigravity (`agy`) with a link to the [Additional CLIs](docs/crossload-matrix.md#additional-clis) note added in #276. The headline 4×4 matrix stays untouched since synthetic-fixture end-to-end coverage doesn't exist for those three yet.

## Test plan

- [x] Custom agent shipped: `grep -n CustomAgentConfig src/config.rs` returns hits at line 270+
- [x] Directory navigation unimplemented: `grep -rE "workspace_manager|directory_navigation" src/` returns nothing meaningful
- [x] PTY middleware unimplemented: `grep -rE "PtyMiddleware|fn.*pty" src/` returns nothing meaningful
- [ ] CI green (docs-only)