### PR TITLE
docs(token-usage): correct top-line claim — Claude only currently

### DIFF
--- a/plugins/bundled/token-usage/README.md
+++ b/plugins/bundled/token-usage/README.md
@@ -1,7 +1,12 @@
 # token-usage
 
-Track token usage across all agent CLIs (Claude, Codex, Gemini, OpenCode, Pi)
-via multiple, independently-toggleable collection methods.
+Track token usage from agent CLIs into a single append-only log via
+multiple, independently-toggleable collection methods.
+
+**Current coverage**: Claude only — both the live Stop-hook tail and the
+on-demand session scan. The other six built-in agents (Codex, Antigravity,
+Gemini, OpenCode, Pi, Hermes) each have a different usage schema; extending
+the scan is tracked in the [Limitations](#limitations) section.
 
 ## Why
 
@@ -59,10 +64,11 @@ treats the plugin as enabled rather than crashing the session.
 
 ## Limitations
 
-- Codex/Gemini/OpenCode/Pi session-scan is not yet wired up. Each CLI has a
-  different usage schema (Codex mirrors OpenAI's `prompt_tokens`/`completion_tokens`,
-  Gemini uses `usageMetadata.{promptTokenCount,candidatesTokenCount}`, etc.).
-  Tracked for v0.2.
+- Codex/Antigravity/Gemini/OpenCode/Pi/Hermes session-scan is not yet wired
+  up. Each CLI has a different usage schema (Codex mirrors OpenAI's
+  `prompt_tokens`/`completion_tokens`, Gemini uses
+  `usageMetadata.{promptTokenCount,candidatesTokenCount}`, Hermes and
+  Antigravity haven't been audited yet). Tracked for v0.2.
 - Provider-API polling is gated on having admin keys per provider and a small
   daemon that won't get caught by network sandboxing. v0.1 reserves the
   setting; v0.2 will implement.


### PR DESCRIPTION
## Summary

The token-usage README's opening sentence claimed it tracks \"all agent CLIs (Claude, Codex, Gemini, OpenCode, Pi)\" — but the Limitations section honestly admits \"Codex/Gemini/OpenCode/Pi session-scan is not yet wired up\". The two sentences contradicted each other, and the top line also omitted Hermes and Antigravity entirely (both added to unleash after this README was written).

Rewrote the opening to match the implementation:

- Names what's actually shipped (**Claude only** — Stop-hook tail + session scan)
- Names the six other built-in agents explicitly so the reader gets honest expectations
- Forward-pointer to Limitations for status detail

Also extended the Limitations bullet to cover all six pending CLIs (added Antigravity and Hermes).

## How it was found

Repo-maintenance §7 widening — per-plugin README inventory after #295 / #294 / #293 / #297 / #291. Last unaudited Mar-30+ plugin README was token-usage; first/last contradiction surfaced on the opening read.

From tracking issue #298 (\"for later\" list, now actioned).

## Test plan

- [x] Coverage claim cross-checked against \`hooks-handlers/token-usage-stop.sh\` (claude only) and \`scripts/report.sh\` (claude scan only)
- [ ] CI green (docs-only)