### PR TITLE
docs: widen #272 plugin-dev link fix into restart-refresh + mcp-refresh

### DIFF
--- a/docs/extensions/restart-refresh.md
+++ b/docs/extensions/restart-refresh.md
@@ -2690,7 +2690,7 @@ interface RestartState {
 
 - [MCP Refresh Plugin README](<REPO_ROOT>/plugins/bundled/mcp-refresh/README.md)
 - [Process Restart Plugin README](<REPO_ROOT>/plugins/bundled/process-restart/README.md)
-- [Plugin Development Guide](<REPO_ROOT>/docs/extensions/plugin-development.md)
+- [Plugin Development Guide](<REPO_ROOT>/docs/internal/claude-code/plugin-development.md)
 
 - [Testing Guide](<REPO_ROOT>/docs/extensions/testing-guide.md)
 
@@ -2698,7 +2698,7 @@ interface RestartState {
 
 Contributions to improve these plugins are welcome! Please:
 
-1. Read the [Plugin Development Guide](<REPO_ROOT>/docs/extensions/plugin-development.md)
+1. Read the [Plugin Development Guide](<REPO_ROOT>/docs/internal/claude-code/plugin-development.md)
 2. Test changes locally with `--plugin-dir`
 3. Update documentation
 4. Submit PR with clear description

--- a/plugins/bundled/mcp-refresh/README.md
+++ b/plugins/bundled/mcp-refresh/README.md
@@ -253,7 +253,7 @@ If Claude Code's source becomes available or if core APIs are exposed:
 - [MCP Refresh & Process Restart Guide](../../../docs/extensions/restart-refresh.md) - Comprehensive guide for both plugins
 - [Process Restart Plugin](../process-restart/README.md)
 
-- [Plugin Development Guide](../../../docs/extensions/plugin-development.md)
+- [Plugin Development Guide](../../../docs/internal/claude-code/plugin-development.md)
 
 ## License
 


### PR DESCRIPTION
## Summary

PR #272 corrected the stale \`docs/extensions/plugin-development.md\` link in \`docs/plugins.md\`. The same broken link survived in three more places — fixed here:

- **\`plugins/bundled/mcp-refresh/README.md:256\`** — Related Documentation pointer in the user-facing plugin README.
- **\`docs/extensions/restart-refresh.md:2693, 2701\`** — two refs in the long-form 2700-line guide (uses \`<REPO_ROOT>/...\` placeholder syntax, sed handled them cleanly).

The real plugin-development guide lives at \`docs/internal/claude-code/plugin-development.md\` — same target CLAUDE.md was corrected to in #264.

## How it was found

Continued the same widen-the-grep pattern that's now caught real bugs in #284, #286, #288, #290:

\`\`\`bash
grep -rn "docs/extensions/plugin-development" . --include="*.md"
\`\`\`

Discovered while inventorying per-plugin README relative-link targets after #291 added \`supercompact/README.md\`.

## Test plan

- [x] Post-edit grep returns empty across the whole tree (excluding .git, target, docs/superpowers)
- [x] Target file exists: \`test -f docs/internal/claude-code/plugin-development.md\` → 0
- [ ] CI green (docs-only, but plugin path → fuller workflow set runs)