### PR TITLE
fix(interchange): reject non-ASCII timestamps instead of panicking (#353)

### DIFF
--- a/src/interchange/hermes.rs
+++ b/src/interchange/hermes.rs
@@ -79,7 +79,10 @@ fn epoch_to_iso(secs: u64) -> String {
 fn iso_to_epoch(s: &str) -> Option<f64> {
     // Accepts: "YYYY-MM-DDTHH:MM:SS[.fff][Z|+00:00|±HH:MM]"
     let s = s.trim();
-    if s.len() < 19 {
+    // The fixed-offset byte slices below assume ASCII; a multibyte char in a
+    // corrupt/hand-edited timestamp would otherwise panic (not a char boundary)
+    // and abort the whole injection. A valid ISO-8601 timestamp is always ASCII.
+    if s.len() < 19 || !s.is_ascii() {
         return None;
     }
     let year: i64 = s[0..4].parse().ok()?;
@@ -486,6 +489,18 @@ mod tests {
         // 2026-05-24T02:00:00+02:00 = 2026-05-24T00:00:00Z = 1779580800
         let epoch = iso_to_epoch("2026-05-24T02:00:00+02:00").unwrap();
         assert_eq!(epoch as u64, 1779580800);
+    }
+
+    #[test]
+    fn iso_to_epoch_multibyte_is_none_not_panic() {
+        // A multibyte char inside the fixed-offset region used to panic the byte
+        // slices (not a char boundary), aborting injection. It must now return
+        // None instead. The 'é' sits where s[8..10] would split it.
+        assert!(iso_to_epoch("2026-06-é7T12:00:00Z").is_none());
+        // A multibyte char in the sub-seconds / tz tail must not panic either.
+        assert!(iso_to_epoch("2026-06-27T12:00:00.5世Z").is_none());
+        // Valid ASCII timestamps still parse.
+        assert!(iso_to_epoch("2026-06-27T12:00:00Z").is_some());
     }
 
     #[test]

--- a/src/interchange/opencode.rs
+++ b/src/interchange/opencode.rs
@@ -379,6 +379,11 @@ fn unix_ms_to_iso(ms: f64) -> String {
 
 fn iso_to_unix_ms(iso: &str) -> f64 {
     // Parse ISO 8601 format: YYYY-MM-DDTHH:MM:SS.mmmZ
+    // Reject non-ASCII up front: the sub-seconds byte slice below would panic on
+    // a multibyte char (not a char boundary), and a valid timestamp is ASCII.
+    if !iso.is_ascii() {
+        return 0.0;
+    }
     let parts: Vec<&str> = iso.split('T').collect();
     if parts.len() != 2 {
         return 0.0;
@@ -1292,6 +1297,17 @@ fn hub_content_to_opencode_parts(blocks: &[ContentBlock]) -> Vec<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn iso_to_unix_ms_multibyte_is_zero_not_panic() {
+        // A multibyte char in the sub-seconds used to panic the `&frac[..3]`
+        // byte slice (not a char boundary), aborting injection. It must now
+        // return the 0.0 fallback instead.
+        assert_eq!(iso_to_unix_ms("2026-06-27T12:00:00.5世Z"), 0.0);
+        assert_eq!(iso_to_unix_ms("2026-06-é7T12:00:00Z"), 0.0);
+        // Valid ASCII timestamps still parse to a positive epoch.
+        assert!(iso_to_unix_ms("2026-06-27T12:00:00.123Z") > 0.0);
+    }
 
     fn make_input(messages: &str, parts: &str) -> OpenCodeInput {
         OpenCodeInput {


### PR DESCRIPTION
## What
Guard `iso_to_epoch` (hermes) and `iso_to_unix_ms` (opencode) against non-ASCII timestamps so a multibyte char can't panic the parser — **#353 (MED, timestamp panics)**.

## Why
Both parse fixed-offset ISO-8601 with byte slices (`s[0..4]`, `&frac[..frac.len().min(3)]`). A multibyte char in a corrupt or hand-edited timestamp lands mid-char and panics (`"… is not a char boundary"`), aborting the **entire session injection**.

## How
An `is_ascii()` guard up front. A valid ISO-8601 timestamp is always ASCII, so non-ASCII input returns the existing fallback (`None` / `0.0`) instead of panicking. Valid timestamps parse identically — no behavior change for real input.

## Tests
- New unit tests feed multibyte timestamps (`…00.5世Z`, `2026-06-é7T…`) and assert the fallback.
- **Verified they panic without the guard** (`end byte index 3 is not a char boundary; it is inside '世'`).
- Full interchange / lossless / semantic suite still green (184 passed).
- fmt + clippy `-D warnings` clean.

## Notes
Low blast radius (timestamp parsing in two converters; pure robustness, no behavior change for valid input). Designed in an isolated worktree, **not self-merging** — for the unleash agent to review/merge. Refs #353.
