### PR TITLE
fix(agents): `add` preserves existing config-block fields on re-add

### DIFF
--- a/docs/custom-agents.md
+++ b/docs/custom-agents.md
@@ -36,6 +36,23 @@ touching disk. Pass values starting with `--` either via `=` syntax
 (`--headless-flag=--message`) or quoted (`--headless-flag '--message'`) —
 clap won't accept an unquoted `--message` as a value otherwise.
 
+### Re-running `agents add` is a merge, not a replace
+
+If an agent with the same `name` is already registered, `agents add` updates
+the existing entry in place. The CLI invocation owns `binary` and the
+`headless` strategy — those always take the values you pass. Optional fields
+(`description`, `continue_flag`, `resume_flag`, `model_flag`, `yolo_flag`,
+`github_repo`, `npm_package`) are only overwritten when the corresponding flag
+is provided. Everything else — `enabled`, `effort_flag`, `sandbox`, `fork`,
+`verbose_flag`, and every other polyfill knob without a dedicated CLI flag —
+is preserved verbatim from the existing config. The matching profile file
+follows the same rule (theme, env, agent_cli_args, stop_prompt all preserved).
+
+This means you can hand-edit `config.toml` to set fields the CLI doesn't expose
+yet, and a later `unleash agents add <name> --binary <new> --headless-flag=…`
+won't wipe them. `--dry-run` previews the merged result with a "merging with
+existing entry" hint so you can confirm before committing.
+
 ### Or do it by hand
 
 If you'd rather edit the config files directly (e.g. to script bulk

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1844,36 +1844,38 @@ mod tests {
             .expect("manager");
 
         let mut existing = mgr.load_app_config().expect("load");
-        existing.custom_agents.push(crate::config::CustomAgentConfig {
-            name: "aider".into(),
-            binary: "aider-old".into(),
-            description: "Hand-tuned description".into(),
-            polyfill: AgentPolyfillConfig {
-                headless: HeadlessStrategy::Flag("--old-prompt".into()),
-                session: SessionStrategy {
-                    continue_strategy: ResumeStrategy::Flag("--restore-chat".into()),
-                    resume_strategy: ResumeStrategy::Flag("--restore-chat".into()),
+        existing
+            .custom_agents
+            .push(crate::config::CustomAgentConfig {
+                name: "aider".into(),
+                binary: "aider-old".into(),
+                description: "Hand-tuned description".into(),
+                polyfill: AgentPolyfillConfig {
+                    headless: HeadlessStrategy::Flag("--old-prompt".into()),
+                    session: SessionStrategy {
+                        continue_strategy: ResumeStrategy::Flag("--restore-chat".into()),
+                        resume_strategy: ResumeStrategy::Flag("--restore-chat".into()),
+                    },
+                    fork: ForkStrategy::Unsupported,
+                    yolo_flag: Some("--yes".into()),
+                    model_flag: "--mdl".into(),
+                    effort_flag: Some("--effort".into()),
+                    auto_flag: None,
+                    verbose_flag: Some("--verbose".into()),
+                    output_format_flag: None,
+                    system_prompt_flag: None,
+                    allowed_tools_flag: None,
+                    sandbox: SandboxStrategy::BoolFlag("--sandbox".into()),
+                    name_flag: None,
+                    add_dir_flag: None,
+                    approval_mode_flag: None,
+                    worktree_flag: None,
+                    interactive_prompt_flag: None,
                 },
-                fork: ForkStrategy::Unsupported,
-                yolo_flag: Some("--yes".into()),
-                model_flag: "--mdl".into(),
-                effort_flag: Some("--effort".into()),
-                auto_flag: None,
-                verbose_flag: Some("--verbose".into()),
-                output_format_flag: None,
-                system_prompt_flag: None,
-                allowed_tools_flag: None,
-                sandbox: SandboxStrategy::BoolFlag("--sandbox".into()),
-                name_flag: None,
-                add_dir_flag: None,
-                approval_mode_flag: None,
-                worktree_flag: None,
-                interactive_prompt_flag: None,
-            },
-            github_repo: Some("paul-gauthier/aider".into()),
-            npm_package: None,
-            enabled: false,
-        });
+                github_repo: Some("paul-gauthier/aider".into()),
+                npm_package: None,
+                enabled: false,
+            });
         mgr.save_app_config(&existing).expect("pre-save");
 
         // Re-add specifying only binary + headless-flag (and the description) —

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1519,13 +1519,28 @@ pub fn add_custom_agent_with(
     mgr: &crate::config::ProfileManager,
     args: AddCustomAgentArgs,
 ) -> io::Result<()> {
-    let agent = build_custom_agent_config(&args)
+    let fresh_agent = build_custom_agent_config(&args)
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+
+    let mut app_config = mgr.load_app_config()?;
+    let existing_idx = app_config
+        .custom_agents
+        .iter()
+        .position(|c| c.name == fresh_agent.name);
+    let merged_with_existing = existing_idx.is_some();
+    let agent = if let Some(idx) = existing_idx {
+        merge_args_into_existing(&app_config.custom_agents[idx], &args, &fresh_agent)
+    } else {
+        fresh_agent
+    };
 
     if args.dry_run {
         let rendered = toml::to_string_pretty(&agent)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
         println!("# Would write to ~/.config/unleash/config.toml under [[custom_agents]]");
+        if merged_with_existing {
+            println!("# (merging with existing entry — preserving fields not specified)");
+        }
         println!("{}", rendered);
         println!(
             "# Would write profile to ~/.config/unleash/profiles/{}.toml",
@@ -1534,16 +1549,10 @@ pub fn add_custom_agent_with(
         return Ok(());
     }
 
-    let mut app_config = mgr.load_app_config()?;
-
-    let existing_idx = app_config
-        .custom_agents
-        .iter()
-        .position(|c| c.name == agent.name);
     if let Some(idx) = existing_idx {
         if !args.force {
             eprintln!(
-                "warn: custom agent '{}' already registered — overwriting (pass --force to silence)",
+                "warn: custom agent '{}' already registered — merging with existing entry (pass --force to silence)",
                 agent.name
             );
         }
@@ -1575,6 +1584,44 @@ pub fn add_custom_agent_with(
         agent.name, agent.name
     );
     Ok(())
+}
+
+/// Overlay CLI args onto an existing custom-agent entry. Required fields
+/// (`binary`, `headless`) come from the CLI invocation; optional fields are
+/// overwritten only when the user explicitly passed the corresponding flag.
+/// Fields with no CLI surface (e.g. `effort_flag`, `sandbox`, `fork`,
+/// `enabled`) are preserved verbatim from the existing config. Mirrors the
+/// profile-level preservation introduced in #349.
+fn merge_args_into_existing(
+    existing: &crate::config::CustomAgentConfig,
+    args: &AddCustomAgentArgs,
+    fresh: &crate::config::CustomAgentConfig,
+) -> crate::config::CustomAgentConfig {
+    let mut merged = existing.clone();
+    merged.binary = fresh.binary.clone();
+    merged.polyfill.headless = fresh.polyfill.headless.clone();
+    if let Some(d) = args.description.clone() {
+        merged.description = d;
+    }
+    if let Some(f) = args.continue_flag.clone() {
+        merged.polyfill.session.continue_strategy = ResumeStrategy::Flag(f);
+    }
+    if let Some(f) = args.resume_flag.clone() {
+        merged.polyfill.session.resume_strategy = ResumeStrategy::Flag(f);
+    }
+    if let Some(f) = args.model_flag.clone() {
+        merged.polyfill.model_flag = f;
+    }
+    if let Some(y) = args.yolo_flag.clone() {
+        merged.polyfill.yolo_flag = Some(y);
+    }
+    if let Some(r) = args.github_repo.clone() {
+        merged.github_repo = Some(r);
+    }
+    if let Some(p) = args.npm_package.clone() {
+        merged.npm_package = Some(p);
+    }
+    merged
 }
 
 #[cfg(test)]
@@ -1782,6 +1829,93 @@ mod tests {
         assert!(cfg.custom_agents.is_empty());
         let profile_path = tmp.path().join("profiles").join("nope.toml");
         assert!(!profile_path.exists());
+    }
+
+    #[test]
+    fn add_custom_agent_with_preserves_existing_config_fields_on_readd() {
+        // Regression: re-running `unleash agents add` without specifying every
+        // optional CLI flag must NOT clobber hand-edited [[custom_agents]]
+        // fields (effort_flag, sandbox, fork, model_flag override, github_repo,
+        // yolo_flag, enabled). Only fields the user explicitly passes on the
+        // CLI — plus the always-required binary + headless — should change.
+        // Mirrors #349 at the config-block level rather than profile level.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mgr = crate::config::ProfileManager::with_config_dir(tmp.path().to_path_buf())
+            .expect("manager");
+
+        let mut existing = mgr.load_app_config().expect("load");
+        existing.custom_agents.push(crate::config::CustomAgentConfig {
+            name: "aider".into(),
+            binary: "aider-old".into(),
+            description: "Hand-tuned description".into(),
+            polyfill: AgentPolyfillConfig {
+                headless: HeadlessStrategy::Flag("--old-prompt".into()),
+                session: SessionStrategy {
+                    continue_strategy: ResumeStrategy::Flag("--restore-chat".into()),
+                    resume_strategy: ResumeStrategy::Flag("--restore-chat".into()),
+                },
+                fork: ForkStrategy::Unsupported,
+                yolo_flag: Some("--yes".into()),
+                model_flag: "--mdl".into(),
+                effort_flag: Some("--effort".into()),
+                auto_flag: None,
+                verbose_flag: Some("--verbose".into()),
+                output_format_flag: None,
+                system_prompt_flag: None,
+                allowed_tools_flag: None,
+                sandbox: SandboxStrategy::BoolFlag("--sandbox".into()),
+                name_flag: None,
+                add_dir_flag: None,
+                approval_mode_flag: None,
+                worktree_flag: None,
+                interactive_prompt_flag: None,
+            },
+            github_repo: Some("paul-gauthier/aider".into()),
+            npm_package: None,
+            enabled: false,
+        });
+        mgr.save_app_config(&existing).expect("pre-save");
+
+        // Re-add specifying only binary + headless-flag (and the description) —
+        // every other optional flag is omitted.
+        let mut a = add_args("aider");
+        a.binary = "aider-new".into();
+        a.headless_flag = Some("--new-prompt".into());
+        a.description = Some("Updated description".into());
+        a.force = true;
+        add_custom_agent_with(&mgr, a).expect("re-add");
+
+        let after = mgr.load_app_config().expect("load");
+        assert_eq!(after.custom_agents.len(), 1, "no duplicate entry");
+        let entry = &after.custom_agents[0];
+
+        // Required fields took the CLI values.
+        assert_eq!(entry.binary, "aider-new");
+        assert!(matches!(
+            entry.polyfill.headless,
+            HeadlessStrategy::Flag(ref f) if f == "--new-prompt"
+        ));
+        // Explicit CLI overrides applied.
+        assert_eq!(entry.description, "Updated description");
+        // Omitted CLI flags must NOT have wiped existing values.
+        assert_eq!(entry.polyfill.effort_flag.as_deref(), Some("--effort"));
+        assert_eq!(entry.polyfill.verbose_flag.as_deref(), Some("--verbose"));
+        assert_eq!(entry.polyfill.yolo_flag.as_deref(), Some("--yes"));
+        assert_eq!(entry.polyfill.model_flag, "--mdl");
+        assert!(matches!(
+            entry.polyfill.session.continue_strategy,
+            ResumeStrategy::Flag(ref f) if f == "--restore-chat"
+        ));
+        assert!(matches!(
+            entry.polyfill.session.resume_strategy,
+            ResumeStrategy::Flag(ref f) if f == "--restore-chat"
+        ));
+        assert!(matches!(
+            entry.polyfill.sandbox,
+            SandboxStrategy::BoolFlag(ref f) if f == "--sandbox"
+        ));
+        assert_eq!(entry.github_repo.as_deref(), Some("paul-gauthier/aider"));
+        assert!(!entry.enabled, "enabled state preserved across re-add");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Mirror of #349 at the config-block level. `unleash agents add <name> ...` used to entirely replace any existing `[[custom_agents]]` entry with a freshly-built one, silently wiping hand-edited fields the CLI doesn't yet expose (`effort_flag`, `sandbox`, `fork`, `verbose_flag`, …) plus any custom `model_flag` / `yolo_flag` / `github_repo` / `description` whenever the user re-ran `agents add` without re-specifying every flag.

After this fix: re-adding merges. Required fields (`binary`, `headless`) always take the CLI value; optional fields are overwritten only when the user explicitly passed them; everything else (including `enabled` and every passthrough polyfill flag) is preserved verbatim.

## Why this matters

The TUI editor and any future passthrough-flag CLI surface can land additional polyfill configuration that the `agents add` subcommand doesn't (yet) accept as a flag. Before this PR, running `agents add` once was enough to clobber all of it. After this PR, `agents add` is safe to re-run as a partial update.

## End-to-end verification (clean-env sandbox via `env -i HOME=$TMPDIR`)

Pre-seeded `~/.config/unleash/config.toml` with an aider entry that has hand-tuned `model_flag = "--mdl"`, custom `yolo_flag`, custom `effort_flag`, custom session flags, and `github_repo`. Then re-ran `agents add aider --binary aider-new --headless-flag=--new-prompt --description "Updated" --force`. Result:

```
[[custom_agents]]
name = "aider"
binary = "aider-new"             # explicit → updated
description = "Updated"          # explicit → updated
github_repo = "paul-gauthier/aider"  # omitted → preserved
enabled = true

[custom_agents.polyfill]
fork = "unsupported"             # preserved
yolo_flag = "--yes"              # preserved
model_flag = "--mdl"             # preserved
effort_flag = "--effort"         # preserved
sandbox = "unsupported"          # preserved

[custom_agents.polyfill.headless]
flag = "--new-prompt"            # explicit → updated

[custom_agents.polyfill.session.continue_strategy]
flag = "--restore-chat"          # preserved
[custom_agents.polyfill.session.resume_strategy]
flag = "--restore-chat"          # preserved
```

`--dry-run` also picks up the merge — it loads the existing config, applies the overlay, and prints a hint line:

```
# Would write to ~/.config/unleash/config.toml under [[custom_agents]]
# (merging with existing entry — preserving fields not specified)
```

## Test plan

- [x] `cargo test --lib` — 594 pass, 3 ignored
- [x] New regression test `add_custom_agent_with_preserves_existing_config_fields_on_readd` pre-seeds custom polyfill flags + `enabled = false`, re-adds with minimal CLI args, asserts every omitted field is preserved + every explicit field is updated
- [x] `add_custom_agent_with_is_idempotent_on_reregister` (existing) still passes — `binary` taken from CLI on every re-add as before
- [x] `tests/test_docs_drift.sh` passes
- [x] Clean-env end-to-end test (with `env -i HOME=$TMPDIR` to bypass `XDG_CONFIG_HOME` shadowing of `$HOME`) confirms both real re-add and `--dry-run` behave as documented above

## Files

- `src/agents.rs` (+142, -8) — `add_custom_agent_with` restructured to compute `agent` via merge-or-fresh before the dry-run branch; new `merge_args_into_existing` helper; warning text + dry-run header updated; regression test added

Follow-up to #342 / #349.