### PR TITLE
feat(crossload): use agy -i (interactive prompt) for auto-fallback when user didn't request -p

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -220,6 +220,14 @@ pub struct AgentPolyfillConfig {
     /// Flag name for git worktree mode, if supported
     #[serde(default)]
     pub worktree_flag: Option<String>,
+    /// Flag name for "run an initial prompt then continue interactively",
+    /// if the agent has a dedicated flag for that mode (e.g. agy's `-i` /
+    /// `--prompt-interactive`). Used by the crossload auto-fallback path
+    /// to drop the user into an interactive session pre-loaded with the
+    /// rendered transcript, instead of using the one-shot `headless` flag
+    /// which would print one response and exit.
+    #[serde(default)]
+    pub interactive_prompt_flag: Option<String>,
 }
 
 fn default_sandbox_unsupported() -> SandboxStrategy {
@@ -362,6 +370,7 @@ impl AgentDefinition {
                 add_dir_flag: Some("--add-dir".to_string()),
                 approval_mode_flag: Some("--permission-mode".to_string()),
                 worktree_flag: Some("--worktree".to_string()),
+                interactive_prompt_flag: None,
             },
             github_repo: Some("anthropics/claude-code".to_string()),
             npm_package: Some("@anthropic-ai/claude-code".to_string()),
@@ -399,6 +408,7 @@ impl AgentDefinition {
                 add_dir_flag: Some("--add-dir".to_string()),
                 approval_mode_flag: Some("-a".to_string()),
                 worktree_flag: None,
+                interactive_prompt_flag: None,
             },
             github_repo: Some("openai/codex".to_string()),
             npm_package: None,
@@ -439,6 +449,12 @@ impl AgentDefinition {
                 add_dir_flag: Some("--include-directories".to_string()),
                 approval_mode_flag: None,
                 worktree_flag: Some("--worktree".to_string()),
+                // agy supports `-i` / `--prompt-interactive`: load the prompt
+                // as the first message and then drop into an interactive
+                // session. The crossload auto-fallback uses this so the user
+                // can keep typing after the prior context loads, instead of
+                // getting a single response and exiting via `-p` / `--print`.
+                interactive_prompt_flag: Some("-i".to_string()),
             },
             github_repo: None,
             // No npm package exists for antigravity — `@google/antigravity-cli`
@@ -476,6 +492,7 @@ impl AgentDefinition {
                 add_dir_flag: Some("--include-directories".to_string()),
                 approval_mode_flag: Some("--approval-mode".to_string()),
                 worktree_flag: Some("--worktree".to_string()),
+                interactive_prompt_flag: None,
             },
             github_repo: Some("google-gemini/gemini-cli".to_string()),
             npm_package: Some("@google/gemini-cli".to_string()),
@@ -510,6 +527,7 @@ impl AgentDefinition {
                 add_dir_flag: None,
                 approval_mode_flag: None,
                 worktree_flag: None,
+                interactive_prompt_flag: None,
             },
             github_repo: Some("anomalyco/opencode".to_string()),
             npm_package: Some("opencode-ai".to_string()),
@@ -544,6 +562,7 @@ impl AgentDefinition {
                 add_dir_flag: None,
                 approval_mode_flag: None,
                 worktree_flag: None,
+                interactive_prompt_flag: None,
             },
             github_repo: None,
             npm_package: Some("@mariozechner/pi-coding-agent".to_string()),
@@ -578,6 +597,7 @@ impl AgentDefinition {
                 add_dir_flag: None,
                 approval_mode_flag: None,
                 worktree_flag: Some("--worktree".to_string()),
+                interactive_prompt_flag: None,
             },
             github_repo: Some("NousResearch/hermes-agent".to_string()),
             npm_package: None,
@@ -1486,6 +1506,45 @@ mod tests {
                 "agy resume-by-id must use --conversation, not --resume"
             ),
             other => panic!("expected resume_strategy::Flag, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn antigravity_has_interactive_prompt_flag() {
+        // The crossload auto-fallback path (lib.rs) uses
+        // `interactive_prompt_flag` to drop the user into an interactive
+        // REPL pre-loaded with the rendered transcript, instead of `-p` /
+        // `--print` which would emit one response and exit. agy exposes
+        // this as `-i` / `--prompt-interactive`. Without this field set,
+        // `unleash agy -x <session>` (no `-p`) silently degrades to a
+        // one-shot run — which defeats the purpose of crossloading.
+        let agy = AgentDefinition::antigravity();
+        assert_eq!(
+            agy.polyfill.interactive_prompt_flag.as_deref(),
+            Some("-i"),
+            "agy must expose its `-i` flag for the crossload auto-fallback path"
+        );
+    }
+
+    #[test]
+    fn non_agy_agents_have_no_interactive_prompt_flag() {
+        // Currently agy is the only target that hits the crossload
+        // auto-fallback (every other CLI has real session injection). Until
+        // someone identifies an analogous flag elsewhere, leave them at
+        // None so the fallback uses the existing one-shot path.
+        for def in [
+            AgentDefinition::claude(),
+            AgentDefinition::codex(),
+            AgentDefinition::gemini(),
+            AgentDefinition::opencode(),
+            AgentDefinition::pi(),
+            AgentDefinition::hermes(),
+        ] {
+            assert!(
+                def.polyfill.interactive_prompt_flag.is_none(),
+                "{} should not set interactive_prompt_flag yet",
+                def.name
+            );
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ fn print_profile_help(profile_name: &str) {
 fn run_agent_with_polyfill(
     profile_name: &str,
     mut polyfill_args: cli::PolyfillArgs,
-    extra_args: Vec<String>,
+    mut extra_args: Vec<String>,
 ) -> io::Result<()> {
     let manager = ProfileManager::new()?;
     let profile = manager.load_profile(profile_name).map_err(|e| {
@@ -421,6 +421,15 @@ fn run_agent_with_polyfill(
                     hub_records
                 };
 
+                // Did the user explicitly request a one-shot headless run
+                // (`-p "do X"`)? If so, the transcript merges into their prompt
+                // and we keep `-p` semantics (single response, exit). If not,
+                // and the target agent has a dedicated "load prompt then go
+                // interactive" flag (e.g. agy's `-i`), use that instead so the
+                // session drops the user into a live REPL with prior context
+                // pre-loaded — much better UX for the common
+                // `unleash <agent> -x <session>` invocation.
+                let was_user_headless = polyfill_args.prompt.is_some();
                 let transcript = interchange::passthrough::render_as_transcript(&hub_records);
                 let new_prompt = match polyfill_args.prompt.take() {
                     Some(user_prompt) => format!("{transcript}\n## Continue\n\n{user_prompt}"),
@@ -442,14 +451,34 @@ fn run_agent_with_polyfill(
                     );
                 }
 
-                eprintln!(
-                    "\x1b[32m✓\x1b[0m Prepended {} bytes of transcript ({}/{} records) as initial prompt",
-                    new_prompt.len(),
-                    hub_records.len(),
-                    total_records,
-                );
-                polyfill_args.prompt = Some(new_prompt.clone());
-                flags.headless = Some(new_prompt);
+                let interactive_flag = (!was_user_headless)
+                    .then_some(agent_def.polyfill.interactive_prompt_flag.as_ref())
+                    .flatten();
+                if let Some(iflag) = interactive_flag {
+                    eprintln!(
+                        "\x1b[32m✓\x1b[0m Prepended {} bytes of transcript ({}/{} records) \
+                         via interactive flag `{iflag}` — session will drop into REPL after \
+                         loading prior context",
+                        new_prompt.len(),
+                        hub_records.len(),
+                        total_records,
+                    );
+                    // Bypass the polyfill headless machinery entirely: push the
+                    // interactive flag + prompt directly so the agent gets `-i
+                    // "<transcript>"` (or whatever the target uses) instead of
+                    // `-p "<transcript>"`.
+                    extra_args.push(iflag.clone());
+                    extra_args.push(new_prompt);
+                } else {
+                    eprintln!(
+                        "\x1b[32m✓\x1b[0m Prepended {} bytes of transcript ({}/{} records) as initial prompt",
+                        new_prompt.len(),
+                        hub_records.len(),
+                        total_records,
+                    );
+                    polyfill_args.prompt = Some(new_prompt.clone());
+                    flags.headless = Some(new_prompt);
+                }
             }
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -832,6 +832,7 @@ impl CustomAgentDraft {
                 add_dir_flag: None,
                 approval_mode_flag: None,
                 worktree_flag: None,
+                interactive_prompt_flag: None,
             },
             github_repo: None,
             npm_package: None,


### PR DESCRIPTION
## Summary

Follow-up to #316 (auto-fallback to passthrough) and the original #313 ticket.

The auto-fallback path currently routes the rendered transcript through the polyfill's headless flag — for agy that's `-p` / `--print`, which means **one response then exit**. That defeats the purpose of a crossload: the user typed `unleash agy -x <session>` to **continue working** in agy with prior context, not to get a single reply and be dropped back at the shell.

agy already exposes `-i` / `--prompt-interactive` for exactly this — "load this prompt as the first message, then continue interactively." This PR uses it.

## Behavioural matrix

| Invocation | Before | After |
|---|---|---|
| `unleash agy -x claude:foo` (no -p) | `agy -p "<transcript>"` → one response, exit | `agy -i "<transcript>"` → REPL with context loaded |
| `unleash agy -x claude:foo -p "do X"` | `agy -p "<transcript>\nContinue\n\ndo X"` (one-shot) | **unchanged** — user explicitly asked for headless |
| `unleash agy -p "do X"` (no -x) | unchanged | unchanged |
| `unleash claude -x codex:bar` | unchanged (real session injection) | unchanged |

## What changed

- New field `interactive_prompt_flag: Option<String>` on `AgentPolyfillConfig` (`#[serde(default)]` so existing custom-agent configs deserialize fine).
- `Some("-i")` for antigravity; `None` for every other agent.
- The auto-fallback site discriminates on `was_user_headless` (was `polyfill_args.prompt.is_some()` before `.take()`); when false and the agent has `interactive_prompt_flag`, push `[iflag, transcript]` to `extra_args` and skip `flags.headless` entirely.
- Two new unit tests pinning the field for agy and asserting `None` for the other six built-ins — so a future contributor can't silently regress either side.

## Test plan

- [x] `cargo build` clean
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` clean
- [x] `cargo test --lib` (581 passed / 0 failed — +2 from main)
- [ ] Manual: `unleash agy -x claude:<session>` shows the new "via interactive flag \`-i\` — session will drop into REPL" line and ends in an interactive agy session
- [ ] Manual: `unleash agy -x claude:<session> -p "what's next?"` shows the old "as initial prompt" line and exits after one response (unchanged)