### PR TITLE
fix: harden issue 353 follow-ups

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1624,7 +1624,7 @@ impl AgentManager {
         let path = self.version_cache_path();
         let content = serde_json::to_string_pretty(&self.versions)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
-        fs::write(path, content)
+        crate::config::atomic_write(&path, &content)
     }
 
     /// Get status summary for all agents

--- a/src/interchange/gemini.rs
+++ b/src/interchange/gemini.rs
@@ -698,7 +698,7 @@ fn message_to_hub(msg: &Value, foreign_session: bool) -> Result<HubMessage, Conv
                     exit_code: tc
                         .get("exitCode")
                         .and_then(|v| v.as_i64())
-                        .map(|v| v as i32),
+                        .and_then(|v| i32::try_from(v).ok()),
                     is_error,
                     interrupted: status.as_deref() == Some("CANCELLED"),
                     status,
@@ -1234,11 +1234,56 @@ mod tests {
                 .filter(|b| matches!(b, ContentBlock::ToolResult { .. }))
                 .collect();
             assert_eq!(tool_results.len(), 1);
+            if let ContentBlock::ToolResult { exit_code, .. } = tool_results[0] {
+                assert_eq!(*exit_code, Some(0));
+            }
         }
 
         let back = from_hub(&hub).unwrap();
         let back_messages = back.get("messages").unwrap().as_array().unwrap();
         semantic_eq(&msg, &back_messages[1]).unwrap();
+    }
+
+    #[test]
+    fn test_tool_result_exit_code_overflow_is_ignored() {
+        let msg = serde_json::json!({
+            "id": "msg-gemini",
+            "type": "gemini",
+            "content": "",
+            "toolCalls": [{
+                "id": "tc-1",
+                "name": "shell",
+                "args": {"command": "false"},
+                "result": "failed",
+                "exitCode": 2147483648_i64,
+                "status": "ERROR"
+            }],
+            "timestamp": "2026-03-29T12:01:00.000Z"
+        });
+
+        let data = gemini_session_json(&[msg]);
+        let hub = to_hub(&data).unwrap();
+        let result_msg = hub
+            .iter()
+            .filter_map(|r| match r {
+                HubRecord::Message(m) => Some(m),
+                _ => None,
+            })
+            .find(|m| {
+                m.content
+                    .iter()
+                    .any(|b| matches!(b, ContentBlock::ToolResult { .. }))
+            })
+            .unwrap();
+        let result = result_msg
+            .content
+            .iter()
+            .find_map(|b| match b {
+                ContentBlock::ToolResult { exit_code, .. } => Some(exit_code),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(*result, None);
     }
 
     #[test]

--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -3,7 +3,9 @@
 use crate::interchange::crossload_index::{self, entry_is_live};
 use crate::interchange::sessions::{find_session, SessionInfo};
 use crate::interchange::{
-    claude, codex, gemini, hermes, hub::HubRecord, opencode, pi, ConvertError,
+    claude, codex, gemini, hermes,
+    hub::{ContentBlock, HubRecord},
+    opencode, pi, ConvertError,
 };
 
 /// Result of injecting a session: the session ID to resume with and any extra args.
@@ -213,6 +215,32 @@ fn estimate_block_chars(block: &crate::interchange::hub::ContentBlock) -> usize 
     }
 }
 
+fn tool_use_ids(record: &HubRecord) -> Vec<String> {
+    let HubRecord::Message(msg) = record else {
+        return Vec::new();
+    };
+    msg.content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::ToolUse { id, .. } => Some(id.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn tool_result_ids(record: &HubRecord) -> Vec<String> {
+    let HubRecord::Message(msg) = record else {
+        return Vec::new();
+    };
+    msg.content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::ToolResult { tool_use_id, .. } => Some(tool_use_id.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
 /// Trim the oldest user+assistant message pairs from `records` until
 /// the estimated token count fits within `max_tokens`.
 /// The session header (first record) is always kept.
@@ -236,13 +264,101 @@ pub(crate) fn truncate_hub_to_budget(
         if estimate_tokens(&current) <= max_tokens {
             return (current, dropped);
         }
-        // Drop the oldest message.
-        messages.remove(0);
+        // Drop the oldest message plus any linked tool counterpart. Keeping
+        // only one side leaves downstream Claude injection with orphaned
+        // tool_result blocks, which Claude rejects.
+        let removed = messages.remove(0);
         dropped += 1;
+        let mut linked_ids = tool_use_ids(&removed);
+        linked_ids.extend(tool_result_ids(&removed));
+        if !linked_ids.is_empty() {
+            let before = messages.len();
+            messages.retain(|msg| {
+                let uses = tool_use_ids(msg);
+                let results = tool_result_ids(msg);
+                !linked_ids
+                    .iter()
+                    .any(|id| uses.contains(id) || results.contains(id))
+            });
+            dropped += before - messages.len();
+        }
     }
 
     // Couldn't fit even with all messages dropped — return just the header.
     (header, dropped)
+}
+
+fn claude_text_is_keepable(text: &str) -> bool {
+    !text.is_empty()
+        && !text.starts_with("<environment_context")
+        && !text.starts_with("<permissions")
+        && !text.starts_with("<user_shell_command")
+        && !text.starts_with("[Reasoning]: \n")
+}
+
+fn claude_block_tool_use_id(block: &serde_json::Value) -> Option<String> {
+    (block.get("type").and_then(|t| t.as_str()) == Some("tool_use"))
+        .then(|| block.get("id").and_then(|id| id.as_str()).map(String::from))
+        .flatten()
+}
+
+fn claude_block_tool_result_id(block: &serde_json::Value) -> Option<String> {
+    (block.get("type").and_then(|t| t.as_str()) == Some("tool_result"))
+        .then(|| {
+            block
+                .get("tool_use_id")
+                .and_then(|id| id.as_str())
+                .map(String::from)
+        })
+        .flatten()
+}
+
+fn claude_block_is_keepable(block: &serde_json::Value, seen_tool_uses: &[String]) -> bool {
+    match block.get("type").and_then(|t| t.as_str()) {
+        Some("text") => block
+            .get("text")
+            .and_then(|t| t.as_str())
+            .is_some_and(claude_text_is_keepable),
+        Some("tool_use") | Some("image") | Some("thinking") => true,
+        Some("tool_result") => {
+            claude_block_tool_result_id(block).is_some_and(|id| seen_tool_uses.contains(&id))
+        }
+        _ => false,
+    }
+}
+
+fn filter_claude_injection_lines(lines: Vec<serde_json::Value>) -> Vec<serde_json::Value> {
+    let mut kept = Vec::new();
+    let mut seen_tool_uses = Vec::new();
+
+    for line in lines {
+        let msg_type = line.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        if msg_type != "user" && msg_type != "assistant" {
+            continue;
+        }
+
+        let content = line.get("message").and_then(|m| m.get("content"));
+        let keep = match content {
+            Some(serde_json::Value::String(s)) => claude_text_is_keepable(s),
+            Some(serde_json::Value::Array(arr)) => arr
+                .iter()
+                .any(|block| claude_block_is_keepable(block, &seen_tool_uses)),
+            _ => false,
+        };
+
+        if keep {
+            if let Some(arr) = content.and_then(|c| c.as_array()) {
+                for block in arr {
+                    if let Some(id) = claude_block_tool_use_id(block) {
+                        seen_tool_uses.push(id);
+                    }
+                }
+            }
+            kept.push(line);
+        }
+    }
+
+    kept
 }
 
 fn resume_args_for(target: &str, session_id: &str) -> Vec<String> {
@@ -412,34 +528,10 @@ fn inject_into_claude(
 ) -> Result<(InjectionResult, String), ConvertError> {
     let all_claude_lines = claude::from_hub(hub_records)?;
 
-    // Filter: only keep user/assistant messages with non-empty, non-system content
-    // Claude renders ALL JSONL lines as conversation turns — events show as blanks
-    let claude_lines: Vec<_> = all_claude_lines
-        .into_iter()
-        .filter(|line| {
-            let msg_type = line.get("type").and_then(|t| t.as_str()).unwrap_or("");
-            if msg_type != "user" && msg_type != "assistant" {
-                return false;
-            }
-            // Check content is non-empty and not system preamble
-            let content = line.get("message").and_then(|m| m.get("content"));
-            match content {
-                Some(serde_json::Value::String(s)) => {
-                    !s.is_empty()
-                        && !s.starts_with("<environment_context")
-                        && !s.starts_with("<permissions")
-                        && !s.starts_with("<user_shell_command")
-                }
-                Some(serde_json::Value::Array(arr)) => arr.iter().any(|block| {
-                    block
-                        .get("text")
-                        .and_then(|t| t.as_str())
-                        .is_some_and(|t| !t.is_empty() && !t.starts_with("[Reasoning]: \n"))
-                }),
-                _ => false,
-            }
-        })
-        .collect();
+    // Claude renders all JSONL records as conversation turns. Keep real
+    // user/assistant content, including tool/image-only turns, but avoid
+    // orphan tool_result blocks when an earlier trim dropped the tool_use.
+    let claude_lines = filter_claude_injection_lines(all_claude_lines);
 
     // Generate a fresh UUID for the Claude session
     let session_id = uuid_v4();
@@ -2275,6 +2367,52 @@ mod tests {
         })
     }
 
+    fn make_tool_use_message(id: &str, command: &str) -> HubRecord {
+        HubRecord::Message(crate::interchange::hub::HubMessage {
+            id: format!("assistant-{id}"),
+            api_message_id: None,
+            parent_id: None,
+            timestamp: "2026-01-01T00:00:00.000Z".to_string(),
+            completed_at: None,
+            role: "assistant".to_string(),
+            content: vec![ContentBlock::ToolUse {
+                id: id.to_string(),
+                name: "Bash".to_string(),
+                display_name: None,
+                description: None,
+                input: serde_json::json!({ "command": command }),
+            }],
+            metadata: Default::default(),
+            extensions: serde_json::Value::Null,
+        })
+    }
+
+    fn make_tool_result_message(id: &str, output: &str) -> HubRecord {
+        HubRecord::Message(crate::interchange::hub::HubMessage {
+            id: format!("user-{id}-result"),
+            api_message_id: None,
+            parent_id: None,
+            timestamp: "2026-01-01T00:00:01.000Z".to_string(),
+            completed_at: None,
+            role: "user".to_string(),
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: id.to_string(),
+                content: vec![ContentBlock::Text {
+                    text: output.to_string(),
+                }],
+                is_error: false,
+                exit_code: None,
+                interrupted: false,
+                status: None,
+                duration_ms: None,
+                title: None,
+                truncated: false,
+            }],
+            metadata: Default::default(),
+            extensions: serde_json::Value::Null,
+        })
+    }
+
     #[test]
     fn test_estimate_tokens_empty() {
         assert_eq!(estimate_tokens(&[]), 0);
@@ -2320,6 +2458,25 @@ mod tests {
     }
 
     #[test]
+    fn test_truncate_drops_linked_tool_result_with_tool_use() {
+        let records = vec![
+            make_session_header(),
+            make_tool_use_message("call_1", &"x".repeat(1200)),
+            make_tool_result_message("call_1", "ok"),
+            make_text_message("user", "keep"),
+        ];
+
+        let (trimmed, dropped) = truncate_hub_to_budget(records, 10);
+        assert_eq!(dropped, 2);
+        assert_eq!(trimmed.len(), 2);
+        assert!(matches!(trimmed[0], HubRecord::Session(_)));
+        assert!(matches!(
+            &trimmed[1],
+            HubRecord::Message(msg) if msg.content.iter().any(|b| matches!(b, ContentBlock::Text { text } if text == "keep"))
+        ));
+    }
+
+    #[test]
     fn test_truncate_always_keeps_header() {
         let records = vec![
             make_session_header(),
@@ -2346,6 +2503,47 @@ mod tests {
         assert_eq!(context_budget(), None);
 
         std::env::remove_var("UNLEASH_CROSSLOAD_MAX_TOKENS");
+    }
+
+    #[test]
+    fn test_claude_filter_keeps_tool_only_pair() {
+        let lines = vec![
+            serde_json::json!({
+                "type": "assistant",
+                "message": {"role": "assistant", "content": [{
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "Bash",
+                    "input": {"command": "echo hi"}
+                }]}
+            }),
+            serde_json::json!({
+                "type": "user",
+                "message": {"role": "user", "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": "hi"
+                }]}
+            }),
+        ];
+
+        let filtered = filter_claude_injection_lines(lines);
+        assert_eq!(filtered.len(), 2);
+    }
+
+    #[test]
+    fn test_claude_filter_drops_orphan_tool_result() {
+        let lines = vec![serde_json::json!({
+            "type": "user",
+            "message": {"role": "user", "content": [{
+                "type": "tool_result",
+                "tool_use_id": "missing",
+                "content": "orphan"
+            }]}
+        })];
+
+        let filtered = filter_claude_injection_lines(lines);
+        assert!(filtered.is_empty());
     }
 
     #[test]

--- a/src/interchange/opencode.rs
+++ b/src/interchange/opencode.rs
@@ -773,7 +773,7 @@ fn parts_to_content_blocks(parts: &[Value]) -> Result<Vec<ContentBlock>, Convert
                     .and_then(|s| s.get("metadata"))
                     .and_then(|m| m.get("exit"))
                     .and_then(|v| v.as_i64())
-                    .map(|v| v as i32);
+                    .and_then(|v| i32::try_from(v).ok());
                 let truncated = state
                     .and_then(|s| s.get("metadata"))
                     .and_then(|m| m.get("truncated"))
@@ -1558,6 +1558,51 @@ mod tests {
             tool_part["state"].get("output").and_then(|v| v.as_str()),
             Some("hello")
         );
+    }
+
+    #[test]
+    fn test_tool_exit_code_overflow_is_ignored() {
+        let messages = r#"[{
+            "role": "assistant",
+            "time": {"created": 1000000, "completed": 2000000},
+            "modelID": "model",
+            "providerID": "p",
+            "mode": "build",
+            "agent": "build",
+            "path": {"cwd": "/tmp", "root": "/"},
+            "cost": 0.0,
+            "tokens": {"input": 0, "output": 0, "reasoning": 0, "cache": {"read": 0, "write": 0}},
+            "finish": "tool-calls"
+        }]"#;
+        let parts = r#"[
+            {"type": "step-start", "text": ""},
+            {"type": "tool", "tool": "bash", "callID": "call_123", "state": {"status": "error", "input": {"command": "false"}, "output": "failed", "metadata": {"exit": 2147483648, "truncated": false}, "time": {"start": 1000, "end": 1500}}, "text": ""},
+            {"type": "step-finish", "reason": "tool-calls", "text": ""}
+        ]"#;
+
+        let input = make_input(messages, parts);
+        let hub = to_hub(&input).unwrap();
+        let msg = hub
+            .iter()
+            .filter_map(|r| match r {
+                HubRecord::Message(m) => Some(m),
+                _ => None,
+            })
+            .find(|m| {
+                m.content
+                    .iter()
+                    .any(|b| matches!(b, ContentBlock::ToolResult { .. }))
+            })
+            .unwrap();
+        let exit_code = msg
+            .content
+            .iter()
+            .find_map(|b| match b {
+                ContentBlock::ToolResult { exit_code, .. } => Some(exit_code),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(*exit_code, None);
     }
 
     #[test]

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -443,12 +443,16 @@ fn self_update_script(version: &str, platform: &str) -> String {
          echo \"Downloading prebuilt unleash...\"\n\
          gh release download {} --repo heiervang-technologies/unleash --pattern 'unleash-{}' --pattern 'splash-{}' --pattern 'checksums.txt' || exit 1\n\
          echo \"Verifying checksums...\"\n\
+         awk -v u=\"unleash-{}\" -v s=\"splash-{}\" '{{name=$2; sub(/^\\*/, \"\", name); if (name == u || name == s) print}}' checksums.txt > checksums.selected\n\
+         grep -Eq '[ *]unleash-{}$' checksums.selected || {{ echo \"Missing checksum for unleash-{}\" >&2; exit 1; }}\n\
+         if [ -f \"splash-{}\" ]; then grep -Eq '[ *]splash-{}$' checksums.selected || {{ echo \"Missing checksum for splash-{}\" >&2; exit 1; }}; fi\n\
          if command -v sha256sum >/dev/null; then\n\
-             sha256sum --ignore-missing -c checksums.txt || exit 1\n\
+             sha256sum -c checksums.selected || exit 1\n\
          elif command -v shasum >/dev/null; then\n\
-             shasum -a 256 --ignore-missing -c checksums.txt || exit 1\n\
+             shasum -a 256 -c checksums.selected || exit 1\n\
          else\n\
-             echo \"Warning: No checksum tool found, skipping verification\" >&2\n\
+             echo \"No checksum tool found; refusing to self-update without verification\" >&2\n\
+             exit 1\n\
          fi\n\
          echo \"Swapping binaries...\"\n\
          BIN_DIR=\"$HOME/.local/bin\"\n\
@@ -464,8 +468,26 @@ fn self_update_script(version: &str, platform: &str) -> String {
          fi\n\
          echo \"Updating plugins and docker files...\"\n\
          gh repo clone heiervang-technologies/unleash source -- -b {} || exit 1\n\
+         expected=$(git -C source rev-list -n 1 {}) || exit 1\n\
+         actual=$(git -C source rev-parse HEAD) || exit 1\n\
+         if [ \"$expected\" != \"$actual\" ]; then echo \"Cloned source does not match {}\" >&2; exit 1; fi\n\
          bash source/scripts/install.sh --no-build",
-        version, platform, platform, platform, platform, platform, version
+        version,
+        platform,
+        platform,
+        platform,
+        platform,
+        platform,
+        platform,
+        platform,
+        platform,
+        platform,
+        platform,
+        platform,
+        platform,
+        version,
+        version,
+        version
     )
 }
 
@@ -1767,6 +1789,47 @@ mod tests {
             !script.contains("2>/dev/null"),
             "self-update must not redirect stderr to /dev/null — \
              that's why prior failures were unactionable: {script}"
+        );
+    }
+
+    #[test]
+    fn self_update_script_fails_closed_without_checksum_tool() {
+        let script = self_update_script("v0.1.82", "linux");
+        assert!(
+            script.contains("No checksum tool found") && script.contains("exit 1"),
+            "self-update must refuse to continue without checksum verification: {script}"
+        );
+        assert!(
+            !script.contains("skipping verification"),
+            "self-update must not fail open when checksum tools are absent: {script}"
+        );
+    }
+
+    #[test]
+    fn self_update_script_verifies_selected_downloaded_assets() {
+        let script = self_update_script("v0.1.82", "linux");
+        assert!(
+            script.contains("checksums.selected"),
+            "self-update should verify a selected checksum subset: {script}"
+        );
+        assert!(
+            script.contains("Missing checksum for unleash-linux"),
+            "self-update must fail if the primary asset has no checksum: {script}"
+        );
+        assert!(
+            !script.contains("--ignore-missing"),
+            "self-update must not let checksum tools ignore downloaded assets: {script}"
+        );
+    }
+
+    #[test]
+    fn self_update_script_verifies_cloned_source_tag() {
+        let script = self_update_script("v0.1.82", "linux");
+        assert!(
+            script.contains("git -C source rev-list -n 1 v0.1.82")
+                && script.contains("git -C source rev-parse HEAD")
+                && script.contains("Cloned source does not match v0.1.82"),
+            "self-update must verify cloned source before running install.sh: {script}"
         );
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -136,7 +136,7 @@ pub fn save_embedded_versions(map: &HashMap<crate::agents::AgentType, Vec<Versio
 
     let path = get_versions_file_path();
     if let Ok(json_str) = serde_json::to_string_pretty(&serde_json::Value::Object(out_map)) {
-        let _ = std::fs::write(path, json_str);
+        let _ = crate::config::atomic_write(&path, &json_str);
     }
 }
 
@@ -2184,7 +2184,7 @@ impl VersionManager {
 ///
 /// - Strips known prefixes ("v", "rust-v") from both inputs.
 /// - Pre-release versions (with `-` suffix) are less than the same base version.
-/// - Splits on `.` and compares each segment as `u32`.
+/// - Splits on `.` and compares each numeric segment without integer overflow.
 /// - Zero-pads shorter versions so "1.2" == "1.2.0".
 pub(crate) fn version_compare(a: &str, b: &str) -> std::cmp::Ordering {
     fn strip_prefix(s: &str) -> &str {
@@ -2192,13 +2192,10 @@ pub(crate) fn version_compare(a: &str, b: &str) -> std::cmp::Ordering {
     }
 
     /// Split a version string into (base numeric parts, optional pre-release suffix).
-    fn parse_parts(s: &str) -> (Vec<u32>, Option<&str>) {
+    fn parse_parts(s: &str) -> (Vec<&str>, Option<&str>) {
         let pre = s.split_once('-').map(|(_, rest)| rest);
         let base = s.split('-').next().unwrap_or(s);
-        let parts = base
-            .split('.')
-            .map(|p| p.parse::<u32>().unwrap_or(0))
-            .collect();
+        let parts = base.split('.').collect();
         (parts, pre)
     }
 
@@ -2209,9 +2206,9 @@ pub(crate) fn version_compare(a: &str, b: &str) -> std::cmp::Ordering {
 
     // Compare base numeric parts
     for i in 0..a_parts.len().max(b_parts.len()) {
-        let pa = a_parts.get(i).copied().unwrap_or(0);
-        let pb = b_parts.get(i).copied().unwrap_or(0);
-        match pa.cmp(&pb) {
+        let pa = a_parts.get(i).copied().unwrap_or("0");
+        let pb = b_parts.get(i).copied().unwrap_or("0");
+        match compare_numeric_segment(pa, pb) {
             std::cmp::Ordering::Equal => continue,
             other => return other,
         }
@@ -2223,6 +2220,28 @@ pub(crate) fn version_compare(a: &str, b: &str) -> std::cmp::Ordering {
         (None, Some(_)) => std::cmp::Ordering::Greater,
         (Some(a_suffix), Some(b_suffix)) => compare_prerelease(a_suffix, b_suffix),
         (None, None) => std::cmp::Ordering::Equal,
+    }
+}
+
+fn compare_numeric_segment(a: &str, b: &str) -> std::cmp::Ordering {
+    fn normalize(s: &str) -> &str {
+        if s.chars().all(|c| c.is_ascii_digit()) {
+            let stripped = s.trim_start_matches('0');
+            if stripped.is_empty() {
+                "0"
+            } else {
+                stripped
+            }
+        } else {
+            "0"
+        }
+    }
+
+    let a = normalize(a);
+    let b = normalize(b);
+    match a.len().cmp(&b.len()) {
+        std::cmp::Ordering::Equal => a.cmp(b),
+        other => other,
     }
 }
 
@@ -2239,11 +2258,14 @@ fn compare_prerelease(a: &str, b: &str) -> std::cmp::Ordering {
             (None, Some(_)) => return std::cmp::Ordering::Less, // fewer fields = lower precedence
             (Some(_), None) => return std::cmp::Ordering::Greater,
             (Some(a_seg), Some(b_seg)) => {
-                let ord = match (a_seg.parse::<u64>(), b_seg.parse::<u64>()) {
-                    (Ok(an), Ok(bn)) => an.cmp(&bn),
-                    (Ok(_), Err(_)) => std::cmp::Ordering::Less, // numeric < alphanumeric
-                    (Err(_), Ok(_)) => std::cmp::Ordering::Greater,
-                    (Err(_), Err(_)) => a_seg.cmp(b_seg),
+                let ord = match (
+                    a_seg.chars().all(|c| c.is_ascii_digit()),
+                    b_seg.chars().all(|c| c.is_ascii_digit()),
+                ) {
+                    (true, true) => compare_numeric_segment(a_seg, b_seg),
+                    (true, false) => std::cmp::Ordering::Less, // numeric < alphanumeric
+                    (false, true) => std::cmp::Ordering::Greater,
+                    (false, false) => a_seg.cmp(b_seg),
                 };
                 if ord != std::cmp::Ordering::Equal {
                     return ord;
@@ -2743,6 +2765,17 @@ mod tests {
         // Large numbers
         assert_eq!(version_compare("0.116.0", "0.115.9"), Ordering::Greater);
         assert_eq!(version_compare("9.4.0", "9.3.0"), Ordering::Greater);
+        assert_eq!(
+            version_compare("999999999999999999999999999999.0.0", "1.0.0"),
+            Ordering::Greater
+        );
+        assert_eq!(
+            version_compare(
+                "1.0.0-preview.999999999999999999999999999999",
+                "1.0.0-preview.2"
+            ),
+            Ordering::Greater
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This tackles a focused batch of the remaining #353 checklist items:

- keep Claude crossload injection from dropping tool-only/image-only assistant turns, and drop orphan `tool_result` lines instead of producing invalid Claude history
- make context-budget trimming remove linked `tool_use` / `tool_result` counterparts together
- make version caches use the shared atomic writer
- harden self-update checksum verification so it fails closed and verifies only the downloaded assets without `--ignore-missing`
- verify the cloned self-update source resolves to the requested release tag before running `scripts/install.sh`
- avoid integer wrap when comparing huge version segments or importing Gemini/OpenCode tool exit codes

## Validation

- `cargo test --lib claude_filter -- --test-threads=1`
- `cargo test --lib test_truncate -- --test-threads=1`
- `cargo test --lib test_version_compare -- --test-threads=1`
- `cargo test --lib self_update_script -- --test-threads=1`
- `cargo test --lib exit_code_overflow -- --test-threads=1`
- `cargo fmt --check`
- `git diff --check`

Part of #353.