### PR TITLE
fix(agents): custom agent profile inherits its own description, not Claude's

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1559,6 +1559,7 @@ pub fn add_custom_agent_with(
         .unwrap_or_else(|| agent.binary.clone());
     let profile = crate::config::Profile {
         name: agent.name.clone(),
+        description: agent.description.clone(),
         agent_cli_path: resolved_binary,
         ..crate::config::Profile::default()
     };
@@ -1669,6 +1670,29 @@ mod tests {
 
         let profile_path = tmp.path().join("profiles").join("myagent.toml");
         assert!(profile_path.exists(), "profile file should exist");
+    }
+
+    #[test]
+    fn add_custom_agent_with_propagates_description_to_profile() {
+        // Regression: the profile is built with `..Profile::default()`, which
+        // hardcodes Claude's name + description. Without an explicit override
+        // the custom agent's profile shows up in TUI search as "Claude Code by
+        // Anthropic" — wrong on its face and pollutes description-based filter
+        // matching. Pin the override.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mgr = crate::config::ProfileManager::with_config_dir(tmp.path().to_path_buf())
+            .expect("manager");
+
+        let mut a = add_args("aider");
+        a.description = Some("Pair programmer".into());
+        add_custom_agent_with(&mgr, a).expect("add");
+
+        let profile = mgr.load_profile("aider").expect("load profile");
+        assert_eq!(profile.description, "Pair programmer");
+        assert_ne!(
+            profile.description, "Claude Code by Anthropic",
+            "must not inherit Profile::default description"
+        );
     }
 
     #[test]


### PR DESCRIPTION
After-the-fact review on #342 caught a small bug. \`add_custom_agent_with\` builds the profile via \`..Profile::default()\`, which sets \`description: \"Claude Code by Anthropic\"\`. That string ended up baked into the custom agent's profile.toml — wrong on its face, and polluting the TUI's description-based search filter (\`profile.description.to_lowercase().contains(&query)\` at \`tui/app.rs:3198\` and \`:5186\`), so searching for \"Anthropic\" would incorrectly surface every custom agent.

One-line override in the \`Profile\` struct literal + a regression test that asserts \`description == agent.description\` (and explicitly \`!=\` the default Claude string, so the fix can't silently regress).

Test count: 22 → 23 in \`agents::tests\`. Without the fix, the new test fails with the expected default-description.

## Test plan

- [x] \`cargo test --lib agents::tests::add_custom_agent_with_propagates_description_to_profile\` passes with fix, fails without
- [x] \`cargo clippy --all-targets --no-deps -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [ ] CI green