### PR TITLE
chore: gitignore .claude/handoffs/ for dated agent handoff notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ docs/superpowers/
 src/assets/candidates/
 src/assets/mascot.*.bbox.ans
 /AGENT_SYNC.md
+.claude/handoffs/


### PR DESCRIPTION
Mirrors the existing \`/AGENT_SYNC.md\` ignore — both are agent-internal state, not project content. A pre-existing handoff already on disk (\`.claude/handoffs/2026-06-16-handoff.md\`) was being seen as untracked on every \`git status\`; this stops the noise.

One-line addition to \`.gitignore\`. No code, no tests, no doc impact.