### PR TITLE
docs: document UNLEASH_CROSSLOAD_* env vars + passthrough fallback

### DIFF
--- a/docs/crossload.md
+++ b/docs/crossload.md
@@ -54,6 +54,46 @@ unleash convert --from claude --to codex session.jsonl -o out.jsonl  # Claude �
 | OpenCode -> Claude | Partial | Thinking blocks converted to text |
 | -> OpenCode (all) | Pending | SQLite injection not yet implemented |
 
+## Passthrough Fallback
+
+Some target CLIs reject session-level injection. Antigravity (`agy`), for
+example, validates every cascade_id against a server-fetched executor from
+Google's CodeAssist API, so a locally-written conversation always fails with
+`cascade ID mismatch` at send time (see issue #307).
+
+When session-level injection refuses, unleash automatically falls back to
+**passthrough mode**: the source session is rendered as a markdown transcript
+and prepended as a single initial prompt. Tool calls, tool results, thinking
+blocks, and images are summarised rather than reproduced verbatim, so the
+result fits in one prompt without escape-sequence or signature issues.
+
+```bash
+# Crossload a Claude session into agy — falls back automatically
+unleash agy -x claude:heierchat
+```
+
+For agents that expose a "load prompt then drop into REPL" flag
+(currently just `agy -i` / `--prompt-interactive`), passthrough uses that
+instead of the one-shot `-p` so the user keeps an interactive session.
+
+### Tuning the fallback
+
+| Variable | Effect |
+|---|---|
+| `UNLEASH_CROSSLOAD_MAX_TOKENS` | Trim the oldest messages so the rendered transcript stays under this token budget. Also applies to the inject path. Unset/0 = no limit. |
+| `UNLEASH_CROSSLOAD_NO_FALLBACK` | Refuse to fall back — surface the original injection error instead. |
+
+```bash
+# Tighter budget for a very large source session (avoids ARG_MAX overflow)
+UNLEASH_CROSSLOAD_MAX_TOKENS=20000 unleash agy -x claude:huge-session
+
+# Hard-error if injection refuses (don't render as passthrough prompt)
+UNLEASH_CROSSLOAD_NO_FALLBACK=1 unleash agy -x claude:huge-session
+```
+
+Manual passthrough is also available via `unleash convert --to passthrough`
+— see [cli-reference.md](cli-reference.md#unleash-convert).
+
 ## Known Limitations
 
 - **Thinking blocks**: Claude requires signed thinking blocks. Foreign
@@ -65,6 +105,9 @@ unleash convert --from claude --to codex session.jsonl -o out.jsonl  # Claude �
   context, progress) are stripped during extraction.
 - **OpenCode**: SQLite writes not yet implemented. Currently exports to hub
   format only.
+- **Passthrough lossiness**: When the fallback fires, the entire source
+  conversation becomes one user-turn from the target's perspective — tool-call
+  structure, model attribution, and thinking blocks are not preserved.
 
 ## Detailed Matrix
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -17,6 +17,8 @@ These can be set before launching `unleash` to change behavior.
 | `OAI_CHAT_BASE` | Optional separate base URL for chat completions (title regeneration) | falls back to `OAI_BASE` |
 | `OAI_CHAT_MODEL` | Chat model used for `sessions name` title generation. **Unset = skip naming** | unset |
 | `ALPHA` | Hybrid-search rank fusion: dense-vs-BM25 weight (0–1, higher = more dense) | `0.4` |
+| `UNLEASH_CROSSLOAD_MAX_TOKENS` | Hub-records budget for `--crossload` / `-x`. Trims the oldest messages when the rendered transcript would exceed this many tokens. Applies to both the inject path (session-level injection) and the passthrough fallback (when the target CLI refuses injection, e.g. `agy`). Unset / `0` = no limit | unset |
+| `UNLEASH_CROSSLOAD_NO_FALLBACK` | Disable the passthrough auto-fallback when session-level injection fails — `-x` will hard-error instead of rendering the source session as a single initial prompt | unset |
 
 ### Examples
 
@@ -29,6 +31,13 @@ AU_HYPRLAND_FOCUS=0 unleash claude
 
 # Silence hook sounds
 HOOK_NO_SOUND=1 unleash claude
+
+# Crossload a large Claude session into agy with a tighter token budget
+# (avoids ARG_MAX overflow when the rendered transcript is multi-MB)
+UNLEASH_CROSSLOAD_MAX_TOKENS=20000 unleash agy -x claude:heierchat
+
+# Refuse to fall back to passthrough — surface the original injection error
+UNLEASH_CROSSLOAD_NO_FALLBACK=1 unleash agy -x claude:heierchat
 ```
 
 Animations can also be toggled persistently via `animations = true` in


### PR DESCRIPTION
## Summary

The crossload auto-fallback (#316) and the budget knob (#318) shipped with no user-facing docs. Both env vars were only discoverable by reading source.

This PR closes that gap:

- **`docs/environment-variables.md`** — adds `UNLEASH_CROSSLOAD_MAX_TOKENS` and `UNLEASH_CROSSLOAD_NO_FALLBACK` to the User-Controllable table, plus two example invocations under the Examples section.
- **`docs/crossload.md`** — new "Passthrough Fallback" section explaining the chain: agy refuses session injection (server-side cascade validation per #307) → fallback renders source session as a markdown transcript → for agy specifically, uses `-i` so the user stays interactive (#320). Adds a tuning table for the same two env vars and a "passthrough lossiness" bullet to Known Limitations.

Pure docs — no code changes. Closes the docs follow-up implicit in #316/#318/#320.

## Test plan

- [x] Markdown renders cleanly in the GitHub preview
- [x] Cross-links (`cli-reference.md#unleash-convert`) resolve
- [x] Env-var names match `std::env::var` call sites in `src/interchange/inject.rs` (`UNLEASH_CROSSLOAD_MAX_TOKENS`) and `src/lib.rs` (`UNLEASH_CROSSLOAD_NO_FALLBACK`)