### PR TITLE
fix(agents): `add` preserves user profile customizations on re-add

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1557,12 +1557,17 @@ pub fn add_custom_agent_with(
         .ok()
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|| agent.binary.clone());
-    let profile = crate::config::Profile {
-        name: agent.name.clone(),
-        description: agent.description.clone(),
-        agent_cli_path: resolved_binary,
-        ..crate::config::Profile::default()
-    };
+    // Preserve user customizations (theme, env, defaults, agents overrides,
+    // agent_cli_args, stop_prompt) when re-adding an agent whose profile
+    // already exists. Only overwrite the fields this subcommand actually
+    // owns: name, description, agent_cli_path. The fresh-install path
+    // (load_profile returns Err) still falls back to Profile::default.
+    let mut profile = mgr
+        .load_profile(&agent.name)
+        .unwrap_or_else(|_| crate::config::Profile::default());
+    profile.name = agent.name.clone();
+    profile.description = agent.description.clone();
+    profile.agent_cli_path = resolved_binary;
     mgr.save_profile(&profile)?;
 
     println!(
@@ -1670,6 +1675,57 @@ mod tests {
 
         let profile_path = tmp.path().join("profiles").join("myagent.toml");
         assert!(profile_path.exists(), "profile file should exist");
+    }
+
+    #[test]
+    fn add_custom_agent_with_preserves_user_profile_customizations() {
+        // Regression: re-adding an agent whose profile already exists must NOT
+        // clobber user-customized fields (theme, env, defaults, agents
+        // overrides, agent_cli_args, stop_prompt). Only name, description, and
+        // agent_cli_path are owned by this subcommand.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mgr = crate::config::ProfileManager::with_config_dir(tmp.path().to_path_buf())
+            .expect("manager");
+
+        // Pre-create a profile with hand-customized fields the user added in
+        // the TUI editor.
+        let mut existing = crate::config::Profile {
+            name: "aider".into(),
+            agent_cli_path: "/old/path/to/aider".into(),
+            theme: "orange".into(),
+            agent_cli_args: vec!["--my-custom-arg".into()],
+            stop_prompt: Some("Custom stop prompt".into()),
+            ..crate::config::Profile::default()
+        };
+        existing
+            .env
+            .insert("CUSTOM_KEY".into(), "custom_value".into());
+        mgr.save_profile(&existing).expect("pre-save");
+
+        // Re-add with new binary — should overwrite name/description/path only.
+        let mut a = add_args("aider");
+        a.description = Some("Pair programmer".into());
+        a.force = true;
+        add_custom_agent_with(&mgr, a).expect("re-add");
+
+        let after = mgr.load_profile("aider").expect("load");
+        assert_eq!(after.description, "Pair programmer", "description updated");
+        assert_eq!(after.theme, "orange", "theme preserved");
+        assert_eq!(
+            after.agent_cli_args,
+            vec!["--my-custom-arg".to_string()],
+            "agent_cli_args preserved"
+        );
+        assert_eq!(
+            after.stop_prompt.as_deref(),
+            Some("Custom stop prompt"),
+            "stop_prompt preserved"
+        );
+        assert_eq!(
+            after.env.get("CUSTOM_KEY").map(String::as_str),
+            Some("custom_value"),
+            "env entries preserved"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Third bug from self-review on #342. \`add_custom_agent_with\` constructed the profile via \`..Profile::default()\` and only overrode name / description / agent_cli_path, clobbering everything else. If the user hand-customized the profile in the TUI (theme, env, agent_cli_args, stop_prompt, defaults, agents overrides) and then ran \`unleash agents add <same-name> ...\` to bump the binary path or description, all those customizations were silently lost.

Load the existing profile via \`mgr.load_profile\` first when it exists, overwrite only the fields this subcommand actually owns, and save it back. Fresh-install path (load_profile returns Err — no file there) still falls back to \`Profile::default\`.

This is the mirror bug to #344: that one fixed the **initial** description inheriting Claude's default; this one fixes the **re-add** path clobbering all user state.

## Regression test

Pre-creates a profile with:
- \`theme = \"orange\"\`
- \`env = { CUSTOM_KEY = \"custom_value\" }\`
- \`agent_cli_args = [\"--my-custom-arg\"]\`
- \`stop_prompt = Some(\"Custom stop prompt\")\`

Re-adds with \`--force\` and a new \`--description\`. Asserts:
- Description updates ✓
- All four customization fields survive verbatim ✓

Without this fix, every assertion except the description one fails.

## Test plan

- [x] \`cargo test --lib agents::tests::add_custom_agent_with_preserves_user_profile_customizations\` passes with fix, fails without
- [x] \`cargo test --lib agents::tests::\` — 24 pass (was 23 before; +1 new regression test)
- [x] \`cargo clippy --all-targets --no-deps -- -D warnings\` clean
- [x] \`cargo fmt --all --check\` clean
- [ ] CI green