### PR TITLE
fix(plugins): use canonical unleash-refresh/unleash-exit names

### DIFF
--- a/plugins/bundled/auto-mode/README.md
+++ b/plugins/bundled/auto-mode/README.md
@@ -52,7 +52,7 @@ The plugin uses Claude Code's `Stop` hook to prevent Claude from ending its turn
 │  Claude continues working...                                │
 │       │                                                     │
 │       ↓                                                     │
-│  Owner says "stop" OR runs exit-claude                      │
+│  Owner says "stop" OR runs unleash-exit                      │
 │       │                                                     │
 │       ↓                                                     │
 │  Flag file removed → Stop hook allows exit                  │
@@ -67,13 +67,13 @@ When you run `/auto`, Claude enters autonomous mode with these behaviors:
 1. **No voluntary exit** - Stop hook blocks Claude from ending its turn
 2. **Continuous operation** - After each task, Claude looks for more work
 3. **Owner contact** - Claude checks for MCP notification tools to contact you
-4. **Exit only by command** - Only `exit-claude` or owner's explicit "stop" ends the session
+4. **Exit only by command** - Only `unleash-exit` or owner's explicit "stop" ends the session
 
 ## Exit Conditions
 
 Claude will only exit auto mode when:
 - You explicitly tell it to stop ("quit", "exit", "stop", "that's enough")
-- You run `exit-claude` (automatically deactivates auto mode)
+- You run `unleash-exit` (automatically deactivates auto mode)
 - A critical unrecoverable error occurs
 
 ## MCP Integration
@@ -120,7 +120,7 @@ The Stop hook must be configured in `~/.claude/settings.json`:
 
 By default, when Claude tries to exit in auto mode, it receives the message:
 ```
-To exit: run 'exit-claude' via Bash tool. Do not end your turn without taking action.
+To exit: run 'unleash-exit' via Bash tool. Do not end your turn without taking action.
 ```
 
 You can customize this message globally using either the CLI or TUI.
@@ -167,7 +167,7 @@ The stop hook uses the following priority when determining which message to show
 
 ## Requirements
 
-- Must run under `unleash` wrapper for `exit-claude` to work
+- Must run under `unleash` wrapper for `unleash-exit` to work
 - Stop hook must be configured in settings
 - Optional: MCP server with notification capabilities
 
@@ -176,7 +176,7 @@ The stop hook uses the following priority when determining which message to show
 - **1.1.0** (2026-01-07) - Stop hook enforcement
   - Added Stop hook to block Claude from ending turn
   - Flag file system for activation/deactivation
-  - Integration with exit-claude for clean shutdown
+  - Integration with unleash-exit for clean shutdown
 
 - **1.0.0** (2026-01-07) - Initial release
   - Basic /auto command with instructions

--- a/plugins/bundled/auto-mode/commands/auto.md
+++ b/plugins/bundled/auto-mode/commands/auto.md
@@ -37,7 +37,7 @@ You are now in **AUTO MODE**. A Stop hook will prompt you to check MCP tools bef
 
 4. **Exit options**: The session can end when:
    - Owner says stop/quit/exit
-   - Running `exit-claude`
+   - Running `unleash-exit`
    - Running `/auto` again to toggle off
 
 ### Behavior Guidelines
@@ -45,7 +45,7 @@ You are now in **AUTO MODE**. A Stop hook will prompt you to check MCP tools bef
 - **Be proactive**: If you see something that needs doing, do it
 - **Use TodoWrite**: Track your work and pending tasks
 - **Check MCP tools**: Signal server, omni-mcp may have tasks or messages
-- **Self-restart if needed**: Use `restart-claude` to refresh context
+- **Self-restart if needed**: Use `unleash-refresh` to refresh context
 
 ---
 

--- a/plugins/bundled/auto-mode/hooks/auto-mode-stop.sh
+++ b/plugins/bundled/auto-mode/hooks/auto-mode-stop.sh
@@ -25,7 +25,7 @@ AUTO_MODE_FILE="${AUTO_MODE_DIR}/active-${WRAPPER_PID}"
 if [[ -f "${AUTO_MODE_FILE}" ]]; then
     # Check for custom reminder message (priority order)
     REMINDER_FILE="${AUTO_MODE_DIR}/reminder-${WRAPPER_PID}"
-    DEFAULT_MSG="You ended your turn, but you are in auto-mode. If you are awaiting a decision, select your recommended decision. If you are done, consider that you have covered all other diligences, testing, documentation, technical debt and cleanup. Use the executables (in PATH) 'restart-claude' if you need to restart yourself, and 'exit-claude' if you are truly done with all your tasks."
+    DEFAULT_MSG="You ended your turn, but you are in auto-mode. If you are awaiting a decision, select your recommended decision. If you are done, consider that you have covered all other diligences, testing, documentation, technical debt and cleanup. Use the executables (in PATH) 'unleash-refresh' if you need to restart yourself, and 'unleash-exit' if you are truly done with all your tasks."
 
     if [[ -f "${REMINDER_FILE}" ]]; then
         # 1. Session-specific reminder (highest priority)

--- a/plugins/bundled/auto-mode/scripts/toggle-auto-mode.sh
+++ b/plugins/bundled/auto-mode/scripts/toggle-auto-mode.sh
@@ -62,6 +62,6 @@ else
     echo "${CLAUDE_SESSION_ID:-unknown}" > "${AUTO_MODE_FILE}"
     echo "AUTO MODE: ON"
     echo "Stop hook enforcement active. You cannot end your turn voluntarily."
-    echo "Toggle off with /auto or exit with exit-claude"
+    echo "Toggle off with /auto or exit with unleash-exit"
     sync_cli_visual "on"
 fi

--- a/plugins/bundled/process-restart/commands/restart.md
+++ b/plugins/bundled/process-restart/commands/restart.md
@@ -1,21 +1,21 @@
 ---
 name: restart
 description: Restart Claude Code while preserving your session
-allowed-tools: Bash(restart-claude)
+allowed-tools: Bash(unleash-refresh)
 ---
 
 # Restart Claude Code
 
-To restart, simply run the restart-claude command:
+To restart, simply run the unleash-refresh command:
 
 ```bash
-restart-claude
+unleash-refresh
 ```
 
 Or with a custom message to receive after restart:
 
 ```bash
-restart-claude "Continue working on the feature"
+unleash-refresh "Continue working on the feature"
 ```
 
 ## Requirements
@@ -24,7 +24,7 @@ You must be running under the `unleash` wrapper (check: `echo $AGENT_UNLEASH` sh
 
 ## What Happens
 
-1. The restart-claude script creates a trigger file
+1. The unleash-refresh script creates a trigger file
 2. Claude process is terminated
 3. The wrapper detects the trigger file
 4. Wrapper restarts Claude with `--continue` flag
@@ -32,8 +32,8 @@ You must be running under the `unleash` wrapper (check: `echo $AGENT_UNLEASH` sh
 
 ## Your Task
 
-Run the restart-claude command now:
+Run the unleash-refresh command now:
 
 ```bash
-restart-claude
+unleash-refresh
 ```


### PR DESCRIPTION
## Summary

The scripts were renamed long ago (\`scripts/restart-claude\` → \`scripts/unleash-refresh\`, same for \`exit-claude\` → \`unleash-exit\`), but five bundled-plugin files still referenced the old names in user-visible places. **Worst case**: \`/restart\` slash command's \`allowed-tools: Bash(restart-claude)\` frontmatter would block Claude Code from invoking \`unleash-refresh\`, and any user without the install.sh compat symlink would get "command not found".

| File | What it said | What it does |
|------|--------------|--------------|
| \`plugins/bundled/process-restart/commands/restart.md\` | \`restart-claude\` x5 + \`allowed-tools: Bash(restart-claude)\` frontmatter | The \`/restart\` slash command body Claude reads when triggered |
| \`plugins/bundled/auto-mode/commands/auto.md\` | \`exit-claude\` + \`restart-claude\` | The \`/auto\` slash command's guidance to the agent |
| \`plugins/bundled/auto-mode/scripts/toggle-auto-mode.sh\` | \`exit-claude\` | Printed on every \`/auto\` toggle |
| \`plugins/bundled/auto-mode/hooks/auto-mode-stop.sh\` | \`restart-claude\` + \`exit-claude\` | Default Stop-hook reminder injected into the agent |
| \`plugins/bundled/auto-mode/README.md\` | 6 refs | User docs for auto-mode |

The compat symlinks in \`scripts/install.sh:194-196\` (which the \`plugins/bundled/process-restart/README.md\` "backward compatibility" note refers to) are intentionally left in place — they exist for users with shell aliases or scripts that hard-coded the old names. This PR only fixes the *canonical-name* drift in places the plugins themselves emit.

## Test plan

- [x] \`grep -rE "restart-claude|exit-claude" plugins/bundled/\` after edits returns only the explicit backward-compat note in process-restart/README.md
- [x] \`shellcheck -S warning\` clean on the two modified shell files
- [ ] CI green