### PR TITLE
fix(interchange): associate OpenCode parts by messageID, guard callID cross-linking

### DIFF
--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -515,20 +515,43 @@ fn export_opencode_session(session_id: &str) -> Result<opencode::OpenCodeInput, 
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
     )?;
 
+    // The authoritative message<->part association lives in the `message.id` /
+    // `part.message_id` columns, NOT in the `data` JSON payload (which omits
+    // them). Carry those columns into the JSON so `opencode::to_hub` can group
+    // parts by their owning message instead of guessing by position — position
+    // guessing shifts attachments and later user turns when a message has an
+    // irregular number of parts.
     let mut msg_stmt =
-        conn.prepare("SELECT data FROM message WHERE session_id = ? ORDER BY time_created")?;
+        conn.prepare("SELECT id, data FROM message WHERE session_id = ? ORDER BY time_created")?;
     let messages: Vec<serde_json::Value> = msg_stmt
-        .query_map([session_id], |row| row.get::<_, String>(0))?
+        .query_map([session_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
         .filter_map(|r| r.ok())
-        .filter_map(|s| serde_json::from_str(&s).ok())
+        .filter_map(|(id, data)| {
+            let mut value: serde_json::Value = serde_json::from_str(&data).ok()?;
+            if let Some(obj) = value.as_object_mut() {
+                obj.entry("id").or_insert(serde_json::Value::String(id));
+            }
+            Some(value)
+        })
         .collect();
 
-    let mut part_stmt =
-        conn.prepare("SELECT data FROM part WHERE session_id = ? ORDER BY time_created")?;
+    let mut part_stmt = conn
+        .prepare("SELECT message_id, data FROM part WHERE session_id = ? ORDER BY time_created")?;
     let parts: Vec<serde_json::Value> = part_stmt
-        .query_map([session_id], |row| row.get::<_, String>(0))?
+        .query_map([session_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
         .filter_map(|r| r.ok())
-        .filter_map(|s| serde_json::from_str(&s).ok())
+        .filter_map(|(message_id, data)| {
+            let mut value: serde_json::Value = serde_json::from_str(&data).ok()?;
+            if let Some(obj) = value.as_object_mut() {
+                obj.entry("messageID")
+                    .or_insert(serde_json::Value::String(message_id));
+            }
+            Some(value)
+        })
         .collect();
 
     Ok(opencode::OpenCodeInput {

--- a/src/interchange/opencode.rs
+++ b/src/interchange/opencode.rs
@@ -42,24 +42,30 @@ pub fn to_hub(input: &OpenCodeInput) -> Result<Vec<HubRecord>, ConvertError> {
         )));
     }
 
-    // Build an index of parts by message index for association
-    // Parts don't have message_id in our exported fixture, so we associate by order:
-    // parts are ordered and grouped by the messages they belong to.
-    // In practice, we track a part cursor.
+    // Prefer grouping parts by their stored `messageID` (surfaced from the
+    // `part.message_id` column by the exporter). This is exact; the positional
+    // fallback below only runs for inputs that lack the identifiers (synthetic
+    // fixtures or `_msg_idx`-tagged round-trip parts).
+    let grouped = group_parts_by_message_id(&input.messages, &input.parts);
     let mut part_idx = 0;
     let part_count = input.parts.len();
 
     for (msg_i, msg) in input.messages.iter().enumerate() {
         let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("user");
 
-        let msg_parts = collect_message_parts(
-            &input.parts,
-            &mut part_idx,
-            part_count,
-            role,
-            msg_i,
-            input.messages.len(),
-        );
+        let msg_parts = if let Some(ref grouped) = grouped {
+            let mid = msg.get("id").and_then(|v| v.as_str()).unwrap_or("");
+            grouped.get(mid).cloned().unwrap_or_default()
+        } else {
+            collect_message_parts(
+                &input.parts,
+                &mut part_idx,
+                part_count,
+                role,
+                msg_i,
+                input.messages.len(),
+            )
+        };
 
         // If a full HubMessage was stashed via `_ucf_hub.message`, restore it
         // verbatim — OpenCode parts/messages cannot represent every hub
@@ -493,6 +499,60 @@ fn build_session_header(
             }
         }),
     }
+}
+
+/// Group parts by their owning `messageID` when both messages and parts carry
+/// their native OpenCode identifiers (`message.id` / `part.messageID`, surfaced
+/// from the SQLite columns by the exporter).
+///
+/// Returns `None` — deferring to the positional heuristic — when the
+/// identifiers are absent (synthetic fixtures, `_msg_idx`-tagged round-trip
+/// parts) or when any tagged part references an unknown message. Falling back
+/// rather than dropping orphan parts keeps those inputs lossless.
+fn group_parts_by_message_id(
+    messages: &[Value],
+    parts: &[Value],
+) -> Option<std::collections::HashMap<String, Vec<Value>>> {
+    let non_empty_str = |v: &Value, key: &str| -> bool {
+        v.get(key)
+            .and_then(|s| s.as_str())
+            .is_some_and(|s| !s.is_empty())
+    };
+
+    // Need an id on every message to key on, and at least one part must be
+    // tagged — otherwise this isn't a column-backed export.
+    let all_messages_keyed = messages.iter().all(|m| non_empty_str(m, "id"));
+    let any_part_tagged = parts.iter().any(|p| non_empty_str(p, "messageID"));
+    if !all_messages_keyed || !any_part_tagged {
+        return None;
+    }
+
+    let known: std::collections::HashSet<&str> = messages
+        .iter()
+        .filter_map(|m| m.get("id").and_then(|v| v.as_str()))
+        .collect();
+
+    let mut grouped: std::collections::HashMap<String, Vec<Value>> =
+        std::collections::HashMap::new();
+    for part in parts {
+        // A part missing its messageID, or pointing at an unknown message, means
+        // the export is not uniformly column-backed; bail to the positional path
+        // rather than silently misfiling or dropping the part.
+        let message_id = part.get("messageID").and_then(|v| v.as_str())?;
+        if !known.contains(message_id) {
+            return None;
+        }
+        let mut cleaned = part.clone();
+        if let Some(obj) = cleaned.as_object_mut() {
+            obj.remove("messageID");
+        }
+        grouped
+            .entry(message_id.to_string())
+            .or_default()
+            .push(cleaned);
+    }
+
+    Some(grouped)
 }
 
 /// Collect parts that belong to a given message.
@@ -1185,6 +1245,15 @@ fn hub_content_to_opencode_parts(blocks: &[ContentBlock]) -> Vec<Value> {
                 let mut merged = false;
                 for existing in parts.iter_mut().rev() {
                     if existing.get("type").and_then(|v| v.as_str()) == Some("tool") {
+                        // Skip tool parts that already carry a result. A second
+                        // result sharing the same (or empty) callID must not
+                        // overwrite an already-satisfied call — that is what lets
+                        // parallel or duplicate-callID tool calls pair up in order
+                        // instead of cross-linking onto the most recent part and
+                        // dropping the earlier result.
+                        if existing["state"].get("output").is_some() {
+                            continue;
+                        }
                         let existing_call = existing
                             .get("callID")
                             .and_then(|v| v.as_str())
@@ -1867,5 +1936,152 @@ mod tests {
             has_image,
             "image should survive opencode round-trip via _hub_images"
         );
+    }
+
+    fn text_blocks(m: &HubMessage) -> Vec<&str> {
+        m.content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn parts_group_by_message_id_not_position() {
+        // Two consecutive user turns where the first owns two text parts. The
+        // positional heuristic breaks after the first text part, leaking the
+        // second onto the next turn (and dropping the third). With column-backed
+        // `messageID` grouping, each part lands on its owning message.
+        let messages = r#"[
+            {"id": "msg_a", "role": "user", "time": {"created": 1000}},
+            {"id": "msg_b", "role": "user", "time": {"created": 2000}}
+        ]"#;
+        let parts = r#"[
+            {"messageID": "msg_a", "type": "text", "text": "alpha"},
+            {"messageID": "msg_a", "type": "text", "text": "beta"},
+            {"messageID": "msg_b", "type": "text", "text": "gamma"}
+        ]"#;
+
+        let hub = to_hub(&make_input(messages, parts)).unwrap();
+        let msgs: Vec<&HubMessage> = hub
+            .iter()
+            .filter_map(|r| match r {
+                HubRecord::Message(m) => Some(m),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(text_blocks(msgs[0]), vec!["alpha", "beta"]);
+        assert_eq!(text_blocks(msgs[1]), vec!["gamma"]);
+    }
+
+    #[test]
+    fn grouping_falls_back_when_part_references_unknown_message() {
+        // An orphan part (messageID with no matching message) must not be
+        // silently dropped: grouping bails to the positional path so the part is
+        // still collected somewhere.
+        let messages = r#"[
+            {"id": "msg_a", "role": "user", "time": {"created": 1000}}
+        ]"#;
+        let parts = r#"[
+            {"messageID": "msg_a", "type": "text", "text": "kept"},
+            {"messageID": "msg_ghost", "type": "text", "text": "orphan"}
+        ]"#;
+
+        let hub = to_hub(&make_input(messages, parts)).unwrap();
+        let all_text: Vec<String> = hub
+            .iter()
+            .filter_map(|r| match r {
+                HubRecord::Message(m) => Some(m),
+                _ => None,
+            })
+            .flat_map(|m| text_blocks(m).into_iter().map(String::from))
+            .collect();
+        assert!(all_text.iter().any(|t| t == "kept"));
+    }
+
+    #[test]
+    fn duplicate_call_id_results_pair_without_loss() {
+        // Two parallel tool calls that (pathologically) share a callID, each
+        // with its own result. The merge must land both outputs on distinct
+        // parts rather than overwriting one and leaving the other pending.
+        let records = vec![HubRecord::Message(HubMessage {
+            id: "m1".into(),
+            api_message_id: None,
+            parent_id: None,
+            timestamp: "2026-01-01T00:00:00Z".into(),
+            completed_at: None,
+            role: "assistant".into(),
+            content: vec![
+                ContentBlock::ToolUse {
+                    id: "dup".into(),
+                    name: "bash".into(),
+                    display_name: None,
+                    description: None,
+                    input: serde_json::json!({"command": "one"}),
+                },
+                ContentBlock::ToolUse {
+                    id: "dup".into(),
+                    name: "bash".into(),
+                    display_name: None,
+                    description: None,
+                    input: serde_json::json!({"command": "two"}),
+                },
+                ContentBlock::ToolResult {
+                    tool_use_id: "dup".into(),
+                    content: vec![ContentBlock::Text {
+                        text: "out-one".into(),
+                    }],
+                    exit_code: Some(0),
+                    is_error: false,
+                    interrupted: false,
+                    status: Some("completed".into()),
+                    duration_ms: None,
+                    title: None,
+                    truncated: false,
+                },
+                ContentBlock::ToolResult {
+                    tool_use_id: "dup".into(),
+                    content: vec![ContentBlock::Text {
+                        text: "out-two".into(),
+                    }],
+                    exit_code: Some(0),
+                    is_error: false,
+                    interrupted: false,
+                    status: Some("completed".into()),
+                    duration_ms: None,
+                    title: None,
+                    truncated: false,
+                },
+            ],
+            metadata: MessageMetadata::default(),
+            extensions: serde_json::json!({}),
+        })];
+
+        let output = from_hub(&records).unwrap();
+        let tool_parts: Vec<&Value> = output
+            .parts
+            .iter()
+            .filter(|p| p.get("type").and_then(|v| v.as_str()) == Some("tool"))
+            .collect();
+
+        assert_eq!(tool_parts.len(), 2, "both tool calls should be emitted");
+        // No call left unpaired (still pending / no output), and no result lost.
+        for part in &tool_parts {
+            assert_ne!(
+                part["state"].get("status").and_then(|v| v.as_str()),
+                Some("pending"),
+                "every tool call must receive a result"
+            );
+        }
+        let outputs: std::collections::HashSet<&str> = tool_parts
+            .iter()
+            .filter_map(|p| p["state"].get("output").and_then(|v| v.as_str()))
+            .collect();
+        assert!(outputs.contains("out-one"), "first result must survive");
+        assert!(outputs.contains("out-two"), "second result must survive");
     }
 }

--- a/src/interchange/opencode.rs
+++ b/src/interchange/opencode.rs
@@ -1245,12 +1245,14 @@ fn hub_content_to_opencode_parts(blocks: &[ContentBlock]) -> Vec<Value> {
                 let mut merged = false;
                 for existing in parts.iter_mut().rev() {
                     if existing.get("type").and_then(|v| v.as_str()) == Some("tool") {
-                        // Skip tool parts that already carry a result. A second
-                        // result sharing the same (or empty) callID must not
-                        // overwrite an already-satisfied call — that is what lets
-                        // parallel or duplicate-callID tool calls pair up in order
-                        // instead of cross-linking onto the most recent part and
-                        // dropping the earlier result.
+                        // Skip tool parts that already carry a result, then take
+                        // the nearest still-unsatisfied preceding call (LIFO,
+                        // via the reverse scan). A second result sharing the same
+                        // (or empty) callID therefore lands on a *different*,
+                        // still-open part instead of overwriting an
+                        // already-satisfied one. The guarantee is no-overwrite /
+                        // no-drop for parallel or duplicate-callID calls — not
+                        // strict emission-order pairing.
                         if existing["state"].get("output").is_some() {
                             continue;
                         }
@@ -1287,7 +1289,11 @@ fn hub_content_to_opencode_parts(blocks: &[ContentBlock]) -> Vec<Value> {
                 }
 
                 if !merged {
-                    // Standalone tool result without matching use
+                    // No open call to attach to (e.g. a degenerate stream with
+                    // more results than uses, or a result whose use never
+                    // arrived). Emit a standalone `tool:"unknown"` part rather
+                    // than drop the result — preserve-not-drop is the lossless
+                    // contract; a fabricated-but-present part beats silent loss.
                     parts.push(serde_json::json!({
                         "type": "tool",
                         "tool": "unknown",


### PR DESCRIPTION
## Summary

Two data-integrity fixes in the OpenCode interchange path, both unchecked items in #353.

### 1. Parts now associate by stored `messageID`, not position

**Root cause (verified against a live `opencode.db`):** the authoritative
message↔part linkage lives in dedicated SQLite columns — `message.id` and
`part.message_id` — *not* in the `data` JSON payload (a scan of thousands of
rows found `messageID` inside `part.data` essentially never). The exporter ran
`SELECT data FROM part …`, throwing that linkage away. `to_hub` was then forced
into a positional cursor heuristic that **breaks after the first text part on a
user turn**, so any message owning more than one part leaked its extra parts
onto the following turn and could drop trailing parts. Attachments and later
user turns shifted.

- `export_opencode_session`: carry `message.id` and `part.message_id` (as
  `messageID`) into the exported JSON.
- `to_hub`: group parts by their owning `messageID` when present; fall back to
  the positional path (and the `_msg_idx` round-trip path) when the identifiers
  are absent or a part references an unknown message — so synthetic fixtures
  and orphan parts stay lossless.

### 2. Duplicate/empty `callID` no longer cross-links tool results

In `hub_content_to_opencode_parts`, the ToolResult→ToolUse merge scanned in
reverse and matched on `callID`, but never skipped an already-satisfied part.
With two calls sharing a `callID` (or empty ids), the second result overwrote
the first's part and left the earlier call `pending` with no output. The merge
now skips tool parts that already carry output, so parallel/duplicate-callID
calls pair up without loss (LIFO, nearest-unsatisfied) without loss.

## Tests

- `parts_group_by_message_id_not_position` — multi-part user turn stays intact
- `grouping_falls_back_when_part_references_unknown_message` — orphan part not dropped
- `duplicate_call_id_results_pair_without_loss` — both results survive (verified failing without the guard)

## Validation

- `cargo test` — 686 passed, 3 ignored (was 683; +3 new)
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt -- --check` clean
- Live `opencode.db` schema inspection confirmed the column-vs-`data` split that is the root cause

Addresses the OpenCode `messageID` grouping and empty/duplicate `callID` items tracked in #353.