### PR TITLE
docs(process-restart): correct script paths (live in <repo>/scripts/, not plugin)

### DIFF
--- a/plugins/bundled/process-restart/README.md
+++ b/plugins/bundled/process-restart/README.md
@@ -108,11 +108,17 @@ After restart:
 
 | File | Purpose |
 |------|---------|
-| `scripts/unleash-refresh` | Restart command |
-| `scripts/unleash-exit` | Exit command |
-| `~/.cache/unleash/process-restart/` | Trigger files |
+| `<repo>/scripts/unleash-refresh` | Restart command — installed to `$PATH` via `install.sh` |
+| `<repo>/scripts/unleash-exit` | Exit command — installed to `$PATH` via `install.sh` |
+| `~/.cache/unleash/process-restart/` | Trigger files (`restart-trigger-<pid>`, `restart-message-<pid>`) |
 
-Note: The old aliases `restart-claude` and `exit-claude` still work for backward compatibility.
+Both scripts live in the project's top-level `scripts/` directory, not inside
+this plugin — `install.sh:188-191` symlinks them into `$BIN_DIR` so
+`unleash-refresh` / `unleash-exit` resolve on `$PATH`.
+
+Note: the old aliases `restart-claude` and `exit-claude` still work as
+backward-compat symlinks `install.sh` creates pointing at the canonical names.
+See [CLAUDE.md](../../../CLAUDE.md) for the current canonical naming guidance.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

\`process-restart/README.md\` File Locations table claimed \`scripts/unleash-refresh\` and \`scripts/unleash-exit\` lived inside the plugin (the table's filename column is relative-to-the-plugin per the surrounding entries). They don't — the plugin has no \`scripts/\` subdir at all:

\`\`\`
\$ find plugins/bundled/process-restart -type f
plugins/bundled/process-restart/README.md
plugins/bundled/process-restart/.claude-plugin/plugin.json
plugins/bundled/process-restart/commands/restart.md
\`\`\`

Actual scripts live at the project root \`<repo>/scripts/\` and \`scripts/install.sh:188-191\` symlinks them into \`\$BIN_DIR\` so the commands resolve on \`\$PATH\`. Updated the table to use the \`<repo>/scripts/\` qualifier + added an inline note explaining the install-symlink path. Also linked CLAUDE.md for the canonical-naming guidance updated in #289.

## How it was found

Repo-maintenance §7 widening — cross-checked file-locations claims against the actual plugin filesystem tree.

## Test plan

- [x] \`find plugins/bundled/process-restart -type f\` confirms no \`scripts/\` subdir
- [x] \`find . -name "unleash-refresh" -type f\` shows the canonical location is \`./scripts/unleash-refresh\`
- [x] \`grep "ln -sf" scripts/install.sh\` confirms the symlink-to-\$BIN_DIR mechanism
- [ ] CI green (plugin path → fuller workflow set runs)