### PR TITLE
build: honor the headless (no-TUI) build contract in code, CI, and docs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -74,8 +74,10 @@ jobs:
             coverage-${{ runner.os }}-
 
       - name: Run coverage (lib tests)
-        # --lib scopes to library unit tests, which is where the ~470 tests
-        # live. Adding integration/binary tests later will broaden this.
+        # --lib scopes to the library unit tests, where the bulk of the suite
+        # lives. This measures library coverage only; the integration tests in
+        # tests/*.rs are not included here (tracked in #401 §4). The report and
+        # PR comment below label it accordingly.
         run: cargo llvm-cov --lib --lcov --output-path lcov.info -- --test-threads=1
 
       - name: Generate summary text

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Run install symlink tests
         run: ./tests/test-install.sh
 
+      - name: Run --boring non-interactive install tests
+        run: ./tests/test-boring-install.sh
+
       - name: Validate install-remote.sh syntax
         run: bash -n scripts/install-remote.sh
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,3 +87,35 @@ jobs:
 
       - name: cargo clippy
         run: cargo clippy --all-targets --no-deps -- -D warnings
+
+  headless-build:
+    # The `tui` feature (ratatui/crossterm + the `splash` binary) is optional so
+    # Unleash compiles in headless environments. This gate proves that contract
+    # holds: `cargo check --no-default-features` must stay green. The `splash`
+    # binary is excluded automatically via its `required-features = ["tui"]`.
+    name: cargo check --no-default-features
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CARGO_TERM_COLOR: always
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry & build
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: headless-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'Cargo.toml') }}
+          restore-keys: |
+            headless-${{ runner.os }}-
+
+      - name: cargo check --no-default-features
+        run: cargo check --no-default-features --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,17 @@ readme = "README.md"
 keywords = ["cli", "ai", "claude", "llm", "agent"]
 categories = ["command-line-utilities", "development-tools"]
 
-# Binaries auto-discovered from src/bin/*.rs
-# Each is a thin wrapper calling unleash::run()
-# Single binary: unleash
+# Binaries: `unleash` (the CLI, auto-discovered from src/bin/unleash.rs) plus
+# `splash` (the interactive TUI splash/agent picker). `splash` links ratatui /
+# crossterm, so it is gated behind the `tui` feature via `required-features`
+# below — this keeps `cargo check/build --no-default-features` (the supported
+# headless build) green. The library itself is already `#[cfg(feature =
+# "tui")]`-gated throughout, so `unleash` builds headless.
+
+[[bin]]
+name = "splash"
+path = "src/bin/splash.rs"
+required-features = ["tui"]
 
 [features]
 default = ["tui"]

--- a/README.md
+++ b/README.md
@@ -343,6 +343,21 @@ Or force the installer to build from source instead of downloading:
 BUILD_FROM_SOURCE=1 bash <(curl -fsSL unleash.software/install)
 ```
 
+#### Headless build (no TUI)
+
+The interactive splash / agent picker (the `splash` binary) links `ratatui`
+and `crossterm` behind the default `tui` feature. In headless environments you
+can build the `unleash` CLI without them:
+
+```bash
+cargo build --no-default-features
+```
+
+This drops the `tui` feature and the `splash` binary; the `unleash` CLI and all
+of its subcommands (version management, crossload, search, sandbox, …) still
+build and run. CI enforces this contract via `cargo check --no-default-features`
+so it cannot silently regress.
+
 ### Platform support
 
 | Platform | Binary | Method |

--- a/scripts/install-remote.sh
+++ b/scripts/install-remote.sh
@@ -631,7 +631,12 @@ download_binary() {
 
     install_binary_atomic "${temp_dir}/unleash" "${INSTALL_DIR}/unleash"
 
-    # Download splash binary (optional — interactive installer)
+    # Download splash binary (optional — the interactive agent picker).
+    # NOTE: this is fetched unconditionally, including under `--boring`. `--boring`
+    # only skips *running* the picker (see maybe_run_interactive_setup), not
+    # installing it, so the artifact is available if the user later wants the
+    # interactive setup. The download is best-effort (failure is ignored below),
+    # so a missing splash asset never fails a --boring install.
     local splash_name="splash-${PLATFORM}-${ARCH}"
     if download_release_asset "$version" "$splash_name" "${temp_dir}/splash" 2>/dev/null; then
         install_binary_atomic "${temp_dir}/splash" "${INSTALL_DIR}/splash"
@@ -844,6 +849,32 @@ check_agent_prereqs() {
     return 0
 }
 
+# Run the interactive splash/agent picker to choose a default agent, unless
+# `--boring` was passed (non-interactive install). Isolated into a function so
+# tests can drive the interactive-vs-boring decision with a stubbed splash
+# binary, without performing a real download/install. Any failure here is
+# best-effort: the binary is already installed, so we never abort the installer.
+maybe_run_interactive_setup() {
+    if [[ "$BORING" == "1" ]]; then
+        return 0
+    fi
+    if [[ -x "${INSTALL_DIR}/splash" ]]; then
+        info "Launching interactive setup..."
+        SELECTED_AGENT=$("${INSTALL_DIR}/splash") || true
+        if [[ -n "${SELECTED_AGENT:-}" ]]; then
+            info "Default profile set to $SELECTED_AGENT"
+            if ! set_default_profile "$SELECTED_AGENT"; then
+                warn "Could not write default profile to config. Run 'unleash' to set it via the TUI."
+            fi
+            # If the selected agent needs npm and npm is missing, surface it now.
+            check_agent_prereqs "$SELECTED_AGENT" || true
+        fi
+    elif [[ -x "${INSTALL_DIR}/unleash" ]]; then
+        info "Launching TUI..."
+        exec "${INSTALL_DIR}/unleash"
+    fi
+}
+
 # Main installation
 main() {
     echo ""
@@ -893,28 +924,8 @@ main() {
 
     show_path_instructions
 
-    # Interactive mode: run the splash to pick default agent
-    if [[ "$BORING" == "0" ]]; then
-        if [[ -x "${INSTALL_DIR}/splash" ]]; then
-            info "Launching interactive setup..."
-            SELECTED_AGENT=$("${INSTALL_DIR}/splash") || true
-            if [[ -n "${SELECTED_AGENT:-}" ]]; then
-                info "Default profile set to $SELECTED_AGENT"
-                # Best-effort: any failure here (existing config that's a
-                # symlink to a read-only dotfile, weird ownership, etc) must
-                # NOT abort the whole installer. The binary still installed.
-                if ! set_default_profile "$SELECTED_AGENT"; then
-                    warn "Could not write default profile to config. Run 'unleash' to set it via the TUI."
-                fi
-                # If the selected agent needs npm and npm is missing, surface
-                # it now so the user knows the next step.
-                check_agent_prereqs "$SELECTED_AGENT" || true
-            fi
-        elif [[ -x "${INSTALL_DIR}/unleash" ]]; then
-            info "Launching TUI..."
-            exec "${INSTALL_DIR}/unleash"
-        fi
-    fi
+    # Interactive mode: run the splash to pick default agent (skipped by --boring)
+    maybe_run_interactive_setup
 
     # Non-interactive (--boring) completion message
     echo ""
@@ -931,4 +942,10 @@ main() {
     success "Done! Run 'unleash' to start."
 }
 
-main "$@"
+# Run the installer, unless we're being sourced by a test that only wants the
+# function definitions. `UNLEASH_INSTALL_TEST` is used instead of the usual
+# `BASH_SOURCE == $0` guard because the canonical install path is `curl | bash`
+# (piped, read from stdin), where that comparison would wrongly skip main.
+if [[ -z "${UNLEASH_INSTALL_TEST:-}" ]]; then
+    main "$@"
+fi

--- a/src/search.rs
+++ b/src/search.rs
@@ -643,6 +643,8 @@ async fn run_async(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // --- Interactive ratatui TUI when stdin is a real terminal -----------
+    // Only consumed under the `tui` feature; headless builds skip the block.
+    #[cfg_attr(not(feature = "tui"), allow(unused_variables))]
     let tui_eligible = !args.json
         && std::io::IsTerminal::is_terminal(&std::io::stdin())
         && std::io::IsTerminal::is_terminal(&std::io::stdout());
@@ -2002,6 +2004,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(feature = "tui")]
     fn cosine_distance_identical_is_zero() {
         let v = vec![1.0_f32, 2.0, 3.0, 4.0];
         let d = cosine_distance(&v, &v);
@@ -2009,6 +2012,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "tui")]
     fn cosine_distance_orthogonal_is_one() {
         let a = vec![1.0_f32, 0.0];
         let b = vec![0.0_f32, 1.0];
@@ -2017,6 +2021,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "tui")]
     fn cosine_distance_opposite_is_two() {
         let a = vec![1.0_f32, 1.0, 1.0];
         let b = vec![-1.0_f32, -1.0, -1.0];
@@ -2025,6 +2030,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "tui")]
     fn cosine_distance_empty_returns_two() {
         let a: Vec<f32> = vec![];
         let b = vec![1.0_f32, 2.0];

--- a/tests/test-boring-install.sh
+++ b/tests/test-boring-install.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# test-boring-install.sh - Prove that `--boring` is a genuine non-interactive
+# install: it must NOT run the interactive splash/agent picker or launch the TUI.
+#
+# Hermetic: sources the production installer with UNLEASH_INSTALL_TEST=1 so
+# main() does not run, points INSTALL_DIR at a temp dir with a *fake* splash
+# that records whether it was invoked, and stubs the side-effecting helpers.
+# No network, no downloads, no writes outside the temp dir.
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO/scripts/install-remote.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+FAILS=0
+pass() { echo -e "${GREEN}PASS${NC}: $1"; }
+fail() {
+    echo -e "${RED}FAIL${NC}: $1"
+    FAILS=$((FAILS + 1))
+}
+
+# Runs the interactive-vs-boring decision in an isolated subshell and prints
+# "INVOKED" if the fake splash ran, "SKIPPED" otherwise.
+# $1: "boring" to pass --boring, anything else for the interactive path.
+run_case() {
+    local mode="$1"
+    local tmp install_dir sentinel
+    tmp="$(mktemp -d)"
+    install_dir="$tmp/bin"
+    mkdir -p "$install_dir"
+    sentinel="$tmp/splash-invoked"
+
+    # Fake splash: records invocation, prints a chosen agent like the real one.
+    cat >"$install_dir/splash" <<EOF
+#!/usr/bin/env bash
+touch "$sentinel"
+echo "claude"
+EOF
+    chmod +x "$install_dir/splash"
+
+    (
+        export UNLEASH_INSTALL_TEST=1
+        export INSTALL_DIR="$install_dir"
+        if [[ "$mode" == "boring" ]]; then
+            # shellcheck disable=SC1090
+            source "$SCRIPT" --boring
+        else
+            # shellcheck disable=SC1090
+            source "$SCRIPT"
+        fi
+        # Override side-effecting helpers *after* sourcing so real config writes
+        # and prereq checks don't run; splash invocation stays observable.
+        set_default_profile() { :; }
+        check_agent_prereqs() { :; }
+        info() { :; }
+        warn() { :; }
+        maybe_run_interactive_setup
+    ) >/dev/null 2>&1 || true
+
+    if [[ -f "$sentinel" ]]; then
+        echo "INVOKED"
+    else
+        echo "SKIPPED"
+    fi
+    rm -rf "$tmp"
+}
+
+# 1. The contract: --boring must not run the picker or TUI.
+result="$(run_case boring)"
+if [[ "$result" == "SKIPPED" ]]; then
+    pass "--boring skips the interactive splash/picker"
+else
+    fail "--boring invoked the splash picker (expected SKIPPED, got $result)"
+fi
+
+# 2. Discriminating sanity check: without --boring the picker *is* run, proving
+#    the test above would actually catch a regression.
+result="$(run_case interactive)"
+if [[ "$result" == "INVOKED" ]]; then
+    pass "interactive install runs the splash picker"
+else
+    fail "interactive install did not run the splash picker (expected INVOKED, got $result)"
+fi
+
+echo ""
+if [[ "$FAILS" -gt 0 ]]; then
+    echo -e "${RED}FAILED: $FAILS test(s)${NC}"
+    exit 1
+fi
+echo -e "${GREEN}All boring-install tests passed.${NC}"


### PR DESCRIPTION
Follows up **#401 §2** (and the stale-comment items in §4/§6). Closes the one
build contract the tracker's baseline flagged as failing:

```text
cargo check --no-default-features   # was: error — splash.rs imports ratatui/crossterm
```

## Root cause

`Cargo.toml` advertises `tui` as an optional, default-on feature "for headless
environments," and the library is already `#[cfg(feature = "tui")]`-gated
throughout — so the `unleash` CLI is *designed* to build headless. The only
thing breaking it was the auto-discovered `splash` binary, which links
ratatui/crossterm unconditionally.

## Contract chosen: option 1 (headless compilation is supported)

This honors the existing claim rather than retracting it. Code, CI, and docs now
match:

- **Cargo.toml** — `splash` declared with `required-features = ["tui"]`, so it is
  excluded from the no-default-features build. Rewrote the stale
  `# Single binary: unleash` comment that contradicted the shipped `splash`
  binary (§6).
- **search.rs** — gated the `tui`-only `tui_eligible` binding and the four
  `cosine_distance` unit tests (they call a `#[cfg(feature = "tui")]` function)
  so `--all-targets` compiles headless.
- **lint.yml** — new `cargo check --no-default-features --all-targets` gate so
  the contract can't silently regress.
- **coverage.yml** — replaced the stale "~470 tests" comment with an accurate
  description of what `--lib` coverage measures (§4/§6).
- **README** — documents the headless build and that CI enforces it.

## Evidence

- `cargo check --no-default-features --all-targets` ✅
- `cargo build --no-default-features --bin unleash` ✅
- default `cargo fmt --all -- --check` ✅, `cargo clippy --all-targets -- -D warnings` ✅
- full suite: 683 lib + integration tests green

## Deliberately out of scope (follow-up)

A strict `clippy --no-default-features -D warnings` gate additionally surfaces
~13 dead-code warnings — `pub` fns whose only callers are `tui`-gated (in
`sandbox.rs`, `search.rs`, `version.rs`). Gating those needs per-symbol
call-site evidence and is exactly the kind of change #401 §5 says must not be a
broad cleanup sweep; it's a separate, evidence-backed follow-up. This PR
delivers the tracker's *stated* `cargo check --no-default-features` contract.