### PR TITLE
docs(CONTRIBUTING): mention cargo fmt --check now that it's CI-enforced

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,14 @@ Welcome, humans and bots alike! We're happy you want to contribute.
 
 1. Fork the repo and create a branch from `main`
 2. Make your changes
-3. Ensure CI passes (`cargo test`, `cargo clippy`, `cargo build --release`)
+3. Ensure CI passes (`cargo test`, `cargo clippy`, `cargo fmt --check`, `cargo build --release`)
 4. Open a pull request
 
 ## Guidelines
 
 - **Keep PRs focused.** One feature or fix per PR. Small PRs get reviewed faster.
 - **Limit open PRs.** Please don't have more than 5 open PRs at a time. Finish what's in flight before starting more.
-- **CI must pass.** All PRs must pass CI before merge. Run `cargo test` and `cargo clippy` locally first.
+- **CI must pass.** All PRs must pass CI before merge. Run `cargo test`, `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --all -- --check` locally first.
 - **Use conventional commits.** `feat:`, `fix:`, `docs:`, `chore:`, etc.
 - **Write tests** for new functionality where applicable.
 - **Update docs** if your change affects user-facing behavior.


### PR DESCRIPTION
## Summary

PR #270 wired `cargo fmt --all -- --check` into the lint workflow as a gating CI step. `CONTRIBUTING.md` predates that (last touched 2026-03-30 at initial release) and still lists only `cargo test` + `cargo clippy` as the local pre-flight, so contributors hit avoidable rustfmt CI failures.

- **Step 3 in Getting Started**: add `cargo fmt --check` to the CI-passes checklist.
- **"CI must pass" guideline**: expand the local-run sentence to include the actual enforced clippy invocation (`--all-targets -- -D warnings`) and `cargo fmt --all -- --check`, matching what the `lint` workflow runs.

No process change; just surfaces what CI already enforces.

## Test plan

- [x] Both `cargo fmt` invocations match the actual command in `.github/workflows/lint.yml`
- [x] Local `cargo fmt --all -- --check` on this branch — clean