### PR TITLE
chore(deps): bump quinn-proto + memmap2 to clear RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,9 +1960,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -2544,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary

Lockfile-only bumps to clear two open RUSTSEC advisories:

- **quinn-proto 0.11.14 → 0.11.15** — closes #334 (RUSTSEC-2026-0185, CVSS 7.5, remote memory exhaustion); reached transitively via `reqwest → quinn`.
- **memmap2 0.9.10 → 0.9.11** — closes #335 (RUSTSEC-2026-0186, unsoundness); reached transitively via `tantivy → turso_core`.

No `Cargo.toml` or `src/` changes — both upstream crates only published patch-version bumps with the fixes.

## Test plan

- [x] `cargo build --release` clean locally
- [x] `cargo audit` no longer flags either advisory (only the pre-existing `paste` unmaintained + `rand` conditional-unsound warnings remain, both unactionable for now)
- [ ] CI checks green (cargo-audit + cargo-deny + integration tests)