### PR TITLE
fix(tui): truncate text input at char boundary

### DIFF
--- a/src/text_input.rs
+++ b/src/text_input.rs
@@ -180,7 +180,8 @@ impl TextInput {
 
     /// Delete from cursor to end of line (Ctrl+K)
     pub fn delete_to_end(&mut self) {
-        self.value.truncate(self.cursor);
+        let byte_idx = self.char_byte_index(self.cursor);
+        self.value.truncate(byte_idx);
         self.ensure_cursor_visible();
     }
 
@@ -442,6 +443,15 @@ mod tests {
         input.cursor = 6;
         input.delete_to_end();
         assert_eq!(input.value, "hello ");
+    }
+
+    #[test]
+    fn test_delete_to_end_with_multibyte_before_cursor() {
+        let mut input = TextInput::new().with_value("héllo world");
+        input.cursor = 2; // after "hé" in character indices
+        input.delete_to_end();
+        assert_eq!(input.value, "hé");
+        assert_eq!(input.cursor, 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the remaining multibyte cursor bug in `TextInput::delete_to_end` after #378.

`TextInput::cursor` is now a character index, but `String::truncate` expects a byte offset at a UTF-8 boundary. The merged Ctrl+K path still passed `self.cursor` directly, which could panic inside a multibyte character or truncate at the wrong position.

This PR converts the character cursor through `char_byte_index` before truncating and adds a regression test for multibyte text before the cursor.

## Validation

- `cargo test text_input --lib -- --test-threads=1`
- `cargo fmt --check`
