### PR TITLE
docs(crossload-matrix): drop phantom #303 issue references

### DIFF
--- a/docs/crossload-matrix.md
+++ b/docs/crossload-matrix.md
@@ -82,7 +82,7 @@ Hub-and-spoke model: O(N) converters, not O(N²) direct pairs.
 
 ## Planned Improvements
 
-### Index Sync (#303)
+### Index Sync
 
 On crossload, automatically update the target CLI's session index:
 - **Claude**: append to `~/.claude/history.jsonl`
@@ -90,7 +90,7 @@ On crossload, automatically update the target CLI's session index:
 - **Gemini**: write `logs.json` entries (already implemented)
 - **OpenCode**: INSERT into SQLite (implemented)
 
-### Session List UX (#303)
+### Session List UX
 
 `unleash sessions` should display a clear tabular view:
 
@@ -111,7 +111,7 @@ Columns:
 
 ## Tracked Issues
 
-- [#303](https://github.com/heiervang-technologies/unleash/issues/303) — Index sync, session list UX, real session filtering, OpenCode SQLite injection
+None of the items above currently have a dedicated GitHub issue — see the section headings for what's planned. Open a new issue if you're picking one up so it can be linked back here.
 
 ## Test Fixtures
 


### PR DESCRIPTION
## Summary

\`docs/crossload-matrix.md\` referenced GitHub issue #303 three times — section headings \`### Index Sync (#303)\` / \`### Session List UX (#303)\` plus a full-URL bullet under "Tracked Issues". The issue doesn't exist:

\`\`\`
$ gh issue view 303
GraphQL: Could not resolve to an issue or pull request with the
number of 303. (repository.issue)
\`\`\`

Looks like a placeholder that was never filed (current high-water mark is #288). The section content is still genuinely useful planning notes — kept it, just stripped the broken references. Updated the Tracked Issues block to say what's true: no GitHub-tracked issue exists for these items, file one if you pick one up.

## How it was found

Repo-maintenance §7 widening — cross-checked every \`#NNN\` reference in user-facing docs (\`docs/ README.md CLAUDE.md CONTRIBUTING.md\`) against actual issue/PR state via \`gh issue view\` / \`gh pr view\`. #303 was the only phantom; other historical refs (#258 closed, #198 merged, #110 merged, etc.) all resolve correctly.

## Test plan

- [x] \`grep -rn "#303" --include="*.md" --include="*.rs"\` returns empty after edits
- [ ] CI green (docs-only)