### PR TITLE
fix(test): wait for non-empty marker to deflake background-reindex test

### DIFF
--- a/src/interchange/sessions.rs
+++ b/src/interchange/sessions.rs
@@ -1,4 +1,5 @@
-//! Session discovery: find and list conversation sessions across all 4 CLIs.
+//! Session discovery: find and list conversation sessions across the supported CLIs
+//! (claude, codex, gemini, opencode, pi, hermes — agy shares the gemini path).
 
 use crate::interchange::CliFormat;
 use serde::Serialize;
@@ -1055,15 +1056,29 @@ mod tests {
 
         // Give the spawned child a moment to flush its echo. The script is
         // trivial; even on slow runners it completes in milliseconds.
-        for _ in 0..20 {
-            if marker.exists() {
-                break;
+        //
+        // Wait for NON-EMPTY marker content, not just existence: under
+        // llvm-cov instrumentation on the GHA runners the `echo "$VAR" >
+        // file` redirection can leave the file visible-but-empty for a
+        // few ms (file-create races ahead of the write-flush), causing
+        // an empty `content.trim()` and an inscrutable string-mismatch
+        // assertion failure. Observed once on #295. Polling for content
+        // size > 0 removes that race without slowing the happy path.
+        for _ in 0..40 {
+            if let Ok(meta) = std::fs::metadata(&marker) {
+                if meta.len() > 0 {
+                    break;
+                }
             }
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
 
         assert!(marker.exists(), "fake child should have written the marker");
         let content = std::fs::read_to_string(&marker).unwrap();
+        assert!(
+            !content.trim().is_empty(),
+            "marker exists but is empty — child likely raced before flushing the echo redirection"
+        );
         let received_path = content.trim();
         assert_eq!(
             received_path,


### PR DESCRIPTION
## Summary

\`interchange::sessions::tests::test_trigger_background_reindex_sets_lock_path_env_var\` flaked once on PR #295's \`cargo-llvm-cov\` job:

\`\`\`
assertion \`left == right\` failed:
child must receive UNLEASH_REINDEX_LOCK_PATH pointing at the parent's lock file
left: \"\"
right: \"/tmp/.tmpXXXXXX/search-index.lock\"
\`\`\`

**Root cause**: the wait loop broke on \`marker.exists()\`, but under llvm-cov instrumentation on the GHA runners the shell's \`echo \"\$VAR\" > file\` redirection can leave the file visible-but-empty for a few milliseconds — file-create races ahead of the write-flush. The next \`read_to_string\` then returns \"\" and \`assert_eq\` fails with a confusingly empty \`left:\`.

**Fix**: wait for non-empty marker content (\`meta.len() > 0\`) rather than existence, with a clearer panic message if the marker exists but is still empty. Bumped the iteration cap from 20×50ms (1s) to 40×50ms (2s) for headroom on slow coverage builds. Happy-path timing unchanged because the loop breaks as soon as content arrives.

Also tidied the file-level docstring: \"across all 4 CLIs\" → an explicit enumeration of the actual six (claude/codex/gemini/opencode/pi/hermes; agy shares the gemini path). Same 4→7 agent-count drift pattern PR #271 fixed in user-facing docs.

Tracking: #298 task 4.

## Test plan

- [x] \`cargo test --lib\` — 565/565 pass
- [x] clippy + fmt clean
- [ ] CI green