### PR TITLE
feat(crossload): auto-fall-back to passthrough when inject refuses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,7 +242,7 @@ fn print_profile_help(profile_name: &str) {
 
 fn run_agent_with_polyfill(
     profile_name: &str,
-    polyfill_args: cli::PolyfillArgs,
+    mut polyfill_args: cli::PolyfillArgs,
     extra_args: Vec<String>,
 ) -> io::Result<()> {
     let manager = ProfileManager::new()?;
@@ -371,8 +371,48 @@ fn run_agent_with_polyfill(
                 flags.resume = Some(Some(result.session_id.clone()));
             }
             Err(e) => {
-                eprintln!("\x1b[31m✗\x1b[0m Crossload failed: {e}");
-                return Err(io::Error::other(e.to_string()));
+                // Auto-fallback: if the target CLI refused session injection
+                // (e.g. agy — server-side cascade validation, see #307), don't
+                // hard-fail. Render the source session as a markdown transcript
+                // and prepend it to the user's prompt. The agent will see the
+                // prior context as a single initial message.
+                //
+                // Disable by exporting UNLEASH_CROSSLOAD_NO_FALLBACK=1.
+                let no_fallback = std::env::var("UNLEASH_CROSSLOAD_NO_FALLBACK")
+                    .map(|v| !v.is_empty() && v != "0")
+                    .unwrap_or(false);
+                let is_refusal = matches!(
+                    &e,
+                    interchange::ConvertError::InvalidFormat(msg)
+                        if msg.contains("requires server-side")
+                            || msg.contains("not yet supported")
+                );
+                if no_fallback || !is_refusal {
+                    eprintln!("\x1b[31m✗\x1b[0m Crossload failed: {e}");
+                    return Err(io::Error::other(e.to_string()));
+                }
+
+                eprintln!(
+                    "\x1b[33minfo:\x1b[0m {target_cli} doesn't support session injection — \
+                     falling back to passthrough prompt mode \
+                     (set UNLEASH_CROSSLOAD_NO_FALLBACK=1 to disable)"
+                );
+                let session = interchange::sessions::find_session(&query)
+                    .ok_or_else(|| io::Error::other(format!("Session not found: {query}")))?;
+                let hub_records = interchange::inject::source_to_hub(&session)
+                    .map_err(|e| io::Error::other(e.to_string()))?;
+                let transcript = interchange::passthrough::render_as_transcript(&hub_records);
+                let new_prompt = match polyfill_args.prompt.take() {
+                    Some(user_prompt) => format!("{transcript}\n## Continue\n\n{user_prompt}"),
+                    None => transcript,
+                };
+                eprintln!(
+                    "\x1b[32m✓\x1b[0m Prepended {} bytes of transcript ({} records) as initial prompt",
+                    new_prompt.len(),
+                    hub_records.len(),
+                );
+                polyfill_args.prompt = Some(new_prompt.clone());
+                flags.headless = Some(new_prompt);
             }
         }
     }


### PR DESCRIPTION
Closes the original \`unleash agy -x …\` loop. When \`inject_session\` returns an InvalidFormat error mentioning \"server-side\" or \"not yet supported\", instead of hard-failing, render the source session as a markdown transcript (via the passthrough renderer landed in #314) and prepend it to the user's \`-p\` prompt.

## End-to-end

\`\`\`
\$ unleash agy -x claude:heierchat --dry-run
info: Loading session: claude:heierchat into agy
Found session: heierchat (heierchat) from claude at /home/me/ht/heierchat
Converted 18303 records to hub format
info: agy doesn't support session injection — falling back to passthrough
      prompt mode (set UNLEASH_CROSSLOAD_NO_FALLBACK=1 to disable)
✓ Prepended 2654688 bytes of transcript (18303 records) as initial prompt
Would execute: agy --dangerously-skip-permissions -p <transcript>
\`\`\`

Opt-out: \`UNLEASH_CROSSLOAD_NO_FALLBACK=1\` restores the hard-fail behavior.

## Trigger guard

Only triggers when:
1. inject_session returns \`InvalidFormat\`
2. AND the error message contains \"requires server-side\" OR \"not yet supported\"

So Claude/Codex/Gemini/OpenCode/Pi/Hermes inject paths are unchanged — if any of those fail for an unrelated reason (e.g. corrupt session file), the user gets the original error. Only the agy refusal class triggers fallback.

## Known limitations (out of scope for this PR)

1. **Very large transcripts may overflow** the target agent's context window AND the OS's ARG_MAX (typically 128 KB for the command line). 2.6 MB transcripts won't fit either. Reusing the existing \`UNLEASH_CROSSLOAD_MAX_TOKENS\` guard (already applied on the inject path) is the natural follow-up.
2. **agy supports \`-p\` (one-shot) and \`-i\` (interactive-after-initial-prompt)**. The current polyfill maps to \`-p\`; switching to \`-i\` would let users continue interactively. Polish follow-up.

Both are tracked in #313 for the next iteration.

## Test plan

- [x] \`cargo test --lib\` — 579/579 pass
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] Manual end-to-end: \`unleash agy -x claude:heierchat --dry-run\` against the live install — falls back correctly, dry-run shows the rendered transcript prepended
- [ ] CI green