### PR TITLE
chore(ci): move CI to the self-hosted org runner

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -36,9 +36,14 @@ permissions:
 jobs:
   actionlint:
     name: actionlint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install shellcheck (self-hosted runner image lacks it; actionlint -shellcheck needs it)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
 
       - name: Install actionlint
         id: install

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Move CI to the org self-hosted runner pool

GitHub-hosted Actions minutes are exhausted org-wide (since 2026-06-08, every hosted run fails at runner allocation). This flips the job(s) below onto snoop-kube's self-hosted runner pool (k8s `github-runner` Deployment on rogue; labels `self-hosted,linux,x64,k8s`; runner manifest: heiervang-technologies/cloud#146).

**Flipped → self-hosted:** `actionlint` (apt `shellcheck` added — `actionlint -shellcheck` invokes it) and `pages` (GitHub Pages deploy).
**FLAG for review:** `pages` uses OIDC `actions/deploy-pages@v4` against the `github-pages` environment — verify OIDC pages-deploy works from the self-hosted pool before readying; if not, revert just that job.
**Kept on ubuntu-latest (intentional):** all Rust + multi-OS matrix jobs — `audit`, `coverage`, `lint`, `docker-build`, `docker-publish`, `memory-profile`, `binary-smoke-test`, `integration-tests`, `release-please`, `tui-release`, `upload-release-binaries`, `flake-check` (nix). These need cargo / macOS-windows runners and stay hosted until billing restores or the runner ships Rust.

Toolchain checked against the runner inventory (Ubuntu 20.04: has git/jq/docker/python3/gcc; missing npm/go/cargo/shellcheck). Jobs needing a missing toolchain either self-provision via `setup-*` actions or install it explicitly (see diff).

Canary precedent: director #410 (flip) · #411 (rust/audit kept hosted) · #413 (gawk install pattern).

**Draft** until director-lead ratifies the diff shape; ready/merge gated on snoop-kube pool capacity (1→2 scale).
