### PR TITLE
docs(docker): note which agents the sandbox supports

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -20,6 +20,11 @@ unleash sandbox run
 unleash sandbox status
 ```
 
+**Supported agents in the sandbox:** `claude`, `codex`, `gemini`,
+`opencode`, `pi`, plus `bash` and `unleash` itself. Hermes and
+Antigravity (`agy`) are not yet wired into the sandbox image / compose
+services — run those on the host or build a custom image.
+
 ### Named Sandboxes
 
 Run multiple independent sandboxes with `--name`:


### PR DESCRIPTION
## Summary

\`unleash sandbox run <agent>\` validates against a hard-coded allowlist at \`src/sandbox.rs:943\`:

\`\`\`rust
let valid_agents = ["claude", "codex", "gemini", "opencode", "pi", "bash", "unleash"];
\`\`\`

Hermes and Antigravity (\`agy\`) are not on the list — they aren't wired into the sandbox image's \`unleash install\` step or into \`docker-compose.yml\` as services. Today \`unleash sandbox run hermes\` fails with \`Unknown agent 'hermes'. Valid agents: …\`.

After the recent README/docs wave (#271, #273, #281) telling users "the seven default profiles map to their respective agents", a reader landing on docs/docker.md would reasonably expect all seven to be sandboxable. They aren't. Adding the limitation up front in docs/docker.md.

Adding Hermes/Agy to the sandbox image is a separate engineering task — deferred, since both have install paths (curl script, AUR helper) that don't fit the npm/binary pattern the existing image uses.

## Test plan

- [x] Allowlist verified at \`src/sandbox.rs:943\`
- [x] Compose service list verified: \`grep '^  [a-z]\+:' docker/docker-compose.yml\` returns \`bash, unleash, claude, codex, gemini, opencode, pi, sandbox\` — no hermes/agy
- [ ] CI green (docs-only)