### PR TITLE
fix(agents/tui): src-side alias drift + remove false antigravity npm gate

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -435,7 +435,10 @@ impl AgentDefinition {
                 worktree_flag: Some("--worktree".to_string()),
             },
             github_repo: None,
-            npm_package: Some("@google/antigravity-cli".to_string()),
+            // No npm package exists for antigravity — `@google/antigravity-cli`
+            // is not published. Real install path is the AUR helper (see
+            // VersionManager::install_antigravity_version_streaming and PR #259).
+            npm_package: None,
             enabled: true,
         }
     }
@@ -704,7 +707,8 @@ impl AgentManager {
                 }
             }
 
-            // Fallback for npm-based global installations (@google/antigravity-cli) or custom paths
+            // Fallback for binaries installed outside the agent's canonical path
+            // (e.g. AUR-installed `agy`, custom `--prefix`, or distro packages).
             if version.is_none() {
                 if let Ok(bin_path) = which::which(&agent.binary) {
                     if let Ok(output) = Command::new(&bin_path).arg("--version").output() {
@@ -1439,6 +1443,19 @@ mod tests {
             hermes.github_repo.as_deref(),
             Some("NousResearch/hermes-agent")
         );
+    }
+
+    #[test]
+    fn antigravity_has_no_npm_package() {
+        // `@google/antigravity-cli` is not published on npm. Setting it on
+        // the definition causes false "npm required" warnings, wasted 404
+        // queries in the version-check path, and pointless `npm uninstall`
+        // attempts. The real install path is the AUR helper — see
+        // VersionManager::install_antigravity_version_streaming.
+        let agy = AgentDefinition::antigravity();
+        assert!(agy.npm_package.is_none());
+        assert_eq!(agy.binary, "agy");
+        assert_eq!(agy.agent_type, AgentType::Antigravity);
     }
 
     #[test]

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -1,7 +1,7 @@
 //! Claude launcher with wrapper features
 //!
 //! Implements the wrapper loop that enables:
-//! - Self-restart capability (restart-claude command)
+//! - Self-restart capability (unleash-refresh command)
 //! - Plugin system integration
 //! - Auto-mode via Stop hook + flag file system
 //! - Process management
@@ -686,7 +686,7 @@ fn check_authentication() {
     eprintln!();
 }
 
-/// Create restart trigger file (called by restart-claude command)
+/// Create restart trigger file (called by unleash-refresh command)
 #[allow(dead_code)]
 pub fn trigger_restart(wrapper_pid: u32, message: Option<&str>) -> io::Result<()> {
     let trigger_file = cache_dir().join(format!("restart-trigger-{}", wrapper_pid));
@@ -702,7 +702,7 @@ pub fn trigger_restart(wrapper_pid: u32, message: Option<&str>) -> io::Result<()
     Ok(())
 }
 
-/// Exit without restart (called by exit-claude command)
+/// Exit without restart (called by unleash-exit command)
 #[allow(dead_code)]
 pub fn trigger_exit(wrapper_pid: u32) -> io::Result<()> {
     // Just send SIGTERM to the wrapper process

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1583,7 +1583,7 @@ impl App {
     /// Get the default stop prompt from the hook script (source of truth)
     fn get_default_stop_prompt(&self) -> String {
         const HOOK_RELATIVE: &str = "plugins/bundled/auto-mode/hooks/auto-mode-stop.sh";
-        const FALLBACK_MSG: &str = "You ended your turn, but you are in auto-mode. If you are awaiting a decision, select your recommended decision. If you are done, consider that you have covered all other diligences, testing, documentation, technical debt and cleanup. Use the executables (in PATH) 'restart-claude' if you need to restart yourself, and 'exit-claude' if you are truly done with all your tasks.";
+        const FALLBACK_MSG: &str = "You ended your turn, but you are in auto-mode. If you are awaiting a decision, select your recommended decision. If you are done, consider that you have covered all other diligences, testing, documentation, technical debt and cleanup. Use the executables (in PATH) 'unleash-refresh' if you need to restart yourself, and 'unleash-exit' if you are truly done with all your tasks.";
 
         // Build candidate paths to search
         let mut candidates: Vec<String> = Vec::new();


### PR DESCRIPTION
## Summary

Two real bugs in source code surfaced by the same §7 widening that caught the plugin command-frontmatter issue in #284:

**\`src/tui/app.rs::get_default_stop_prompt\` FALLBACK_MSG** — the Rust-side mirror of the Stop-hook fallback still told the agent to use \`restart-claude\` / \`exit-claude\`. Same fix as #284 applied in the plugin shell hook, but for the compiled-binary fallback path used when the hook script can't be located (headless install, \`AGENT_UNLEASH_ROOT\` unset, exe outside the standard layout).

**\`src/agents.rs::antigravity\`** had \`npm_package: Some("@google/antigravity-cli")\`. That package was never published — verified during the PR #259 investigation, documented in \`src/updater.rs:1185\`. Setting the field anyway caused three downstream problems on every \`unleash update [--all]\` cycle:

| Where | Stale-state behavior | After |
|-------|---------------------|-------|
| \`updater.rs:125\` | False "npm not found. Required for: Antigravity CLI" warning when npm is missing — but npm is *not* needed for antigravity (AUR is) | warning skips antigravity |
| \`updater.rs:535\` | \`get_latest_npm_version("@google/antigravity-cli")\` → 404 → fallthrough on every version check | npm branch skipped |
| \`updater.rs:904\` | \`npm uninstall -g @google/antigravity-cli\` → 404 → fallthrough on every uninstall | npm branch skipped |

Fixed by setting \`npm_package: None\` with a comment pointing at the real install path (\`VersionManager::install_antigravity_version_streaming\` → AUR helper). Added a regression test \`antigravity_has_no_npm_package\` mirroring \`hermes_has_no_npm_package\`.

Also tidied three stale comment references to \`restart-claude\`/\`exit-claude\` in \`src/agents.rs:707\` and \`src/launcher.rs:4,689,705\` (comments only — no behavior change).

## Test plan

- [x] \`cargo test --lib agents::tests::antigravity_has_no_npm_package\` — passes
- [x] \`cargo test --lib\` — 563/563 pass (3 pre-existing ignored)
- [x] \`cargo clippy --all-targets --no-deps -- -D warnings\` — clean
- [x] \`cargo fmt --all -- --check\` — clean
- [ ] CI green