### PR TITLE
fix(launcher): restart-loop resume-detection covers all 7 agents (#304)

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -70,6 +70,43 @@ pub(crate) fn exec_meta_command(
     Ok(status.code().unwrap_or(1))
 }
 
+/// Returns true if `args` already encodes a resume/continue signal in any of
+/// the polyfill-emitted forms across the 7 supported agents. Used by the
+/// restart loop to decide whether to inject its own `--continue` or leave the
+/// existing intent alone.
+///
+/// Coverage map (mirrors `AgentDefinition::*` polyfill strategies):
+///
+/// | Agent      | continue form            | resume-by-id form        |
+/// |------------|--------------------------|--------------------------|
+/// | Claude     | `--continue`, `-c`       | `--resume`, `-r`         |
+/// | Codex      | `resume` (subcommand)    | `resume` (subcommand)    |
+/// | Gemini     | `--resume` (`latest`)    | `--resume`               |
+/// | OpenCode   | `--continue`             | `-s`                     |
+/// | Pi         | `--continue`             | `--session`              |
+/// | Hermes     | `--continue`             | `--resume`               |
+/// | Antigravity| `--continue`             | `--conversation`         |
+///
+/// Bare-token match against the first whitespace-delimited token of each
+/// arg covers both flag-style (`--continue`) and subcommand-style (`resume`,
+/// where the polyfill inserts it as the first positional arg).
+pub(crate) fn args_already_signal_resume(args: &[String]) -> bool {
+    const RESUME_TOKENS: &[&str] = &[
+        "--continue",
+        "-c",
+        "--resume",
+        "-r",
+        "resume", // codex
+        "--conversation",
+        "-s",
+        "--session",
+    ];
+    args.iter().any(|a| {
+        let first_token = a.split_whitespace().next().unwrap_or("");
+        RESUME_TOKENS.contains(&first_token)
+    })
+}
+
 /// Configuration for [`run_loop`]: bundles the inputs the auto-mode restart
 /// state machine needs without having to read from the user's profile, env,
 /// or `dirs::cache_dir()`. Production callers build this from real config in
@@ -139,7 +176,7 @@ pub fn run_loop(config: LauncherConfig) -> io::Result<i32> {
 
         // If this is a restart, add --continue and message
         if restart_count > 0 {
-            if !args.iter().any(|a| a == "--continue" || a == "--resume") {
+            if !args_already_signal_resume(&args) {
                 args.insert(0, "--continue".to_string());
                 // Only Claude Code supports --dangerously-skip-permissions
                 if is_claude {
@@ -755,5 +792,65 @@ mod tests {
         // Substrings must not match — only exact arg equality.
         assert!(!is_meta_command(&s(&["--version-check"])));
         assert!(!is_meta_command(&s(&["--help-mcp"])));
+    }
+
+    // Coverage for args_already_signal_resume — one assertion per agent's
+    // polyfill-emitted form. Matches the table in the function's doc comment;
+    // any agent whose polyfill changes shape should add a row here.
+    #[test]
+    fn resume_detection_claude_long_and_short() {
+        assert!(args_already_signal_resume(&s(&["--continue"])));
+        assert!(args_already_signal_resume(&s(&["-c"])));
+        assert!(args_already_signal_resume(&s(&["--resume", "abc"])));
+        assert!(args_already_signal_resume(&s(&["-r", "abc"])));
+    }
+
+    #[test]
+    fn resume_detection_codex_subcommand() {
+        // Codex polyfill emits `resume --last` (continue) or `resume <id>` (resume).
+        // Previously these slipped past the literal "--continue/--resume" check
+        // and the wrapper would prepend its own --continue on every restart.
+        assert!(args_already_signal_resume(&s(&["resume", "--last"])));
+        assert!(args_already_signal_resume(&s(&[
+            "resume",
+            "01234567-89ab-cdef-0123-456789abcdef"
+        ])));
+    }
+
+    #[test]
+    fn resume_detection_gemini() {
+        // Gemini polyfill: continue = "--resume latest" (single space-joined
+        // string token in the polyfill table), resume = "--resume".
+        assert!(args_already_signal_resume(&s(&["--resume latest"])));
+        assert!(args_already_signal_resume(&s(&["--resume", "abc"])));
+    }
+
+    #[test]
+    fn resume_detection_opencode_and_pi_short_forms() {
+        // OpenCode resume-by-id uses -s; Pi uses --session.
+        assert!(args_already_signal_resume(&s(&["-s", "abc"])));
+        assert!(args_already_signal_resume(&s(&["--session", "abc"])));
+    }
+
+    #[test]
+    fn resume_detection_antigravity() {
+        // After PR #302: agy continue → --continue, resume-by-id → --conversation.
+        // Previously this slipped past the check and the wrapper would prepend
+        // --continue on top of an existing --conversation invocation.
+        assert!(args_already_signal_resume(&s(&["--continue"])));
+        assert!(args_already_signal_resume(&s(&["--conversation", "abc"])));
+    }
+
+    #[test]
+    fn resume_detection_ignores_unrelated_args() {
+        // Bare prompts, model flags, paths — none should look like resume.
+        assert!(!args_already_signal_resume(&s(&[])));
+        assert!(!args_already_signal_resume(&s(&["--print", "hello"])));
+        assert!(!args_already_signal_resume(&s(&["-m", "opus"])));
+        assert!(!args_already_signal_resume(&s(&["--model", "gpt-5"])));
+        // Substring match should NOT trigger.
+        assert!(!args_already_signal_resume(&s(&["--continue-on-error"])));
+        assert!(!args_already_signal_resume(&s(&["--resume-id-prefix"])));
+        assert!(!args_already_signal_resume(&s(&["resume-from"])));
     }
 }


### PR DESCRIPTION
## Summary

Closes #304. The restart-loop check at \`launcher.rs::run_loop\` literal-matched only \`\"--continue\"\` / \`\"--resume\"\`, missing 5 of 7 agents' polyfill-emitted forms:

| Agent       | continue form         | resume-by-id form          | Covered before? |
|-------------|-----------------------|----------------------------|-----------------|
| Claude      | \`--continue\`, \`-c\`    | \`--resume\`, \`-r\`           | ✓               |
| **Codex**   | \`resume\` (subcommand) | \`resume\` (subcommand)      | ✗               |
| Gemini      | \`--resume latest\`     | \`--resume\`                 | ✓               |
| **OpenCode**| \`--continue\`          | \`-s\`                       | partial         |
| **Pi**      | \`--continue\`          | \`--session\`                | partial         |
| Hermes      | \`--continue\`          | \`--resume\`                 | ✓               |
| **Agy**     | \`--continue\`          | \`--conversation\` (post-#302) | partial      |

**Failure mode**: codex/opencode/pi/agy users who originally ran \`-r <id>\` would get a double-resume on every restart-loop iteration — the wrapper prepends \`--continue\` on top of an existing \`--conversation <id>\` / \`-s <id>\` / \`--session <id>\` / \`resume <id>\`. Agy and codex would either ignore one signal (best case) or error (worst case).

## Fix

Extracted the check into a documented helper \`args_already_signal_resume(args)\` covering every polyfill form. First-token matching (split on whitespace) handles both flag-style (\`--continue\`) and space-separated polyfill outputs (\`--resume latest\`, \`resume --last\`). Substring matches like \`--continue-on-error\` and \`resume-from\` correctly don't trigger.

Six regression tests, one per agent shape + one for false positives. Doc-comment table mirrors the agent-polyfill table so future agent additions have an obvious extension point.

## What's not fixed

For non-Claude agents on a fresh restart (no original resume signal), the wrapper still inserts \`--continue\` which isn't valid for codex/gemini/opencode in general. Doing it right requires per-agent continue-strategy lookup. Tracking separately if it surfaces in practice — auto-mode is Claude-centric so the path is rarely exercised for non-Claude.

## Test plan

- [x] \`cargo test --lib launcher::tests::resume_detection\` — 6/6 pass
- [x] \`cargo test --lib\` — 571/571 pass (3 pre-existing ignored)
- [x] clippy + fmt clean
- [ ] CI green