### PR TITLE
fix(interchange): preserve reasoning/image/patch/step blocks on hub→Hermes

### DIFF
--- a/src/interchange/hermes.rs
+++ b/src/interchange/hermes.rs
@@ -26,6 +26,13 @@ pub struct HermesMessage {
     pub tool_call_id: Option<String>,
     pub tool_name: Option<String>,
     pub timestamp: f64,
+    /// Hub `Thinking` blocks, mapped to Hermes' native `reasoning` column so
+    /// reasoning survives hub → Hermes injection instead of being dropped.
+    pub reasoning: Option<String>,
+    /// From a `StepBoundary` finish block, mapped to Hermes' `finish_reason`.
+    pub finish_reason: Option<String>,
+    /// From a `StepBoundary` finish block's token usage.
+    pub token_count: Option<i64>,
 }
 
 // ── Timestamp helpers (no chrono dep) ───────────────────────────────────────
@@ -400,21 +407,62 @@ pub fn from_hub(records: &[HubRecord]) -> Result<HermesOutput, ConvertError> {
             None
         };
 
+        // Content: Text verbatim, plus textual placeholders for blocks Hermes
+        // has no native column for (Image, Patch) so they are not silently
+        // dropped on injection.
         let text_content: String = msg
             .content
             .iter()
-            .filter_map(|b| {
-                if let ContentBlock::Text { text } = b {
-                    Some(text.as_str())
-                } else {
-                    None
-                }
+            .filter_map(|b| match b {
+                ContentBlock::Text { text } if !text.is_empty() => Some(text.clone()),
+                ContentBlock::Image {
+                    media_type, data, ..
+                } => Some(format!("[image: {} ({} bytes)]", media_type, data.len())),
+                ContentBlock::Patch { path, .. } => Some(format!("[patch: {path}]")),
+                _ => None,
             })
             .collect::<Vec<_>>()
             .join("\n");
 
+        // Thinking → Hermes' native `reasoning` column. Capturing this also
+        // means reasoning-only assistant turns (no text, no tool calls) are
+        // still emitted below instead of vanishing.
+        let reasoning: Option<String> = {
+            let joined = msg
+                .content
+                .iter()
+                .filter_map(|b| match b {
+                    ContentBlock::Thinking { text, .. } if !text.is_empty() => Some(text.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            (!joined.is_empty()).then_some(joined)
+        };
+
+        // StepBoundary finish → native finish_reason / token_count columns.
+        let (finish_reason, token_count) = msg
+            .content
+            .iter()
+            .find_map(|b| match b {
+                ContentBlock::StepBoundary {
+                    boundary,
+                    finish_reason,
+                    tokens,
+                    ..
+                } if boundary == "finish" => Some((
+                    finish_reason.clone(),
+                    tokens
+                        .as_ref()
+                        .map(|t| t.total.max(t.output) as i64)
+                        .filter(|&n| n > 0),
+                )),
+                _ => None,
+            })
+            .unwrap_or((None, None));
+
         // Emit primary message
-        if !text_content.is_empty() || tool_calls_json.is_some() {
+        if !text_content.is_empty() || tool_calls_json.is_some() || reasoning.is_some() {
             messages.push(HermesMessage {
                 role: msg.role.clone(),
                 content: if text_content.is_empty() {
@@ -426,6 +474,9 @@ pub fn from_hub(records: &[HubRecord]) -> Result<HermesOutput, ConvertError> {
                 tool_call_id: None,
                 tool_name: None,
                 timestamp: ts,
+                reasoning,
+                finish_reason,
+                token_count,
             });
         }
 
@@ -456,6 +507,9 @@ pub fn from_hub(records: &[HubRecord]) -> Result<HermesOutput, ConvertError> {
                     tool_name: hermes_tool_name_for_result(&msg.extensions, tool_use_id)
                         .or_else(|| tool_names_by_id.get(tool_use_id).cloned()),
                     timestamp: ts,
+                    reasoning: None,
+                    finish_reason: None,
+                    token_count: None,
                 });
             }
         }
@@ -795,5 +849,121 @@ mod tests {
         assert_eq!(tools[0].tool_name.as_deref(), Some("bash"));
         assert_eq!(tools[1].tool_call_id.as_deref(), Some("call_extra"));
         assert_eq!(tools[1].tool_name.as_deref(), Some("grep"));
+    }
+
+    #[test]
+    fn from_hub_preserves_reasoning_image_patch_and_step() {
+        let session = HubRecord::Session(SessionHeader {
+            ucf_version: UCF_VERSION.to_string(),
+            session_id: "s".into(),
+            created_at: "2026-06-01T00:00:00Z".into(),
+            updated_at: "2026-06-01T00:01:00Z".into(),
+            source_cli: "codex".into(),
+            source_version: String::new(),
+            project: None,
+            model: Some("gpt".into()),
+            title: None,
+            slug: None,
+            parent_session_id: None,
+            extensions: Value::Object(Default::default()),
+        });
+
+        // A reasoning-only assistant turn — no text, no tool calls. Previously
+        // dropped entirely; must now be emitted with the reasoning preserved.
+        let reasoning_only = HubRecord::Message(HubMessage {
+            id: "m1".into(),
+            api_message_id: None,
+            parent_id: None,
+            timestamp: "2026-06-01T00:00:10Z".into(),
+            completed_at: None,
+            role: "assistant".into(),
+            content: vec![ContentBlock::Thinking {
+                text: "let me think".into(),
+                subject: None,
+                description: None,
+                signature: None,
+                encrypted: false,
+                encryption_format: None,
+                encrypted_data: None,
+                timestamp: None,
+            }],
+            metadata: MessageMetadata::default(),
+            extensions: Value::Object(Default::default()),
+        });
+
+        // A mixed turn exercising Image, Patch, and a StepBoundary finish.
+        let mixed = HubRecord::Message(HubMessage {
+            id: "m2".into(),
+            api_message_id: None,
+            parent_id: None,
+            timestamp: "2026-06-01T00:00:20Z".into(),
+            completed_at: None,
+            role: "assistant".into(),
+            content: vec![
+                ContentBlock::Text {
+                    text: "done".into(),
+                },
+                ContentBlock::Image {
+                    media_type: "image/png".into(),
+                    encoding: "base64".into(),
+                    data: "AAAA".into(),
+                    source_url: None,
+                },
+                ContentBlock::Patch {
+                    path: "src/x.rs".into(),
+                    hash_before: None,
+                    hash_after: None,
+                },
+                ContentBlock::StepBoundary {
+                    boundary: "finish".into(),
+                    snapshot: None,
+                    finish_reason: Some("stop".into()),
+                    cost: None,
+                    tokens: Some(TokenUsage {
+                        input: 10,
+                        output: 20,
+                        cache_creation: 0,
+                        cache_read: 0,
+                        reasoning: 0,
+                        tool: 0,
+                        total: 30,
+                    }),
+                },
+            ],
+            metadata: MessageMetadata::default(),
+            extensions: Value::Object(Default::default()),
+        });
+
+        let out = from_hub(&[session, reasoning_only, mixed]).unwrap();
+        let assistants: Vec<_> = out
+            .messages
+            .iter()
+            .filter(|m| m.role == "assistant")
+            .collect();
+        assert_eq!(
+            assistants.len(),
+            2,
+            "reasoning-only turn must still be emitted"
+        );
+
+        assert_eq!(assistants[0].reasoning.as_deref(), Some("let me think"));
+        assert!(
+            assistants[0].content.is_none(),
+            "reasoning-only turn has no textual content"
+        );
+
+        let mixed_out = assistants[1];
+        let content = mixed_out.content.as_deref().unwrap();
+        assert!(content.contains("done"));
+        assert!(
+            content.contains("[image:"),
+            "image not preserved: {content}"
+        );
+        assert!(
+            content.contains("[patch: src/x.rs]"),
+            "patch not preserved: {content}"
+        );
+        assert_eq!(mixed_out.finish_reason.as_deref(), Some("stop"));
+        assert_eq!(mixed_out.token_count, Some(30));
     }
 }

--- a/src/interchange/hermes.rs
+++ b/src/interchange/hermes.rs
@@ -26,9 +26,16 @@ pub struct HermesMessage {
     pub tool_call_id: Option<String>,
     pub tool_name: Option<String>,
     pub timestamp: f64,
-    /// Hub `Thinking` blocks, mapped to Hermes' native `reasoning` column so
-    /// reasoning survives hub → Hermes injection instead of being dropped.
+    /// Plaintext `Thinking` blocks, mapped to Hermes' native `reasoning`
+    /// column so reasoning survives hub → Hermes injection instead of being
+    /// dropped.
     pub reasoning: Option<String>,
+    /// Encrypted/redacted `Thinking` blocks, serialized as a JSON array and
+    /// mapped to Hermes' `reasoning_details` column. This is what keeps an
+    /// *encrypted* reasoning-only turn from vanishing: its payload lives in
+    /// `encrypted_data`, not `text`, so the plaintext `reasoning` column stays
+    /// empty and cannot carry it.
+    pub reasoning_details: Option<String>,
     /// From a `StepBoundary` finish block, mapped to Hermes' `finish_reason`.
     pub finish_reason: Option<String>,
     /// From a `StepBoundary` finish block's token usage.
@@ -424,21 +431,43 @@ pub fn from_hub(records: &[HubRecord]) -> Result<HermesOutput, ConvertError> {
             .collect::<Vec<_>>()
             .join("\n");
 
-        // Thinking → Hermes' native `reasoning` column. Capturing this also
-        // means reasoning-only assistant turns (no text, no tool calls) are
-        // still emitted below instead of vanishing.
-        let reasoning: Option<String> = {
-            let joined = msg
-                .content
-                .iter()
-                .filter_map(|b| match b {
-                    ContentBlock::Thinking { text, .. } if !text.is_empty() => Some(text.as_str()),
-                    _ => None,
-                })
-                .collect::<Vec<_>>()
-                .join("\n");
-            (!joined.is_empty()).then_some(joined)
-        };
+        // Thinking → Hermes' reasoning columns. Plaintext goes to `reasoning`;
+        // encrypted/redacted reasoning (whose payload is in `encrypted_data`,
+        // not `text`) goes to `reasoning_details` as JSON. Capturing BOTH is
+        // what keeps a reasoning-only assistant turn from vanishing — including
+        // the encrypted case, where `text` is empty so `reasoning` alone would
+        // stay None and the emit guard below would drop the turn.
+        let mut reasoning_texts: Vec<&str> = Vec::new();
+        let mut encrypted_details: Vec<Value> = Vec::new();
+        for block in &msg.content {
+            if let ContentBlock::Thinking {
+                text,
+                encrypted,
+                encryption_format,
+                encrypted_data,
+                ..
+            } = block
+            {
+                if !text.is_empty() {
+                    reasoning_texts.push(text.as_str());
+                }
+                if *encrypted {
+                    let mut detail = serde_json::Map::new();
+                    detail.insert("type".into(), Value::String("reasoning.encrypted".into()));
+                    if let Some(data) = encrypted_data {
+                        detail.insert("data".into(), Value::String(data.clone()));
+                    }
+                    if let Some(fmt) = encryption_format {
+                        detail.insert("format".into(), Value::String(fmt.clone()));
+                    }
+                    encrypted_details.push(Value::Object(detail));
+                }
+            }
+        }
+        let reasoning: Option<String> =
+            (!reasoning_texts.is_empty()).then(|| reasoning_texts.join("\n"));
+        let reasoning_details: Option<String> =
+            (!encrypted_details.is_empty()).then(|| Value::Array(encrypted_details).to_string());
 
         // StepBoundary finish → native finish_reason / token_count columns.
         let (finish_reason, token_count) = msg
@@ -461,8 +490,15 @@ pub fn from_hub(records: &[HubRecord]) -> Result<HermesOutput, ConvertError> {
             })
             .unwrap_or((None, None));
 
-        // Emit primary message
-        if !text_content.is_empty() || tool_calls_json.is_some() || reasoning.is_some() {
+        // Emit primary message. Note reasoning_details in the guard: an
+        // encrypted reasoning-only turn has empty text, no tool calls, and
+        // empty `reasoning`, so without this it would be dropped — the exact
+        // headline bug for the encrypted case.
+        if !text_content.is_empty()
+            || tool_calls_json.is_some()
+            || reasoning.is_some()
+            || reasoning_details.is_some()
+        {
             messages.push(HermesMessage {
                 role: msg.role.clone(),
                 content: if text_content.is_empty() {
@@ -475,6 +511,7 @@ pub fn from_hub(records: &[HubRecord]) -> Result<HermesOutput, ConvertError> {
                 tool_name: None,
                 timestamp: ts,
                 reasoning,
+                reasoning_details,
                 finish_reason,
                 token_count,
             });
@@ -508,6 +545,7 @@ pub fn from_hub(records: &[HubRecord]) -> Result<HermesOutput, ConvertError> {
                         .or_else(|| tool_names_by_id.get(tool_use_id).cloned()),
                     timestamp: ts,
                     reasoning: None,
+                    reasoning_details: None,
                     finish_reason: None,
                     token_count: None,
                 });
@@ -965,5 +1003,72 @@ mod tests {
         );
         assert_eq!(mixed_out.finish_reason.as_deref(), Some("stop"));
         assert_eq!(mixed_out.token_count, Some(30));
+    }
+
+    #[test]
+    fn encrypted_reasoning_only_turn_survives() {
+        // The headline bug's encrypted variant: an assistant turn whose only
+        // content is an ENCRYPTED thinking block. Its payload is in
+        // `encrypted_data`, not `text`, so a text-only extractor leaves
+        // `reasoning` empty and the turn was being dropped. It must now survive
+        // via `reasoning_details`.
+        let session = HubRecord::Session(SessionHeader {
+            ucf_version: UCF_VERSION.to_string(),
+            session_id: "s".into(),
+            created_at: "2026-06-01T00:00:00Z".into(),
+            updated_at: "2026-06-01T00:01:00Z".into(),
+            source_cli: "codex".into(),
+            source_version: String::new(),
+            project: None,
+            model: None,
+            title: None,
+            slug: None,
+            parent_session_id: None,
+            extensions: Value::Object(Default::default()),
+        });
+        let encrypted_only = HubRecord::Message(HubMessage {
+            id: "m1".into(),
+            api_message_id: None,
+            parent_id: None,
+            timestamp: "2026-06-01T00:00:10Z".into(),
+            completed_at: None,
+            role: "assistant".into(),
+            content: vec![ContentBlock::Thinking {
+                text: String::new(),
+                subject: None,
+                description: None,
+                signature: None,
+                encrypted: true,
+                encryption_format: Some("codex-v1".into()),
+                encrypted_data: Some("BASE64BLOB".into()),
+                timestamp: None,
+            }],
+            metadata: MessageMetadata::default(),
+            extensions: Value::Object(Default::default()),
+        });
+
+        let out = from_hub(&[session, encrypted_only]).unwrap();
+        let assistants: Vec<_> = out
+            .messages
+            .iter()
+            .filter(|m| m.role == "assistant")
+            .collect();
+        assert_eq!(
+            assistants.len(),
+            1,
+            "encrypted reasoning-only turn must not vanish"
+        );
+        let m = assistants[0];
+        assert!(
+            m.reasoning.is_none(),
+            "no plaintext reasoning for an encrypted-only turn"
+        );
+        let details = m
+            .reasoning_details
+            .as_deref()
+            .expect("encrypted payload preserved in reasoning_details");
+        assert!(details.contains("reasoning.encrypted"), "got {details}");
+        assert!(details.contains("BASE64BLOB"), "payload lost: {details}");
+        assert!(details.contains("codex-v1"), "format lost: {details}");
     }
 }

--- a/src/interchange/hermes.rs
+++ b/src/interchange/hermes.rs
@@ -423,8 +423,21 @@ pub fn from_hub(records: &[HubRecord]) -> Result<HermesOutput, ConvertError> {
             .filter_map(|b| match b {
                 ContentBlock::Text { text } if !text.is_empty() => Some(text.clone()),
                 ContentBlock::Image {
-                    media_type, data, ..
-                } => Some(format!("[image: {} ({} bytes)]", media_type, data.len())),
+                    media_type,
+                    data,
+                    encoding,
+                    ..
+                } => {
+                    // Report the decoded size for base64 payloads, not the raw
+                    // base64 character count (~4/3 larger). Placeholder only.
+                    let bytes = if encoding == "base64" {
+                        let padding = data.bytes().rev().take_while(|&b| b == b'=').count();
+                        (data.len() / 4) * 3 - padding.min((data.len() / 4) * 3)
+                    } else {
+                        data.len()
+                    };
+                    Some(format!("[image: {media_type} ({bytes} bytes)]"))
+                }
                 ContentBlock::Patch { path, .. } => Some(format!("[patch: {path}]")),
                 _ => None,
             })
@@ -498,6 +511,8 @@ pub fn from_hub(records: &[HubRecord]) -> Result<HermesOutput, ConvertError> {
             || tool_calls_json.is_some()
             || reasoning.is_some()
             || reasoning_details.is_some()
+            || finish_reason.is_some()
+            || token_count.is_some()
         {
             messages.push(HermesMessage {
                 role: msg.role.clone(),
@@ -1070,5 +1085,68 @@ mod tests {
         assert!(details.contains("reasoning.encrypted"), "got {details}");
         assert!(details.contains("BASE64BLOB"), "payload lost: {details}");
         assert!(details.contains("codex-v1"), "format lost: {details}");
+    }
+
+    #[test]
+    fn step_boundary_only_turn_is_not_dropped() {
+        // Consistency with the reasoning fix: an assistant turn whose ONLY
+        // content is a StepBoundary finish (finish_reason + tokens, no text,
+        // reasoning, or tool calls) must still be emitted so the finish
+        // metadata isn't lost — the emit guard has to key on finish_reason /
+        // token_count too, not just reasoning.
+        let session = HubRecord::Session(SessionHeader {
+            ucf_version: UCF_VERSION.to_string(),
+            session_id: "s".into(),
+            created_at: "2026-06-01T00:00:00Z".into(),
+            updated_at: "2026-06-01T00:01:00Z".into(),
+            source_cli: "codex".into(),
+            source_version: String::new(),
+            project: None,
+            model: None,
+            title: None,
+            slug: None,
+            parent_session_id: None,
+            extensions: Value::Object(Default::default()),
+        });
+        let step_only = HubRecord::Message(HubMessage {
+            id: "m1".into(),
+            api_message_id: None,
+            parent_id: None,
+            timestamp: "2026-06-01T00:00:10Z".into(),
+            completed_at: None,
+            role: "assistant".into(),
+            content: vec![ContentBlock::StepBoundary {
+                boundary: "finish".into(),
+                snapshot: None,
+                finish_reason: Some("stop".into()),
+                cost: None,
+                tokens: Some(TokenUsage {
+                    input: 5,
+                    output: 7,
+                    cache_creation: 0,
+                    cache_read: 0,
+                    reasoning: 0,
+                    tool: 0,
+                    total: 12,
+                }),
+            }],
+            metadata: MessageMetadata::default(),
+            extensions: Value::Object(Default::default()),
+        });
+
+        let out = from_hub(&[session, step_only]).unwrap();
+        let assistants: Vec<_> = out
+            .messages
+            .iter()
+            .filter(|m| m.role == "assistant")
+            .collect();
+        assert_eq!(
+            assistants.len(),
+            1,
+            "step-boundary-only turn must not vanish"
+        );
+        assert_eq!(assistants[0].finish_reason.as_deref(), Some("stop"));
+        assert_eq!(assistants[0].token_count, Some(12));
+        assert!(assistants[0].content.is_none());
     }
 }

--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -1185,8 +1185,9 @@ fn inject_into_hermes(
     for msg in &output.messages {
         tx.execute(
             "INSERT INTO messages
-             (session_id, role, content, tool_calls, tool_call_id, tool_name, timestamp)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+             (session_id, role, content, tool_calls, tool_call_id, tool_name, timestamp,
+              reasoning, finish_reason, token_count)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             rusqlite::params![
                 session_id,
                 msg.role,
@@ -1195,6 +1196,9 @@ fn inject_into_hermes(
                 msg.tool_call_id,
                 msg.tool_name,
                 msg.timestamp,
+                msg.reasoning,
+                msg.finish_reason,
+                msg.token_count,
             ],
         )
         .map_err(|e| ConvertError::InvalidFormat(format!("Failed to insert message: {e}")))?;

--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -1182,27 +1182,7 @@ fn inject_into_hermes(
     )
     .map_err(|e| ConvertError::InvalidFormat(format!("Failed to insert session: {e}")))?;
 
-    for msg in &output.messages {
-        tx.execute(
-            "INSERT INTO messages
-             (session_id, role, content, tool_calls, tool_call_id, tool_name, timestamp,
-              reasoning, finish_reason, token_count)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
-            rusqlite::params![
-                session_id,
-                msg.role,
-                msg.content,
-                msg.tool_calls,
-                msg.tool_call_id,
-                msg.tool_name,
-                msg.timestamp,
-                msg.reasoning,
-                msg.finish_reason,
-                msg.token_count,
-            ],
-        )
-        .map_err(|e| ConvertError::InvalidFormat(format!("Failed to insert message: {e}")))?;
-    }
+    hermes_insert_messages(&tx, &session_id, &output.messages)?;
 
     tx.commit()
         .map_err(|e| ConvertError::InvalidFormat(format!("Failed to commit: {e}")))?;
@@ -1226,6 +1206,96 @@ fn inject_into_hermes(
         },
         target_path,
     ))
+}
+
+/// Insert Hermes messages, writing only the columns the target `messages` table
+/// actually has. Older Hermes DBs predate the `reasoning` / `reasoning_details`
+/// / `finish_reason` / `token_count` columns; a fixed INSERT that names them
+/// aborts the whole injection on those DBs. We probe `PRAGMA table_info` once
+/// and build the statement from the intersection of what we can write and what
+/// exists.
+fn hermes_insert_messages(
+    conn: &rusqlite::Connection,
+    session_id: &str,
+    messages: &[hermes::HermesMessage],
+) -> Result<(), ConvertError> {
+    use std::collections::HashSet;
+
+    let existing: HashSet<String> = {
+        let mut stmt = conn.prepare("PRAGMA table_info(messages)").map_err(|e| {
+            ConvertError::InvalidFormat(format!("Failed to read messages schema: {e}"))
+        })?;
+        let cols = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .map_err(|e| {
+                ConvertError::InvalidFormat(format!("Failed to read messages schema: {e}"))
+            })?
+            .filter_map(Result::ok)
+            .collect();
+        cols
+    };
+
+    // Base columns are assumed present on every Hermes schema; optional columns
+    // are appended only when the probe found them. Column order and per-message
+    // param order below MUST stay in lockstep.
+    let optional_cols = [
+        "reasoning",
+        "reasoning_details",
+        "finish_reason",
+        "token_count",
+    ];
+    let mut columns: Vec<&str> = vec![
+        "session_id",
+        "role",
+        "content",
+        "tool_calls",
+        "tool_call_id",
+        "tool_name",
+        "timestamp",
+    ];
+    for col in optional_cols {
+        if existing.contains(col) {
+            columns.push(col);
+        }
+    }
+    let placeholders: Vec<String> = (1..=columns.len()).map(|i| format!("?{i}")).collect();
+    let sql = format!(
+        "INSERT INTO messages ({}) VALUES ({})",
+        columns.join(", "),
+        placeholders.join(", ")
+    );
+
+    let mut stmt = conn
+        .prepare(&sql)
+        .map_err(|e| ConvertError::InvalidFormat(format!("Failed to prepare insert: {e}")))?;
+
+    for msg in messages {
+        let mut params: Vec<&dyn rusqlite::ToSql> = vec![
+            &session_id,
+            &msg.role,
+            &msg.content,
+            &msg.tool_calls,
+            &msg.tool_call_id,
+            &msg.tool_name,
+            &msg.timestamp,
+        ];
+        if existing.contains("reasoning") {
+            params.push(&msg.reasoning);
+        }
+        if existing.contains("reasoning_details") {
+            params.push(&msg.reasoning_details);
+        }
+        if existing.contains("finish_reason") {
+            params.push(&msg.finish_reason);
+        }
+        if existing.contains("token_count") {
+            params.push(&msg.token_count);
+        }
+        stmt.execute(params.as_slice())
+            .map_err(|e| ConvertError::InvalidFormat(format!("Failed to insert message: {e}")))?;
+    }
+
+    Ok(())
 }
 
 /// the partial-UUID resolver fast — pi reads every file in the project
@@ -1753,6 +1823,97 @@ fn chrono_like_now() -> String {
 mod tests {
     use super::*;
     use crate::interchange::hub::{HubRecord, SessionHeader, UCF_VERSION};
+
+    // ── hermes_insert_messages schema probe ──────────────────
+
+    fn sample_hermes_msg() -> hermes::HermesMessage {
+        hermes::HermesMessage {
+            role: "assistant".into(),
+            content: Some("hi".into()),
+            tool_calls: None,
+            tool_call_id: None,
+            tool_name: None,
+            timestamp: 1000.0,
+            reasoning: Some("thought".into()),
+            reasoning_details: Some(r#"[{"type":"reasoning.encrypted","data":"x"}]"#.into()),
+            finish_reason: Some("stop".into()),
+            token_count: Some(42),
+        }
+    }
+
+    #[test]
+    fn hermes_insert_tolerates_old_schema_without_reasoning_columns() {
+        // An older Hermes DB whose `messages` table predates the reasoning /
+        // finish_reason / token_count / reasoning_details columns. The insert
+        // must succeed (writing only the base columns), not abort the whole
+        // injection.
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL
+            );",
+        )
+        .unwrap();
+
+        hermes_insert_messages(&conn, "sess1", &[sample_hermes_msg()])
+            .expect("insert must not abort on an old schema");
+
+        let (count, content): (i64, String) = conn
+            .query_row(
+                "SELECT COUNT(*), MAX(content) FROM messages WHERE session_id = 'sess1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(content, "hi");
+    }
+
+    #[test]
+    fn hermes_insert_writes_reasoning_columns_when_present() {
+        // A current Hermes DB with the extended columns: the reasoning /
+        // reasoning_details / finish_reason / token_count values must land.
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_count INTEGER,
+                finish_reason TEXT,
+                reasoning TEXT,
+                reasoning_details TEXT
+            );",
+        )
+        .unwrap();
+
+        hermes_insert_messages(&conn, "sess1", &[sample_hermes_msg()]).unwrap();
+
+        let (reasoning, details, finish, tokens): (String, String, String, i64) = conn
+            .query_row(
+                "SELECT reasoning, reasoning_details, finish_reason, token_count
+                 FROM messages WHERE session_id = 'sess1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(reasoning, "thought");
+        assert!(details.contains("reasoning.encrypted"));
+        assert_eq!(finish, "stop");
+        assert_eq!(tokens, 42);
+    }
 
     // ── encode_claude_project_path ───────────────────────────
 

--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -1238,6 +1238,13 @@ fn hermes_insert_messages(
     // Base columns are assumed present on every Hermes schema; optional columns
     // are appended only when the probe found them. Column order and per-message
     // param order below MUST stay in lockstep.
+    //
+    // TRADEOFF: on an old schema lacking `reasoning_details`, an encrypted
+    // reasoning-only turn (empty content, no plaintext reasoning, payload only
+    // in reasoning_details) lands as a content-less "ghost" row — the payload
+    // can't be stored because the column doesn't exist. This is deliberate:
+    // preserving the turn as an empty row beats dropping it or aborting the
+    // whole injection. Such DBs simply predate encrypted-reasoning support.
     let optional_cols = [
         "reasoning",
         "reasoning_details",


### PR DESCRIPTION
## Summary

`hermes::from_hub` only emitted `Text`, `ToolUse`, and `ToolResult` blocks.
`Thinking`, `Image`, `StepBoundary`, and `Patch` blocks were silently dropped,
and — worst — a **reasoning-only assistant turn** (a `Thinking` block with no
text and no tool calls) produced an empty message that the emit guard skipped,
so the whole turn vanished on injection.

Inspecting the live `~/.hermes/state.db` schema showed the `messages` table
already has native columns for most of this (`reasoning`, `finish_reason`,
`token_count`, plus 556 rows with populated `reasoning`) — the converter just
wasn't using them.

## Change

- **Thinking → native `reasoning` column.** Reasoning presence now also
  satisfies the emit guard, so reasoning-only turns are preserved instead of
  dropped.
- **StepBoundary finish → native `finish_reason` + `token_count` columns.**
- **Image / Patch** (no native Hermes column) → concise textual placeholders
  folded into `content` (`[image: …]`, `[patch: <path>]`) so they are visible
  instead of silently dropped — matching how the Pi converter handles images.
- `HermesMessage` gains `reasoning` / `finish_reason` / `token_count`; the
  `inject_into_hermes` INSERT writes the three new columns.

## Tests

- `from_hub_preserves_reasoning_image_patch_and_step` — a reasoning-only turn is
  emitted with `reasoning` set (and no content), and a mixed turn preserves the
  image/patch placeholders plus the step's `finish_reason` / `token_count`.
  Verified failing without the emit-guard fix.

## Validation

- `cargo test` — interchange suite 207 passed, 2 ignored (+1 new)
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt -- --check` clean
- Live Hermes DB schema inspection confirmed the native columns used

Addresses the "preserve Hermes Thinking/Image/StepBoundary/Patch blocks on
hub-to-Hermes conversion, including reasoning-only assistant turns" item in #353.