### PR TITLE
docs(restart-refresh): add stale-content banner + fix prominent fake Settings

### DIFF
--- a/docs/extensions/restart-refresh.md
+++ b/docs/extensions/restart-refresh.md
@@ -2,6 +2,33 @@
 
 Comprehensive guide to the MCP hot-reload and process restart functionality in unleash.
 
+> ## ⚠️ Stale-content notice (2026-06-05)
+>
+> Parts of this guide predate the current implementation. In particular,
+> **any reference to an `autoDetect` or `configPaths` setting in
+> `.claude/settings.json` is fabricated** — no code reads those fields
+> (verified by `grep -rE "autoDetect|configPaths" src/ plugins/`). The
+> mcp-refresh plugin's `plugin.json` has no `settings` block; its watch
+> paths are hardcoded in `hooks-handlers/check-mcp-changes.sh`.
+>
+> Canonical sources for the current state:
+>
+> - **Enable/disable plugins**: `enabled_plugins` allowlist in
+>   `~/.config/unleash/config.toml`, or the TUI's **Plugins** tab.
+>   See [`docs/extensions/configuration.md`](configuration.md).
+> - **Plugin-specific docs**: per-plugin READMEs under
+>   `plugins/bundled/<name>/README.md` (mcp-refresh refreshed in PR #293,
+>   process-restart in PR #297, auto-mode in PR #294, omnihook in PR #295).
+> - **Restart command naming**: see [`CLAUDE.md`](../../CLAUDE.md) — the
+>   canonical names are `unleash-refresh` / `unleash-exit`; the old
+>   `restart-claude` / `exit-claude` continue to work as install.sh
+>   symlinks.
+>
+> The pre-deprecation content below remains useful for the architectural
+> rationale and the hash-detection algorithm sketch. Treat the settings
+> JSON snippets, configuration sections, and "Settings" subheadings as
+> historical / aspirational rather than as instructions.
+
 ## Table of Contents
 
 1. [Overview](#overview)
@@ -738,17 +765,12 @@ Configure in `.claude/settings.json`:
 }
 ```
 
-**Settings**:
+**Settings** *(see top-of-doc stale-content notice — these settings don't exist in the shipped plugin; see `plugins/bundled/mcp-refresh/README.md` for the real configuration model)*:
 
-- **`autoDetect`** (boolean, default: `true`)
-  - Enable automatic change detection via PreToolUse hook
-  - Disable if you prefer manual checking only
-  - Reduces notification frequency
+- ~~**`autoDetect`** — fabricated; no plugin setting reads this. Detection runs on every `PreToolUse` event whenever the plugin is enabled.~~
+- ~~**`configPaths`** — fabricated; watched paths are hardcoded to `.mcp.json`, `~/.claude.json`, and `plugins/*/.mcp.json` in `hooks-handlers/check-mcp-changes.sh`.~~
 
-- **`configPaths`** (array, default: `[".mcp.json", ".claude.json", "~/.claude.json"]`)
-  - Paths to monitor for changes
-  - Relative paths resolved from working directory
-  - Add custom paths as needed
+To disable detection entirely, exclude `mcp-refresh` from the `enabled_plugins` allowlist in `~/.config/unleash/config.toml`, or toggle it off in the TUI Plugins tab.
 
 ### How It Works
 


### PR DESCRIPTION
## Summary

\`docs/extensions/restart-refresh.md\` is the 2700-line guide that predates the current plugin implementation. The same fabricated \`autoDetect\` / \`configPaths\` settings schema PR #293 removed from \`mcp-refresh/README.md\` survives in this guide in **14+ scattered locations** (lines 285, 286, 730, 731, 743, 748, 1693, 1698, 1701, 1705, 1917, 2457, 2460, 2469, 2470).

None of those fields are read by code (\`grep -rE \"autoDetect|configPaths\" src/ plugins/\` finds them only in this doc + user-visible notification text).

Rewriting all 2700 lines in one PR is overscoped. This PR does the two highest-impact bits:

1. **Top-of-doc stale-content notice** that warns the configuration sections + Settings JSON snippets are fabricated; points readers at the canonical sources:
   - \`docs/extensions/configuration.md\` for the real \`enabled_plugins\` allowlist (refreshed in #278)
   - Per-plugin READMEs refreshed in #293 / #294 / #295 / #297
   - \`CLAUDE.md\` for the restart-command naming clarified in #289
2. **Strikes through** the most prominent fictitious **Settings** table (lines 741–751) — same treatment the \`mcp-refresh\` README got in #293

The remaining 12+ scattered refs are tracked in #300 for a focused follow-up.

## Tracking issue

#298 task 3. Follow-up tracked as #300.

## Test plan

- [x] Banner positioning correct (between H1 + TOC)
- [x] Stale-content references all correctly cite PR numbers
- [x] Strike-through markdown renders correctly (\`~~text~~\`)
- [ ] CI green (docs-only)