### PR TITLE
feat(crossload): cap passthrough transcript size via existing budget + ARG_MAX warning

### DIFF
--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -179,7 +179,7 @@ fn normalize_target_cli(target: &str) -> &str {
 
 /// Read the optional context budget from `UNLEASH_CROSSLOAD_MAX_TOKENS`.
 /// Returns `None` when the variable is unset or zero (no limit).
-fn context_budget() -> Option<usize> {
+pub(crate) fn context_budget() -> Option<usize> {
     std::env::var("UNLEASH_CROSSLOAD_MAX_TOKENS")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
@@ -217,7 +217,10 @@ fn estimate_block_chars(block: &crate::interchange::hub::ContentBlock) -> usize 
 /// the estimated token count fits within `max_tokens`.
 /// The session header (first record) is always kept.
 /// Returns (trimmed_records, num_messages_dropped).
-fn truncate_hub_to_budget(records: Vec<HubRecord>, max_tokens: usize) -> (Vec<HubRecord>, usize) {
+pub(crate) fn truncate_hub_to_budget(
+    records: Vec<HubRecord>,
+    max_tokens: usize,
+) -> (Vec<HubRecord>, usize) {
     if estimate_tokens(&records) <= max_tokens {
         return (records, 0);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,15 +401,52 @@ fn run_agent_with_polyfill(
                     .ok_or_else(|| io::Error::other(format!("Session not found: {query}")))?;
                 let hub_records = interchange::inject::source_to_hub(&session)
                     .map_err(|e| io::Error::other(e.to_string()))?;
+
+                // Apply the same UNLEASH_CROSSLOAD_MAX_TOKENS budget the inject
+                // path uses, so the rendered transcript doesn't overrun the
+                // target agent's context window or the OS's ARG_MAX
+                // (typically ~128 KB on Linux).
+                let total_records = hub_records.len();
+                let hub_records = if let Some(max_tokens) = interchange::inject::context_budget() {
+                    let (trimmed, dropped) =
+                        interchange::inject::truncate_hub_to_budget(hub_records, max_tokens);
+                    if dropped > 0 {
+                        eprintln!(
+                            "\x1b[33minfo:\x1b[0m Context guard: dropped {dropped} oldest \
+                                 messages to stay within {max_tokens} token budget"
+                        );
+                    }
+                    trimmed
+                } else {
+                    hub_records
+                };
+
                 let transcript = interchange::passthrough::render_as_transcript(&hub_records);
                 let new_prompt = match polyfill_args.prompt.take() {
                     Some(user_prompt) => format!("{transcript}\n## Continue\n\n{user_prompt}"),
                     None => transcript,
                 };
+
+                // ARG_MAX safety: warn loudly if the rendered transcript will
+                // likely exceed the kernel's argv limit. Don't truncate
+                // (that's worse than failing); user can rerun with a tighter
+                // UNLEASH_CROSSLOAD_MAX_TOKENS.
+                const ARG_MAX_SAFE_BYTES: usize = 100_000;
+                if new_prompt.len() > ARG_MAX_SAFE_BYTES {
+                    eprintln!(
+                        "\x1b[33mwarn:\x1b[0m Rendered transcript is {} bytes, above the ~{}-byte \
+                         safe ARG_MAX margin. Some agents may reject the command-line. \
+                         Re-run with `UNLEASH_CROSSLOAD_MAX_TOKENS=<n>` to trim.",
+                        new_prompt.len(),
+                        ARG_MAX_SAFE_BYTES
+                    );
+                }
+
                 eprintln!(
-                    "\x1b[32m✓\x1b[0m Prepended {} bytes of transcript ({} records) as initial prompt",
+                    "\x1b[32m✓\x1b[0m Prepended {} bytes of transcript ({}/{} records) as initial prompt",
                     new_prompt.len(),
                     hub_records.len(),
+                    total_records,
                 );
                 polyfill_args.prompt = Some(new_prompt.clone());
                 flags.headless = Some(new_prompt);


### PR DESCRIPTION
## Summary

Follow-up to #316 (auto-fallback to passthrough). That PR explicitly flagged this as a known limitation:

> Very large sessions (multi-MB transcripts) may exceed both the target agent's context window and the OS's ARG_MAX. Reusing the existing `UNLEASH_CROSSLOAD_MAX_TOKENS` guard … would be a natural follow-up.

This PR is that follow-up.

## What changed

- `context_budget()` and `truncate_hub_to_budget()` in `src/interchange/inject.rs` are now `pub(crate)` — no behavioural change for the inject path, just visibility.
- The auto-fallback block in `src/lib.rs` now:
  - Trims hub records via `UNLEASH_CROSSLOAD_MAX_TOKENS` (same env var the inject path already honours), dropping oldest messages first.
  - Prints `info: Context guard: dropped N oldest messages …` when trimming actually happens.
  - Prints `warn: Rendered transcript is N bytes, above the ~100KB safe ARG_MAX margin …` when the *rendered* size still exceeds the kernel's argv safe margin — telling the user exactly which env var to lower.
  - Shows `(kept/total records)` in the success line so the trim is visible.

## Why a warning rather than truncation at the byte level

Truncating the rendered markdown mid-stream produces an unparseable transcript and risks cutting in the middle of a tool-call fence. Better to surface the problem and let the user dial the budget down — the rendered-byte threshold is just a heuristic floor; many shells/agents tolerate more.

## Test plan

- [x] `cargo build` clean
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean
- [x] `cargo test --lib` (579 passed / 0 failed)
- [ ] Manual: `UNLEASH_CROSSLOAD_MAX_TOKENS=2000 unleash agy -x claude:<large-session>` shows the `info:` trim line; without the var on a multi-MB session, shows the `warn:` line.