### PR TITLE
docs(supercompact): add two missing slash-command flags I missed in #291

### DIFF
--- a/plugins/bundled/supercompact/README.md
+++ b/plugins/bundled/supercompact/README.md
@@ -38,6 +38,8 @@ For per-session overrides without touching the TUI:
 ```
 /supercompact-budget                       # show current overrides
 /supercompact-budget <N>                   # set BUDGET to N tokens (manual mode)
+/supercompact-budget budget <N>            # set BUDGET (explicit form of the above)
+/supercompact-budget budget auto           # switch BUDGET back to auto (percentage-of-current)
 /supercompact-budget threshold <N>         # set the trigger THRESHOLD
 /supercompact-budget threshold default     # restore default threshold (180000)
 /supercompact-budget floor <N>             # set BUDGET floor (auto-mode min)


### PR DESCRIPTION
## Summary

Self-follow-up to #291. When I wrote \`plugins/bundled/supercompact/README.md\` there, I missed two flags that \`scripts/set-budget.sh\` actually supports and that the canonical \`commands/supercompact-budget.md\` already documents:

- **\`/supercompact-budget budget <N>\`** — explicit form of the \`<N>\` shorthand. Useful when scripting against the command and you want to be unambiguous.
- **\`/supercompact-budget budget auto\`** — switch BUDGET from manual back to auto (percentage-of-current) mode. Without this, a user who's set a manual budget has no documented way back to auto short of editing \`settings.env\` directly.

Both verified at \`set-budget.sh\`'s \`budget)\` case (~line 60):

\`\`\`bash
budget)
  val="\${2:-}"
  if [[ "\${val}" == "auto" ]]; then
    set_kv PLUGIN_SETTING_BUDGET_MODE auto
    unset_kv PLUGIN_SETTING_BUDGET
    echo "Switched BUDGET to auto (percentage-of-current) mode."
  elif is_int "\${val}"; then
    set_kv PLUGIN_SETTING_BUDGET_MODE manual
    set_kv PLUGIN_SETTING_BUDGET "\${val}"
    ...
\`\`\`

## How it was found

Repo-maintenance §7 widen-the-grep follow-up — cross-checked my own #291 README against the actual \`set-budget.sh\` script and the canonical \`commands/supercompact-budget.md\` after auditing the omnihook README in #295. Same pattern catches my own gaps, not just other contributors'.

## Test plan

- [x] Both new flags exist in \`set-budget.sh\`'s \`budget)\` case
- [x] \`commands/supercompact-budget.md\` also documents both flags (this PR brings the README in line with the canonical source)
- [ ] CI green (plugin path → fuller workflow set runs)