### PR TITLE
[codex] style: apply rustfmt

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -799,9 +799,8 @@ impl AgentManager {
                 if let Ok(bin_path) = which::which(&agent.binary) {
                     if let Ok(output) = Command::new(&bin_path).arg("--version").output() {
                         let stdout = String::from_utf8_lossy(&output.stdout);
-                        version = Self::parse_version(&stdout).or_else(|| {
-                            stdout.lines().next().map(|s| s.trim().to_string())
-                        });
+                        version = Self::parse_version(&stdout)
+                            .or_else(|| stdout.lines().next().map(|s| s.trim().to_string()));
                     }
                 }
             }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -966,9 +966,7 @@ pub fn run_agent(
     let mut network_ok = true;
     if !network_exists() {
         network_ok = false;
-        eprintln!(
-            "\x1b[31merror:\x1b[0m Sandbox network not found. LAN isolation is not active."
-        );
+        eprintln!("\x1b[31merror:\x1b[0m Sandbox network not found. LAN isolation is not active.");
         eprintln!("  Fix: sudo unleash sandbox setup");
     }
 
@@ -1248,8 +1246,19 @@ pub fn handle_sandbox(action: Option<&SandboxAction>) -> io::Result<()> {
         Some(SandboxAction::Status) => return run_status(docker_dir.as_deref()),
         Some(SandboxAction::List) => return run_list(),
         Some(SandboxAction::Enter { target, shell }) => return run_enter(target, shell),
-        Some(SandboxAction::Run { name, agent, args, i_know_its_unsafe }) => {
-            return run_agent(docker_dir.as_deref(), agent, name, args.as_slice(), *i_know_its_unsafe)
+        Some(SandboxAction::Run {
+            name,
+            agent,
+            args,
+            i_know_its_unsafe,
+        }) => {
+            return run_agent(
+                docker_dir.as_deref(),
+                agent,
+                name,
+                args.as_slice(),
+                *i_know_its_unsafe,
+            )
         }
         _ => {}
     }


### PR DESCRIPTION
## Summary

Applies `cargo fmt` to the Rust sources that currently make `main` fail `cargo fmt --all -- --check`.

## Root cause

Dependabot PR #368 is failing `cargo fmt --check`, but its diff only changes `actions/cache` versions in workflow YAML. The failing log points at pre-existing Rust formatting drift in `src/agents.rs` and `src/sandbox.rs` on the base branch.

## Validation

- `cargo fmt --all -- --check`

## Follow-up

After this lands, rebase or rerun #368 so its cache bump checks against a formatted base.
