### PR TITLE
docs: surface `unleash agents add` as the quick-start path

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -97,9 +97,25 @@ unleash auth                # Human-readable status
 unleash auth --json         # Machine-readable JSON output
 ```
 
-### `unleash agents status`
+### `unleash agents`
 
-Show all agent versions and update status in a single table.
+Manage agent CLIs (built-in or custom).
+
+```bash
+unleash agents status                # All agent versions + update status (default)
+unleash agents list                  # Available agents (built-in + registered custom)
+unleash agents check [agent]         # Query latest releases (all, or one)
+unleash agents update <agent>        # Install the latest release of one agent
+unleash agents info <agent>          # Detailed info for one agent
+unleash agents add <name> --binary <path> --headless-flag=<flag>  # Register a custom agent
+```
+
+`unleash agents add` writes both a `[[custom_agents]]` entry to
+`~/.config/unleash/config.toml` and a matching profile file at
+`~/.config/unleash/profiles/<name>.toml`, so `unleash <name>` works
+immediately. See [docs/custom-agents.md](custom-agents.md) for full
+field reference and examples; `--dry-run` previews the TOML without
+touching disk.
 
 ### `unleash sessions`
 

--- a/docs/custom-agents.md
+++ b/docs/custom-agents.md
@@ -11,7 +11,35 @@ What's deferred: automatic version install/update for custom agents. Use the bin
 
 ## Quick start
 
-Two steps: declare the agent's capabilities, then create a profile that launches it.
+The fastest path is `unleash agents add`, which writes both the
+`[[custom_agents]]` entry and the matching profile file in one shot:
+
+```bash
+unleash agents add aider \
+  --binary aider \
+  --headless-flag=--message \
+  --model-flag=--model \
+  --yolo-flag=--yes \
+  --github-repo paul-gauthier/aider
+```
+
+Then launch:
+
+```bash
+unleash aider              # launch interactive
+unleash aider -p "fix it"  # headless — translated to `aider --message "fix it"`
+unleash aider -m gpt-4 -c  # model + continue
+```
+
+Use `--dry-run` to preview the TOML that would be written without
+touching disk. Pass values starting with `--` either via `=` syntax
+(`--headless-flag=--message`) or quoted (`--headless-flag '--message'`) —
+clap won't accept an unquoted `--message` as a value otherwise.
+
+### Or do it by hand
+
+If you'd rather edit the config files directly (e.g. to script bulk
+registration or check the result into a dotfiles repo):
 
 **1.** Add a `[[custom_agents]]` block to `~/.config/unleash/config.toml`:
 
@@ -44,15 +72,7 @@ theme = "orange"
 
 The profile's `name` must match the `[[custom_agents]].name` exactly — that's how the launcher resolves which polyfill to apply. `agent_cli_path` is what gets exec'd; usually identical to `binary` (or an absolute path if the binary isn't on `$PATH`).
 
-Then:
-
-```bash
-unleash aider              # launch
-unleash aider -p "fix it"  # headless — translated to `aider --message "fix it"`
-unleash aider -m gpt-4 -c  # model + continue
-```
-
-> The TUI's "Add custom agent" wizard does step 1 automatically and points the *currently-editing* profile at the new binary. To get a dedicated `unleash <name>` subcommand, you still need a profile file with the matching name — copy any built-in profile and adjust.
+> The TUI's "Add custom agent" wizard writes the same files. `unleash agents add` is the headless/scriptable equivalent.
 
 ## Required fields
 


### PR DESCRIPTION
PR #342 added a CLI subcommand (\`unleash agents add\`) that writes both the \`[[custom_agents]]\` config entry and the matching profile file in one shot. Docs were written for the pre-#342 manual two-step flow; this brings them in line.

## Changes

- **\`docs/custom-agents.md\`** — lead with \`unleash agents add\` (with a real working example, verified end-to-end against the release binary). Move the manual TOML-editing path under an "Or do it by hand" header for users who want to script bulk registration or check it into dotfiles. Drop the stale note about the TUI wizard not creating a profile file (which was true pre-#342 — the wizard now writes both, same as the CLI).
- **\`docs/cli-reference.md\`** — replace the single-line "agents status" entry with the full subcommand surface: \`status\` / \`list\` / \`check\` / \`update\` / \`info\` / \`add\`.

## The \`=\` syntax footnote

The docs example uses \`--headless-flag=--message\` rather than \`--headless-flag --message\` because clap won't accept an unquoted \`--message\` as a positional value (it parses as an unknown flag) unless \`allow_hyphen_values = true\` is set. #342 set it on the relevant args so both forms work, but the \`=\` form is the more discoverable one — documented inline right after the example so users hit the right form first try.

## Test plan

- [x] Verified the docs example produces the documented TOML via the release binary (\`./target/release/unleash agents add aider ... --dry-run\`)
- [x] No code touched; no tests affected