### PR TITLE
chore(cargo): add repository / homepage / readme / keywords / categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,14 @@
 name = "unleash"
 version = "0.1.64"
 edition = "2021"
-description = "unleash - Extended CLI for AI Code Agents"
+description = "Extended CLI for AI code agents — version manager, polyfill layer, cross-CLI session crossload, plugins"
 authors = ["Heiervang Technologies"]
 license = "MIT"
+repository = "https://github.com/heiervang-technologies/unleash"
+homepage = "https://unleash.software"
+readme = "README.md"
+keywords = ["cli", "ai", "claude", "llm", "agent"]
+categories = ["command-line-utilities", "development-tools"]
 
 # Binaries auto-discovered from src/bin/*.rs
 # Each is a thin wrapper calling unleash::run()


### PR DESCRIPTION
## Summary

\`Cargo.toml\` was missing several metadata fields that tooling consumes from the embedded crate-metadata block (security scanners, \`cargo about\`, dependency-graph viewers, IDE crate-info hovers). Added the obvious ones:

| Field | Value |
|---|---|
| \`repository\` | \`https://github.com/heiervang-technologies/unleash\` |
| \`homepage\` | \`https://unleash.software\` (matches README install URL) |
| \`readme\` | \`README.md\` |
| \`keywords\` | \`[\"cli\", \"ai\", \"claude\", \"llm\", \"agent\"]\` (5 is the cargo limit) |
| \`categories\` | \`[\"command-line-utilities\", \"development-tools\"]\` |

Also tightened the \`description\` from \`\"unleash - Extended CLI for AI Code Agents\"\` (which awkwardly repeats the name) to a one-liner naming the four headline features.

No behavior change. From the For-Later list in tracking issue #298.

## Test plan

- [x] \`cargo check\` clean
- [ ] CI green