### PR TITLE
docs(README): fix intro typos (verison/ritch/duplicate 'for') + add agy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 **unleash** is...
   
-* an **agent CLI verison manager**. `nvm` for AI agents such as claude code, codex, gemini and opencode with a ritch TUI 
-  
-* a compatibility layer that lets you start in claude code, then continue where you left off in codex.  
+* an **agent CLI version manager**. `nvm` for AI agents — claude code, codex, antigravity, gemini, opencode, pi, hermes — with a rich TUI
+
+* a compatibility layer that lets you start in claude code, then continue where you left off in codex.
 
 * a **unified cli** that brings all your code agents under the same signature. No more confusion about `claude -p` vs `codex run`
 
@@ -33,7 +33,7 @@ docker run -it --rm -e ANTHROPIC_API_KEY -e CLAUDE_CODE_OAUTH_TOKEN -e OPENAI_AP
 
 > See [Installation](#installation) for build-from-source, platform details, and non-interactive mode.
 
-> **unleash is best run in a sandbox.** Bring your own or use ours — see the [Docker + gVisor sandbox guide](docs/docker.md) for for more  hardened containers with LAN isolation.
+> **unleash is best run in a sandbox.** Bring your own or use ours — see the [Docker + gVisor sandbox guide](docs/docker.md) for more hardened containers with LAN isolation.
 
 
 
@@ -42,6 +42,7 @@ docker run -it --rm -e ANTHROPIC_API_KEY -e CLAUDE_CODE_OAUTH_TOKEN -e OPENAI_AP
 unleash          # Launch TUI (profiles, versions, settings)
 unleash claude   # Start Claude with unleash features
 unleash codex    # Start Codex with unleash features
+unleash agy      # Start Antigravity CLI with unleash features
 unleash gemini   # Start Gemini CLI with unleash features
 unleash opencode # Start OpenCode with unleash features
 unleash pi       # Start Pi with unleash features


### PR DESCRIPTION
## Summary

User-visible drift in the README intro (the first three sentences a visitor reads on the GitHub project page):

- \`verison\` → \`version\` (typo in the very first bullet)
- \`ritch TUI\` → \`rich TUI\` (same line)
- "claude code, codex, gemini and opencode" → all 7 supported agents — same 4-agent drift pattern fixed in #271 / #273 / #274 / #278
- "for for more  hardened" → "for more hardened" (duplicated word + doubled space in the sandbox callout)
- **After-Install** code block missing \`unleash agy\` — added so the example matches the 7 default profiles (\`claude, codex, agy, gemini, opencode, pi, hermes\`)

## Test plan

- [x] No remaining typos: \`grep -E "verison|ritch|for for" README.md\` returns empty
- [x] Agent list matches \`ProfileManager::default_profiles\`
- [ ] CI green (docs-only)