### PR TITLE
docs(auto-mode): wrapper auto-syncs the Stop hook, no manual JSON edit

### DIFF
--- a/plugins/bundled/auto-mode/README.md
+++ b/plugins/bundled/auto-mode/README.md
@@ -97,7 +97,15 @@ If found, Claude uses these to request clarification when blocked or report prog
 
 ## Configuration
 
-The Stop hook must be configured in `~/.claude/settings.json`:
+The Stop hook is wired automatically — `unleash`'s launcher syncs every
+bundled plugin's `hooks/hooks.json` into `~/.claude/settings.json` on
+startup via `HookManager::sync_plugin_hooks` (see `src/launcher.rs`
+around the `manager.sync_plugin_hooks(&plugin_dirs)` call). No manual
+JSON editing required.
+
+The canonical entry the wrapper installs (using `${CLAUDE_PLUGIN_ROOT}`
+so it resolves whether unleash is installed via curl, npm, Docker, or
+in-tree):
 
 ```json
 {
@@ -107,7 +115,7 @@ The Stop hook must be configured in `~/.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/unleash/plugins/bundled/auto-mode/hooks/auto-mode-stop.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/auto-mode-stop.sh"
           }
         ]
       }
@@ -115,6 +123,11 @@ The Stop hook must be configured in `~/.claude/settings.json`:
   }
 }
 ```
+
+To disable auto-mode entirely, add an `enabled_plugins` allowlist to
+`~/.config/unleash/config.toml` that excludes `auto-mode`, or toggle it
+from the **Plugins** tab in the unleash TUI. See
+[docs/extensions/configuration.md](../../../docs/extensions/configuration.md).
 
 ### Customizing the Stop Prompt
 


### PR DESCRIPTION
## Summary

Same fabricated-config class of bug as #293 / #289. The auto-mode README's Configuration section told users they "must" configure the Stop hook by hand-editing \`~/.claude/settings.json\` with a JSON snippet. That's wrong on two counts:

1. **unleash auto-syncs the hook.** \`HookManager::sync_plugin_hooks\` (call site: \`src/launcher.rs\` around \`manager.sync_plugin_hooks(&plugin_dirs)\`) discovers every bundled plugin's \`hooks/hooks.json\` on startup and merges entries into \`~/.claude/settings.json\`. No manual JSON editing required.
2. **The hardcoded path is broken.** The snippet used \`\$HOME/unleash/plugins/bundled/auto-mode/hooks/auto-mode-stop.sh\`. The real auto-synced entry uses \`\${CLAUDE_PLUGIN_ROOT}/hooks/auto-mode-stop.sh\` so it resolves whether unleash is installed via curl, npm, Docker, or \`~/.local/share/unleash\`.

**Net effect of the old wording:** any user who took it literally would end up with a stale, unbound hook entry in their settings.json that either shadows (and breaks) or duplicates the one the wrapper installs.

Rewrote to describe reality — auto-sync, canonical entry uses \`\${CLAUDE_PLUGIN_ROOT}\` — and added the disable path (\`enabled_plugins\` allowlist or TUI Plugins tab) matching the correction PR #293 applied to mcp-refresh.

## How it was found

Repo-maintenance §7 widening — applied the same \`grep -nE "settings\\.json|autoDetect|configPaths"\` scan to the other plugin READMEs after PR #293. Auto-mode was the only remaining offender (process-restart/omnihook/token-usage/hyprland-focus all clean).

## Test plan

- [x] \`grep "\$HOME/unleash/plugins" plugins/bundled/auto-mode/README.md\` returns empty
- [x] Real auto-sync call site verified at \`src/launcher.rs\` (\`sync_plugin_hooks\`)
- [x] Real hook entry verified at \`plugins/bundled/auto-mode/hooks/hooks.json\` (uses \`\${CLAUDE_PLUGIN_ROOT}\`)
- [ ] CI green (plugin path → fuller workflow set runs)