### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Fixes the `Security Audit` workflow failure on `main` (post-#377 release 0.1.84 run).

**RUSTSEC-2026-0204** — `crossbeam-epoch <0.9.20`'s `fmt::Display` impls dereferenced the underlying pointer, causing UB e.g. for pointers created with `Atomic::null` / `Shared::null`. Upstream fix in 0.9.20.

Pulled via `tokenizers → rayon → rayon-core → crossbeam-deque` (and via `turso_core → tantivy → rayon`, plus `crossbeam-skiplist`).

## Test plan

- [x] `cargo update -p crossbeam-epoch` — `0.9.18 -> 0.9.20`
- [x] `cargo deny check advisories` clean locally
- [x] `cargo build` clean