### PR TITLE
fix(launcher): inject agent-native continue form on restart, not literal `--continue`

### DIFF
--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -107,6 +107,24 @@ pub(crate) fn args_already_signal_resume(args: &[String]) -> bool {
     })
 }
 
+/// Args to prepend on restart to make the agent resume its last session.
+/// Each agent has its own native form (Claude `--continue`, Codex `resume
+/// --last`, Gemini `--resume latest`, etc.); we delegate to the same
+/// `AgentDefinition::polyfill.session.continue_strategy` the polyfill uses
+/// at first launch so the two stay in sync. Unknown / custom / wrapper
+/// agents fall back to `--continue` since that's also the default the
+/// `unleash agents add` subcommand picks for custom polyfills.
+pub(crate) fn restart_continue_args(agent_type: Option<&AgentType>) -> Vec<String> {
+    match agent_type {
+        Some(t) if !matches!(t, AgentType::Unleash | AgentType::Custom(_)) => {
+            crate::agents::AgentDefinition::from_type(t.clone())
+                .polyfill
+                .get_continue_args()
+        }
+        _ => vec!["--continue".to_string()],
+    }
+}
+
 /// Configuration for [`run_loop`]: bundles the inputs the auto-mode restart
 /// state machine needs without having to read from the user's profile, env,
 /// or `dirs::cache_dir()`. Production callers build this from real config in
@@ -174,13 +192,21 @@ pub fn run_loop(config: LauncherConfig) -> io::Result<i32> {
         // Build command arguments
         let mut args = extra_args.clone();
 
-        // If this is a restart, add --continue and message
+        // If this is a restart, add the agent's continue form and message
         if restart_count > 0 {
             if !args_already_signal_resume(&args) {
-                args.insert(0, "--continue".to_string());
+                // Use the agent's native continue form. Claude → `--continue`,
+                // Codex → `resume --last`, Gemini → `--resume latest`, etc.
+                // Injecting a literal `--continue` for non-Claude agents
+                // would have made codex/gemini error on restart.
+                let continue_args = restart_continue_args(agent_type.as_ref());
+                let injected = continue_args.len();
+                for (i, arg) in continue_args.into_iter().enumerate() {
+                    args.insert(i, arg);
+                }
                 // Only Claude Code supports --dangerously-skip-permissions
                 if is_claude {
-                    args.insert(1, "--dangerously-skip-permissions".to_string());
+                    args.insert(injected, "--dangerously-skip-permissions".to_string());
                 }
             }
 

--- a/tests/auto_mode_loop.rs
+++ b/tests/auto_mode_loop.rs
@@ -261,6 +261,147 @@ fn auto_mode_restart_loop_injects_dangerously_skip_permissions_for_claude() {
 }
 
 #[test]
+fn auto_mode_restart_loop_injects_codex_resume_subcommand_not_continue_flag() {
+    // Regression: prior to this test, the restart loop unconditionally
+    // injected the literal `--continue` flag on every restart. That works
+    // for Claude/OpenCode/Pi/Hermes/Antigravity (all use `--continue`) but
+    // would have made Codex error out — Codex resumes via `resume --last`
+    // subcommand, not a `--continue` flag. Now the loop consults the
+    // agent's polyfill continue_strategy and injects whatever native form
+    // the agent expects.
+    if bash_path().is_none() {
+        eprintln!("skipping: bash not available on PATH");
+        return;
+    }
+
+    let workspace = TempDir::new().expect("tempdir");
+    let cache_dir = workspace.path().join("cache");
+    fs::create_dir_all(&cache_dir).unwrap();
+    let home_guard = ScopedEnv::set("HOME", workspace.path());
+
+    let scripts_dir = workspace.path().join("bin");
+    fs::create_dir_all(&scripts_dir).unwrap();
+    let real_script = write_fake_agent(workspace.path(), &cache_dir);
+    let codex_path = scripts_dir.join("codex");
+    std::os::unix::fs::symlink(&real_script, &codex_path).unwrap();
+
+    let config = LauncherConfig {
+        agent_cmd: codex_path,
+        agent_type: Some(unleash::agents::AgentType::Codex),
+        cache_dir: cache_dir.clone(),
+        auto_mode: false,
+        prompt: None,
+        extra_args: vec![],
+        profile_env: HashMap::new(),
+        include_plugin_args: false,
+    };
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = std::thread::spawn(move || {
+        let _ = tx.send(run_loop(config));
+    });
+    let result = rx
+        .recv_timeout(std::time::Duration::from_secs(30))
+        .expect("run_loop did not return within 30s");
+    handle.join().expect("worker thread panicked");
+    drop(home_guard);
+
+    assert_eq!(result.expect("io error from run_loop"), 0);
+
+    let scratch = workspace.path().join("scratch");
+    let args2 = read_argv(&scratch.join("run-2.argv"));
+    assert!(
+        args2.iter().any(|a| a == "resume"),
+        "Codex run 2 must inject `resume` subcommand, got: {:?}",
+        args2
+    );
+    assert!(
+        args2.iter().any(|a| a == "--last"),
+        "Codex run 2 must inject `--last` after `resume`, got: {:?}",
+        args2
+    );
+    assert!(
+        !args2.iter().any(|a| a == "--continue"),
+        "Codex run 2 must NOT inject `--continue` (codex doesn't support it), got: {:?}",
+        args2
+    );
+    assert!(
+        !args2.iter().any(|a| a == "--dangerously-skip-permissions"),
+        "non-Claude agent must not get --dangerously-skip-permissions, got: {:?}",
+        args2
+    );
+}
+
+#[test]
+fn auto_mode_restart_loop_injects_gemini_resume_latest_flag_not_continue() {
+    // Regression: same shape as the Codex case above, but Gemini uses a
+    // flag-style continue (`--resume latest`) rather than a subcommand.
+    // The polyfill table at src/agents.rs encodes both forms; the launcher
+    // delegates to it so the two stay in sync.
+    if bash_path().is_none() {
+        eprintln!("skipping: bash not available on PATH");
+        return;
+    }
+
+    let workspace = TempDir::new().expect("tempdir");
+    let cache_dir = workspace.path().join("cache");
+    fs::create_dir_all(&cache_dir).unwrap();
+    let home_guard = ScopedEnv::set("HOME", workspace.path());
+
+    let scripts_dir = workspace.path().join("bin");
+    fs::create_dir_all(&scripts_dir).unwrap();
+    let real_script = write_fake_agent(workspace.path(), &cache_dir);
+    let gemini_path = scripts_dir.join("gemini");
+    std::os::unix::fs::symlink(&real_script, &gemini_path).unwrap();
+
+    let config = LauncherConfig {
+        agent_cmd: gemini_path,
+        agent_type: Some(unleash::agents::AgentType::Gemini),
+        cache_dir: cache_dir.clone(),
+        auto_mode: false,
+        prompt: None,
+        extra_args: vec![],
+        profile_env: HashMap::new(),
+        include_plugin_args: false,
+    };
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = std::thread::spawn(move || {
+        let _ = tx.send(run_loop(config));
+    });
+    let result = rx
+        .recv_timeout(std::time::Duration::from_secs(30))
+        .expect("run_loop did not return within 30s");
+    handle.join().expect("worker thread panicked");
+    drop(home_guard);
+
+    assert_eq!(result.expect("io error from run_loop"), 0);
+
+    let scratch = workspace.path().join("scratch");
+    let args2 = read_argv(&scratch.join("run-2.argv"));
+    assert!(
+        args2.iter().any(|a| a == "--resume"),
+        "Gemini run 2 must inject `--resume`, got: {:?}",
+        args2
+    );
+    assert!(
+        args2.iter().any(|a| a == "latest"),
+        "Gemini run 2 must inject `latest` after `--resume`, got: {:?}",
+        args2
+    );
+    assert!(
+        !args2.iter().any(|a| a == "--continue"),
+        "Gemini run 2 must NOT inject `--continue` (gemini doesn't support it), got: {:?}",
+        args2
+    );
+    assert!(
+        !args2.iter().any(|a| a == "--dangerously-skip-permissions"),
+        "non-Claude agent must not get --dangerously-skip-permissions, got: {:?}",
+        args2
+    );
+}
+
+#[test]
 fn auto_mode_restart_loop_no_trigger_returns_immediately() {
     if bash_path().is_none() {
         eprintln!("skipping: bash not available on PATH");


### PR DESCRIPTION
## Summary

`launcher::run_loop` used to unconditionally insert `--continue` at args[0] on every restart_count > 0 iteration. That works for Claude, OpenCode, Pi, Hermes, and Antigravity (all use `--continue` as their continue form) but is wrong for Codex (`resume --last` subcommand) and Gemini (`--resume latest` flag). A user who triggered `unleash-refresh` inside an interactive Codex or Gemini session would have hit an "unknown flag" error on the next iteration.

## Bug shape

```rust
// run_loop, before fix
if restart_count > 0 {
    if !args_already_signal_resume(&args) {
        args.insert(0, "--continue".to_string());  // ← Claude-shaped, wrong for codex/gemini
        if is_claude { args.insert(1, "--dangerously-skip-permissions".to_string()); }
    }
    ...
}
```

For `unleash codex` (plain interactive) → `unleash-refresh`: restart_count = 1, args = [], `args_already_signal_resume([])` = false, injects `--continue`. Codex doesn't have `--continue` → error. Same shape for `unleash gemini`.

## Fix

Delegate to the same `AgentDefinition::polyfill.session.continue_strategy` the polyfill consults at first launch. The agent's native form is the single source of truth, kept in `src/agents.rs`:

| Agent | continue_strategy | Injected on restart |
|-------|-------------------|---------------------|
| Claude / Hermes / OpenCode / Pi / Antigravity | `Flag("--continue")` | `--continue` |
| Codex | `Subcommand("resume --last")` | `resume --last` |
| Gemini | `Flag("--resume latest")` | `--resume latest` |
| None / Custom / Unleash | _fallback_ | `--continue` |

The `--dangerously-skip-permissions` injection stays Claude-gated; the insert index now uses the actual number of injected continue args so it lands right after them regardless of shape (1 arg for Claude, 2 for Codex/Gemini, etc.).

## Why now

Found while deep-reading `src/launcher.rs` end-to-end per COO directive (overnight bug-hunt of unleash core). The existing integration test only covers Claude + agent_type=None paths; Codex and Gemini restart had never been exercised end-to-end.

## Test plan

- [x] `cargo test --lib` — 602 passing, 3 ignored
- [x] `cargo test --test auto_mode_loop` — 5/5 passing (2 new + 3 pre-existing)
- [x] New: `auto_mode_restart_loop_injects_codex_resume_subcommand_not_continue_flag` — symlinks fake agent as `codex`, asserts run-2 argv contains `resume` + `--last` and does NOT contain `--continue` or `--dangerously-skip-permissions`
- [x] New: `auto_mode_restart_loop_injects_gemini_resume_latest_flag_not_continue` — same shape, asserts `--resume` + `latest`
- [x] Pre-existing Claude test (`injects_dangerously_skip_permissions_for_claude`) still passes — Claude's continue is `["--continue"]` so behavior is identical
- [x] Pre-existing None-agent test (`runs_agent_twice_with_continue_on_second_invocation`) still passes — helper falls back to `["--continue"]` for None
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean

## Files

- `src/launcher.rs` (+22, -3) — new `restart_continue_args` helper + rewrite the injection block
- `tests/auto_mode_loop.rs` (+148, 0) — two regression tests

## Follow-up not in this PR

The restart-message tail (`RESURRECTED.` or the user's custom message) is still pushed unconditionally to `args` for every agent. For Codex `resume --last RESURRECTED.` it works (per `src/polyfill.rs` line 155 comment, the resume subcommand accepts a trailing positional prompt). For Gemini `--resume latest RESURRECTED.`, it depends on whether gemini's interactive mode takes a trailing positional as the initial user message — likely works, untested. If a follow-up incident report shows it doesn't, the message can be gated similarly to dangerously-skip-permissions. Not addressed here because it's the same surface as before the fix.

The double `--dangerously-skip-permissions` smell (polyfill adds it on iter 1, restart logic adds it again on iter 2+) is also pre-existing. Claude tolerates the duplicate. Out of scope.