### PR TITLE
docs(CLAUDE.md): correct alias deprecation note — symlinks still exist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Or with a custom message to receive after restart:
 unleash-refresh "Continue working on the feature"
 ```
 
-> **Note:** The old aliases `restart-claude` and `exit-claude` have been removed. Use `unleash-refresh` and `unleash-exit`.
+> **Note:** Prefer `unleash-refresh` / `unleash-exit` — these are the canonical names. The old `restart-claude` / `exit-claude` are still available as backward-compat symlinks created by `scripts/install.sh` and will keep working, but new code and docs should use the canonical names.
 
 ### What Happens When You Restart
 


### PR DESCRIPTION
## Summary

The CLAUDE.md note said:

> The old aliases \`restart-claude\` and \`exit-claude\` have been removed. Use \`unleash-refresh\` and \`unleash-exit\`.

But \`scripts/install.sh:194-196\` actively creates them as backward-compat symlinks every time someone installs, and \`plugins/bundled/process-restart/README.md\` correctly documents them as "still work for backward compatibility":

\`\`\`bash
# scripts/install.sh
ln -sf "\$BIN_DIR/unleash-refresh" "\$BIN_DIR/restart-claude"
ln -sf "\$BIN_DIR/unleash-exit" "\$BIN_DIR/exit-claude"
\`\`\`

This is the worst kind of doc drift: AI agents reading CLAUDE.md internalize "those commands don't exist" and refuse to suggest them, while users on any install.sh-provisioned machine have them working fine. The contradiction is also why earlier PRs (#266 / #284 / #286) all had to be carefully scoped — neither "everything's an alias" nor "everything's been removed" was true.

New wording: "Prefer the canonical names. Old aliases are still available as backward-compat symlinks and will keep working, but new code and docs should use the canonical names." Matches install.sh + plugin README.

If you'd rather actually drop the symlinks too, this is the natural moment — both the install.sh lines and the plugin README note would come out in the same PR. Surface, not action.

## Test plan

- [x] Reality-check: \`grep -A 2 'restart-claude' scripts/install.sh\` shows the \`ln -sf\` lines are present
- [ ] CI green (docs-only)