### PR TITLE
ci(integration): trigger Integration Tests on Cargo.lock changes

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'src/**'
       - 'Cargo.toml'
+      - 'Cargo.lock'
       - 'plugins/**'
       - 'scripts/**'
       - 'tests/**'
@@ -18,6 +19,7 @@ on:
     paths:
       - 'src/**'
       - 'Cargo.toml'
+      - 'Cargo.lock'
       - 'plugins/**'
       - 'scripts/**'
       - 'tests/**'


### PR DESCRIPTION
## Summary

Lockfile-only PRs — like the recent #336 RUSTSEC bump or any dependabot rebase — were skipping the entire integration test matrix (plugin tests, install scripts, headless commands, auth, auto-mode hook). A transitive dep change that breaks runtime behavior would slip past CI: audit/coverage/lint don't exercise the install + plugin shell paths.

\`lint.yml\` already includes \`Cargo.lock\` in its path filter; this brings \`integration-tests.yml\` in line. Coverage runs on every PR with no filter, so it was catching unit-test-level regressions — but the shell-level install + plugin smoke tests are only in this workflow.

Two lines added (\`'Cargo.lock'\`), one for \`push\` and one for \`pull_request\`.

## Test plan

- [x] Diff is two lines, both additive to existing path filters
- [x] No behavior change for non-lockfile PRs
- [ ] This PR itself touches a workflow file, so integration-tests will run (the workflow-self-include path \`'.github/workflows/integration-tests.yml'\` already covers this case) — verifying the change is wired correctly