### PR TITLE
fix: detect Antigravity CLI versions from AUR

### DIFF
--- a/data/versions.json
+++ b/data/versions.json
@@ -67,6 +67,7 @@
     "0.35.0-preview.1"
   ],
   "antigravity": [
+    "1.1.0",
     "1.0.3"
   ],
   "opencode": [

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -776,31 +776,37 @@ impl AgentManager {
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Agent not found"))?;
 
         if agent_type == AgentType::Antigravity {
-            // Check Electron app.asar paths for system/packaged installations
+            // Prefer the CLI binary version. The desktop Antigravity app and
+            // the `agy` companion CLI use different version lines, and this
+            // manager is reporting the CLI.
+            let mut version = None;
+            if let Ok(bin_path) = which::which(&agent.binary) {
+                if let Ok(output) = Command::new(&bin_path).arg("--version").output() {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    version = Self::parse_version(&stdout)
+                        .or_else(|| Self::parse_version(&stderr))
+                        .or_else(|| stdout.lines().next().map(|s| s.trim().to_string()))
+                        .or_else(|| stderr.lines().next().map(|s| s.trim().to_string()));
+                }
+            }
+
+            // Fallback to Electron app.asar paths only when no `agy` binary is
+            // available. This can identify a desktop-only install, but should
+            // not override the actual CLI version.
             let paths = [
                 PathBuf::from("/opt/Antigravity/resources/app.asar"), // Arch Linux / pacman default
                 PathBuf::from("/Applications/Antigravity.app/Contents/Resources/app.asar"), // macOS default
             ];
-            let mut version = None;
-            for path in &paths {
-                if path.exists() {
-                    if let Ok(content) = fs::read(path) {
-                        if let Some(v) = Self::parse_asar_version(&content) {
-                            version = Some(v);
-                            break;
-                        }
-                    }
-                }
-            }
-
-            // Fallback for binaries installed outside the agent's canonical path
-            // (e.g. AUR-installed `agy`, custom `--prefix`, or distro packages).
             if version.is_none() {
-                if let Ok(bin_path) = which::which(&agent.binary) {
-                    if let Ok(output) = Command::new(&bin_path).arg("--version").output() {
-                        let stdout = String::from_utf8_lossy(&output.stdout);
-                        version = Self::parse_version(&stdout)
-                            .or_else(|| stdout.lines().next().map(|s| s.trim().to_string()));
+                for path in &paths {
+                    if path.exists() {
+                        if let Ok(content) = fs::read(path) {
+                            if let Some(v) = Self::parse_asar_version(&content) {
+                                version = Some(v);
+                                break;
+                            }
+                        }
                     }
                 }
             }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -634,6 +634,16 @@ fn get_latest_version(agent_type: AgentType) -> io::Result<Option<String>> {
         }
     }
 
+    // Antigravity has no npm or GitHub release feed. On Arch, the AUR
+    // package is the update source, but its package version includes a build
+    // suffix (e.g. 1.1.0_4523441756438528-1) while `agy --version` reports the
+    // CLI version (1.1.0). Normalize to the CLI version before comparing.
+    if agent_type == AgentType::Antigravity {
+        if let Some(version) = get_latest_antigravity_aur_version()? {
+            return Ok(Some(version));
+        }
+    }
+
     // Both live lookups failed (npm down, GitHub rate-limited, no network,
     // etc.) — fall back to the embedded version list compiled into the
     // binary. Without this, the check phase emits "not installed (up to
@@ -714,6 +724,52 @@ fn get_latest_github_version(repo: &str) -> io::Result<Option<String>> {
         }
     }
     fetch_github_release_tag(&url, None)
+}
+
+fn get_latest_antigravity_aur_version() -> io::Result<Option<String>> {
+    for helper in ["yay", "paru"] {
+        let Ok(output) = Command::new(helper)
+            .args(["-Si", "antigravity-cli"])
+            .output()
+        else {
+            continue;
+        };
+        if !output.status.success() {
+            continue;
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if let Some(version) = parse_antigravity_aur_version(&stdout) {
+            return Ok(Some(version));
+        }
+    }
+
+    Ok(None)
+}
+
+fn parse_antigravity_aur_version(output: &str) -> Option<String> {
+    let raw = output
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("Version"))?
+        .split_once(':')?
+        .1
+        .trim();
+    normalize_antigravity_package_version(raw)
+}
+
+fn normalize_antigravity_package_version(raw: &str) -> Option<String> {
+    let no_epoch = raw.rsplit_once(':').map(|(_, v)| v).unwrap_or(raw);
+    let no_pkgrel = no_epoch.split_once('-').map(|(v, _)| v).unwrap_or(no_epoch);
+    let no_build = no_pkgrel
+        .split_once('_')
+        .map(|(v, _)| v)
+        .unwrap_or(no_pkgrel);
+    let version = sanitize_version(no_build.trim());
+    if version.is_empty() {
+        None
+    } else {
+        Some(version)
+    }
 }
 
 /// Make a single GitHub releases-latest API call, optionally authenticated.
@@ -1690,6 +1746,30 @@ mod tests {
     fn parse_release_tag_returns_none_for_missing_tag_name() {
         let body = br#"{"name":"Release","id":12345}"#;
         assert_eq!(parse_release_tag(body), None);
+    }
+
+    #[test]
+    fn parse_antigravity_aur_version_normalizes_pkgver_to_cli_version() {
+        let output = "\
+Repository                    : aur\n\
+Name                          : antigravity-cli\n\
+Version                       : 1.1.0_4523441756438528-1\n";
+        assert_eq!(
+            parse_antigravity_aur_version(output),
+            Some("1.1.0".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_antigravity_package_version_strips_epoch_build_and_release() {
+        assert_eq!(
+            normalize_antigravity_package_version("2:1.2.3_999999-4"),
+            Some("1.2.3".to_string())
+        );
+        assert_eq!(
+            normalize_antigravity_package_version("v1.2.3-1"),
+            Some("1.2.3".to_string())
+        );
     }
 
     #[test]

--- a/src/version.rs
+++ b/src/version.rs
@@ -91,12 +91,11 @@ fn merge_disk_and_fallback(
         }
         // Migration: earlier builds shipped antigravity = ["2.0.1"] as the
         // embedded "latest", but that version was never published anywhere
-        // (npm 404, no GitHub release). Cached copies of that list still live
-        // in users' ~/.config/unleash/versions.json and cause `update agy` to
-        // report a perpetually-available phantom update. If the cache exactly
-        // matches the legacy stub, fall through to the in-binary fallback so
-        // the fix in data/versions.json takes effect.
-        if *key == "antigravity" && versions == ["2.0.1"] {
+        // (npm 404, no GitHub release). Some refreshed caches kept the bogus
+        // value alongside real entries, e.g. ["2.0.1", "1.0.3"], so any
+        // occurrence means the cache is contaminated. Fall through to the
+        // in-binary fallback so the fixed data/versions.json takes effect.
+        if *key == "antigravity" && versions.iter().any(|v| v == "2.0.1") {
             versions.clear();
         }
         if versions.is_empty() {
@@ -2661,9 +2660,25 @@ mod tests {
     #[test]
     fn merge_disk_strips_legacy_antigravity_2_0_1_stub() {
         let disk = serde_json::json!({ "antigravity": ["2.0.1"] });
-        let fallback = serde_json::json!({ "antigravity": ["1.0.3"] });
+        let fallback = serde_json::json!({ "antigravity": ["1.1.0", "1.0.3"] });
         let merged = merge_disk_and_fallback(&disk, &fallback);
-        assert_eq!(merged.get("antigravity"), Some(&vec!["1.0.3".to_string()]));
+        assert_eq!(
+            merged.get("antigravity"),
+            Some(&vec!["1.1.0".to_string(), "1.0.3".to_string()])
+        );
+    }
+
+    /// Refreshed caches also shipped the bogus value alongside a real
+    /// Antigravity version. Treat the whole cached list as contaminated.
+    #[test]
+    fn merge_disk_strips_legacy_antigravity_2_0_1_mixed_cache() {
+        let disk = serde_json::json!({ "antigravity": ["2.0.1", "1.0.3"] });
+        let fallback = serde_json::json!({ "antigravity": ["1.1.0", "1.0.3"] });
+        let merged = merge_disk_and_fallback(&disk, &fallback);
+        assert_eq!(
+            merged.get("antigravity"),
+            Some(&vec!["1.1.0".to_string(), "1.0.3".to_string()])
+        );
     }
 
     /// A real cached version list — e.g. once Google ships a 2.x agy — must


### PR DESCRIPTION
## Summary
- normalize Antigravity AUR package versions like `1.1.0_4523441756438528-1` to the CLI version reported by `agy --version`
- invalidate cached Antigravity version lists containing the old phantom `2.0.1` entry, including mixed caches like `["2.0.1", "1.0.3"]`
- prefer the `agy` binary version over the desktop app `app.asar` version in agent status
- bump the bundled Antigravity fallback list to `1.1.0`

## Root Cause
Antigravity has separate version surfaces: the AUR package version includes a build suffix, the CLI reports a normalized version, and the desktop Electron app can report a different `app.asar` version. We also only migrated the exact legacy `antigravity = ["2.0.1"]` cache, so refreshed caches containing `2.0.1` plus real entries kept advertising a phantom update.

## Validation
- `cargo fmt --check`
- `cargo test --lib antigravity -- --nocapture`
- `cargo test --lib`
- `cargo run --quiet --bin unleash -- update --check antigravity` -> `1.1.0 (up to date)`
- `cargo run --quiet --bin unleash -- update antigravity` -> `All agents are up to date.`
- `cargo run --quiet --bin unleash -- agents status` -> `Antigravity CLI: v1.1.0`