### PR TITLE
docs(crossload): refresh compatibility matrix — OpenCode shipped, agy added

### DIFF
--- a/docs/crossload.md
+++ b/docs/crossload.md
@@ -52,7 +52,8 @@ unleash convert --from claude --to codex session.jsonl -o out.jsonl  # Claude �
 | Gemini -> Claude | Lossless | Chain intact |
 | Claude -> Codex | Lossless | State DB registered |
 | OpenCode -> Claude | Partial | Thinking blocks converted to text |
-| -> OpenCode (all) | Pending | SQLite injection not yet implemented |
+| -> OpenCode (all) | Implemented | Writes directly to OpenCode SQLite |
+| -> Antigravity (`agy`) | Passthrough | Server-side cascade validation blocks injection (#307); auto-falls back to a rendered transcript prepended as initial prompt — `agy -i` interactive when no `-p` given |
 
 ## Passthrough Fallback
 
@@ -103,8 +104,9 @@ Manual passthrough is also available via `unleash convert --to passthrough`
   exists, tool calls are rendered as descriptive text.
 - **System preamble**: Claude-specific system events (permissions, environment
   context, progress) are stripped during extraction.
-- **OpenCode**: SQLite writes not yet implemented. Currently exports to hub
-  format only.
+- **Antigravity**: Direct injection blocked server-side (see Passthrough
+  Fallback section above). Falls back to a single rendered prompt — tool
+  structure, model attribution, and thinking blocks are flattened to text.
 - **Passthrough lossiness**: When the fallback fires, the entire source
   conversation becomes one user-turn from the target's perspective — tool-call
   structure, model attribution, and thinking blocks are not preserved.


### PR DESCRIPTION
## Summary

Two more §7 doc-drifts caught in the same idle sweep that produced #322 / #323:

1. **\`-> OpenCode (all): Pending\`** row in the Compatibility Matrix — true at one point, but \`inject_into_opencode\` (\`src/interchange/inject.rs:871\`) has been live for many releases. Wired into the dispatcher at line 135 and exercised by \`test_inject_into_opencode_sqlite\` (\`inject.rs:2007\`) + full round-trip in \`lossless_tests.rs:84+\`. Marked Implemented.

2. **No Antigravity (agy) row at all** — even though agy's auto-fallback is the most load-bearing crossload case for the current user. Added a "Passthrough" row pointing at #307 + the new Passthrough Fallback section, and split the catch-all OpenCode/Antigravity bullet in Known Limitations into agy-specific guidance.

## Test plan

- [x] \`inject_into_opencode\` exists and is wired (\`grep -n "inject_into_opencode" src/interchange/inject.rs\`)
- [x] Renders correctly in GitHub markdown preview (tabular matrix + bullet split)