### PR TITLE
docs(docker): 'all 5/all agent CLIs' → '5 of 7 bundled' + drop stale antigravity TODO

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,15 @@
 # unleash Docker Image
 #
-# Sandboxed container with all 5 supported coder CLIs:
+# Sandboxed container with 5 of unleash's 7 built-in coder CLIs:
 #   - Claude Code (Anthropic)
 #   - Codex (OpenAI)
 #   - Gemini CLI (Google)
 #   - OpenCode
 #   - Pi (mariozechner/pi-coding-agent)
+#
+# Not bundled: Hermes Agent (curl install script) and Antigravity CLI
+# (AUR helper; see PR #259) — both have install paths that don't fit
+# the npm/binary pattern this image uses. Run them on the host.
 #
 # Build:
 #   docker build -f docker/Dockerfile -t unleash .
@@ -147,7 +151,7 @@ RUN chown unleash:unleash /home/unleash/.config/starship.toml \
 USER unleash
 WORKDIR /workspace
 
-# -- Install all 5 agent CLIs using unleash's own install paths --
+# -- Install the 5 bundled agent CLIs using unleash's own install paths --
 # Claude Code: native GCS binary (not npm)
 # Codex: prebuilt binary from GitHub releases
 # Gemini CLI: npm

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,12 +1,15 @@
 # unleash CUDA Docker Image
 #
 # GPU-enabled development environment for AI training on Vast.ai and other GPU clouds.
-# Includes CUDA 12.8 toolkit, PyTorch, all 5 supported coder CLIs:
+# Includes CUDA 12.8 toolkit, PyTorch, and 5 of unleash's 7 built-in coder CLIs:
 #   - Claude Code (Anthropic)
 #   - Codex (OpenAI)
 #   - Gemini CLI (Google)
 #   - OpenCode
 #   - Pi (mariozechner/pi-coding-agent)
+#
+# Not bundled: Hermes Agent and Antigravity CLI — see docker/Dockerfile
+# header for the reason. Run them on the host.
 #
 # Build:
 #   docker build -f docker/Dockerfile.cuda -t marksverdhei/unleash:cuda .
@@ -49,7 +52,7 @@ RUN cargo build --release \
 FROM nvidia/cuda:12.8.0-devel-ubuntu24.04 AS cuda
 
 LABEL maintainer="Heiervang Technologies"
-LABEL description="unleash CUDA - GPU-enabled dev environment with all 5 agent CLIs, CUDA 12.8 toolkit, PyTorch"
+LABEL description="unleash CUDA - GPU-enabled dev environment with 5 agent CLIs (claude/codex/gemini/opencode/pi), CUDA 12.8 toolkit, PyTorch"
 LABEL org.opencontainers.image.source="https://github.com/heiervang-technologies/unleash"
 
 # Install Node 22 via nodesource + dev tools
@@ -128,8 +131,10 @@ ENV SANDBOX_NAME=cuda-sandbox
 USER unleash
 WORKDIR /workspace
 
-# -- Install all 5 agent CLIs --
-# TODO: Once antigravity-cli lands (PR #198), add: npm install -g @google/antigravity-cli
+# -- Install the 5 bundled agent CLIs --
+# Antigravity install path is the AUR helper (PR #259) — incompatible with
+# the Ubuntu base; not installed here. Hermes uses a curl install script
+# that isn't run at build time either. Both can be installed at runtime.
 RUN unleash install claude codex gemini pi \
     && npm install -g opencode-ai@latest
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -125,7 +125,8 @@ docker run --gpus all -it --rm marksverdhei/unleash:cuda
 ```
 
 This image adds CUDA 12.8 toolkit, PyTorch with GPU support, and Python 3 on
-top of the standard unleash image with all agent CLIs.
+top of the standard unleash image with the 5 bundled agent CLIs
+(claude/codex/gemini/opencode/pi).
 
 ### Build Locally
 
@@ -162,7 +163,7 @@ vastai search offers 'gpu_ram>=24 cuda_vers>=12.0' --limit 5
 vastai create instance <template-id> <offer-id> --disk 50
 ```
 
-Inside the instance, all agent CLIs and PyTorch are ready:
+Inside the instance, the 5 bundled agent CLIs and PyTorch are ready:
 
 ```bash
 unleash claude                                    # start coding


### PR DESCRIPTION
## Summary

Pair with #282 which made the same disclosure for \`unleash sandbox run\`. The Dockerfiles and \`docs/docker.md\` claimed "all 5 supported coder CLIs" or "all agent CLIs" — but unleash now supports 7 built-in agents (claude, codex, agy, gemini, opencode, pi, hermes), so "all X" reads as misleading or wrong depending on the count cited.

Honest framing throughout:

| Where | Before | After |
|-------|--------|-------|
| \`docker/Dockerfile\` header | "all 5 supported coder CLIs" | "5 of unleash's 7 built-in coder CLIs" + not-bundled list (Hermes, Antigravity) with reasons |
| \`docker/Dockerfile.cuda\` header | same | same fix |
| \`docker/Dockerfile.cuda\` LABEL | "all 5 agent CLIs" | "5 agent CLIs (claude/codex/gemini/opencode/pi)" |
| Both Dockerfiles install-step comment | "all 5 agent CLIs" | "the 5 bundled agent CLIs" |
| \`docs/docker.md\` CUDA section | "with all agent CLIs" | "with the 5 bundled agent CLIs (claude/codex/gemini/opencode/pi)" |
| \`docs/docker.md\` Vast.ai section | "all agent CLIs and PyTorch are ready" | "the 5 bundled agent CLIs and PyTorch are ready" |

Also drops the **stale CUDA Dockerfile TODO** at line 132:

\`\`\`dockerfile
# TODO: Once antigravity-cli lands (PR #198), add: npm install -g @google/antigravity-cli
\`\`\`

PR #198 was the original (npm) approach which never shipped — #259 went with the AUR-helper path, which is incompatible with the Ubuntu base. Replaced with a current-reality comment.

## Test plan

- [x] No more "all 5/all agent" drift: \`grep -nE "(all [0-9]+ agent|all agent CLIs)" docker/ docs/docker.md\` returns empty
- [x] Actual install set verified: \`unleash install claude codex gemini pi\` + \`npm install -g opencode-ai\` in both Dockerfiles
- [ ] CI green (touches Dockerfile → Docker Build job will run)