### PR TITLE
feat(stream): normalize live harness output into UCF stream events

### DIFF
--- a/src/interchange/claude.rs
+++ b/src/interchange/claude.rs
@@ -359,7 +359,7 @@ fn extract_content_blocks(val: &Value, msg_type: &str) -> Result<Vec<ContentBloc
     }
 }
 
-fn claude_content_to_hub(block: &Value) -> Result<ContentBlock, ConvertError> {
+pub(crate) fn claude_content_to_hub(block: &Value) -> Result<ContentBlock, ConvertError> {
     let block_type = block.get("type").and_then(|t| t.as_str()).unwrap_or("");
     match block_type {
         "text" => Ok(ContentBlock::Text {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ mod progress;
 mod sandbox;
 pub mod search;
 pub mod skillsync;
+pub mod stream;
 #[cfg(feature = "tui")]
 mod text_input;
 pub mod theme;

--- a/src/stream/claude.rs
+++ b/src/stream/claude.rs
@@ -220,7 +220,15 @@ fn claude_stream_content_to_hub(content: &Value) -> Vec<crate::interchange::hub:
         Value::String(s) => vec![ContentBlock::Text { text: s.clone() }],
         Value::Array(blocks) => blocks
             .iter()
-            .filter_map(|b| crate::interchange::claude::claude_content_to_hub(b).ok())
+            .map(|b| {
+                // A block the converter rejects must not silently vanish from
+                // `content`; the raw frame survives in `_original_frame`.
+                crate::interchange::claude::claude_content_to_hub(b).unwrap_or_else(|_| {
+                    ContentBlock::Text {
+                        text: format!("[Unparseable content block: {b}]"),
+                    }
+                })
+            })
             .collect(),
         _ => Vec::new(),
     }

--- a/src/stream/claude.rs
+++ b/src/stream/claude.rs
@@ -1,0 +1,346 @@
+//! Claude Code `--output-format stream-json` adapter.
+//!
+//! Frame reference (headless `claude -p`):
+//! - `{"type":"system","subtype":"init",...}` — session identity
+//! - `{"type":"assistant","message":{...}}` — completed assistant message
+//! - `{"type":"user","message":{...}}` — tool results echoed back
+//! - `{"type":"stream_event","event":{...}}` — raw API deltas when
+//!   `--include-partial-messages` is set
+//! - `{"type":"result",...}` — terminal summary frame
+
+use super::{parse_line, DeltaKind, ParsedLine, StreamEvent, UcfStreamParser};
+use crate::interchange::hub::{
+    HubEvent, HubMessage, MessageMetadata, SessionHeader, TokenUsage, UCF_VERSION,
+};
+use serde_json::Value;
+
+pub struct ClaudeStreamParser {
+    session_id: String,
+    timestamp: String,
+    seq: u64,
+}
+
+impl ClaudeStreamParser {
+    pub fn new() -> Self {
+        Self {
+            session_id: String::new(),
+            timestamp: String::new(),
+            seq: 0,
+        }
+    }
+
+    /// Fixed timestamp applied to emitted messages/events. Live callers pass
+    /// wall-clock time per line; tests pass a constant for determinism. When
+    /// unset, timestamps are empty and the consumer is expected to stamp.
+    pub fn with_timestamp(mut self, timestamp: impl Into<String>) -> Self {
+        self.timestamp = timestamp.into();
+        self
+    }
+
+    fn next_id(&mut self) -> String {
+        self.seq += 1;
+        format!("claude-stream-{}", self.seq)
+    }
+
+    /// Claude attaches `session_id` to most frames; grab it wherever it
+    /// appears (latest wins) so the run always has an id by the end.
+    fn capture_session_id(&mut self, frame: &Value) {
+        if let Some(id) = frame.get("session_id").and_then(Value::as_str) {
+            if !id.is_empty() {
+                self.session_id = id.to_string();
+            }
+        }
+    }
+
+    fn message_frame_to_event(&mut self, frame: &Value, role: &str) -> StreamEvent {
+        let message = frame.get("message").cloned().unwrap_or(Value::Null);
+        let content = message
+            .get("content")
+            .map(claude_stream_content_to_hub)
+            .unwrap_or_default();
+
+        let mut metadata = MessageMetadata::default();
+        if let Some(model) = message.get("model").and_then(Value::as_str) {
+            metadata.model = Some(model.to_string());
+        }
+        if let Some(stop) = message.get("stop_reason").and_then(Value::as_str) {
+            metadata.stop_reason = Some(stop.to_string());
+        }
+        metadata.tokens = message.get("usage").and_then(usage_to_tokens);
+
+        StreamEvent::Message(HubMessage {
+            id: self.next_id(),
+            api_message_id: message.get("id").and_then(Value::as_str).map(String::from),
+            parent_id: None,
+            timestamp: self.timestamp.clone(),
+            completed_at: None,
+            role: role.to_string(),
+            content,
+            metadata,
+            extensions: serde_json::json!({"claude-code": {"_original_frame": frame}}),
+        })
+    }
+
+    fn stream_event_frame(&self, frame: &Value) -> Vec<StreamEvent> {
+        let event = frame.get("event").unwrap_or(&Value::Null);
+        let event_type = event.get("type").and_then(Value::as_str).unwrap_or("");
+        match event_type {
+            "content_block_delta" => {
+                let delta = event.get("delta").unwrap_or(&Value::Null);
+                let delta_type = delta.get("type").and_then(Value::as_str).unwrap_or("");
+                let (kind, text) = match delta_type {
+                    "text_delta" => (
+                        DeltaKind::Text,
+                        delta.get("text").and_then(Value::as_str).unwrap_or(""),
+                    ),
+                    "thinking_delta" => (
+                        DeltaKind::Thinking,
+                        delta.get("thinking").and_then(Value::as_str).unwrap_or(""),
+                    ),
+                    // input_json_delta / signature_delta carry no renderable
+                    // text; the completed assistant frame has the full data.
+                    _ => return Vec::new(),
+                };
+                vec![StreamEvent::Delta {
+                    kind,
+                    text: text.to_string(),
+                    cumulative: false,
+                }]
+            }
+            // Pure protocol framing — the completed `assistant` frame
+            // repeats everything these delimit, so they carry no data a
+            // consumer could lose.
+            "message_start"
+            | "message_delta"
+            | "message_stop"
+            | "content_block_start"
+            | "content_block_stop"
+            | "ping" => Vec::new(),
+            _ => vec![StreamEvent::Passthrough {
+                harness: "claude-code",
+                raw: frame.clone(),
+            }],
+        }
+    }
+}
+
+impl Default for ClaudeStreamParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UcfStreamParser for ClaudeStreamParser {
+    fn harness(&self) -> &'static str {
+        "claude-code"
+    }
+
+    fn feed_line(&mut self, line: &str) -> Vec<StreamEvent> {
+        let frame = match parse_line(line) {
+            ParsedLine::Frame(frame) => frame,
+            ParsedLine::Blank => return Vec::new(),
+            ParsedLine::Raw(raw) => {
+                return vec![StreamEvent::Passthrough {
+                    harness: "claude-code",
+                    raw: Value::String(raw),
+                }]
+            }
+        };
+        self.capture_session_id(&frame);
+
+        match frame.get("type").and_then(Value::as_str).unwrap_or("") {
+            "system" => {
+                if frame.get("subtype").and_then(Value::as_str) == Some("init") {
+                    vec![StreamEvent::SessionStart(self.init_header(&frame))]
+                } else {
+                    vec![StreamEvent::Event(HubEvent {
+                        event_type: "system".to_string(),
+                        timestamp: self.timestamp.clone(),
+                        data: frame,
+                        extensions: Value::Null,
+                    })]
+                }
+            }
+            "assistant" => vec![self.message_frame_to_event(&frame, "assistant")],
+            "user" => vec![self.message_frame_to_event(&frame, "user")],
+            "stream_event" => self.stream_event_frame(&frame),
+            "result" => vec![StreamEvent::Event(HubEvent {
+                event_type: "agent_end".to_string(),
+                timestamp: self.timestamp.clone(),
+                data: frame,
+                extensions: Value::Null,
+            })],
+            _ => vec![StreamEvent::Passthrough {
+                harness: "claude-code",
+                raw: frame,
+            }],
+        }
+    }
+}
+
+impl ClaudeStreamParser {
+    fn init_header(&self, frame: &Value) -> SessionHeader {
+        SessionHeader {
+            ucf_version: UCF_VERSION.to_string(),
+            session_id: self.session_id.clone(),
+            created_at: self.timestamp.clone(),
+            updated_at: self.timestamp.clone(),
+            source_cli: "claude-code".to_string(),
+            source_version: frame
+                .get("version")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+            project: frame.get("cwd").and_then(Value::as_str).map(|cwd| {
+                crate::interchange::hub::ProjectInfo {
+                    directory: cwd.to_string(),
+                    root: None,
+                    hash: None,
+                    vcs: None,
+                    branch: None,
+                    sha: None,
+                    origin_url: None,
+                }
+            }),
+            model: frame.get("model").and_then(Value::as_str).map(String::from),
+            title: None,
+            slug: None,
+            parent_session_id: None,
+            extensions: serde_json::json!({"claude-code": {"_original_frame": frame}}),
+        }
+    }
+}
+
+/// Convert a Claude message `content` value (string or block array) into hub
+/// blocks, delegating per-block parsing to the interchange converter so the
+/// live and transcript paths cannot drift.
+fn claude_stream_content_to_hub(content: &Value) -> Vec<crate::interchange::hub::ContentBlock> {
+    use crate::interchange::hub::ContentBlock;
+    match content {
+        Value::String(s) => vec![ContentBlock::Text { text: s.clone() }],
+        Value::Array(blocks) => blocks
+            .iter()
+            .filter_map(|b| crate::interchange::claude::claude_content_to_hub(b).ok())
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn usage_to_tokens(usage: &Value) -> Option<TokenUsage> {
+    let get = |key: &str| usage.get(key).and_then(Value::as_u64).unwrap_or(0);
+    if !usage.is_object() {
+        return None;
+    }
+    Some(TokenUsage {
+        input: get("input_tokens"),
+        output: get("output_tokens"),
+        cache_creation: get("cache_creation_input_tokens"),
+        cache_read: get("cache_read_input_tokens"),
+        reasoning: 0,
+        tool: 0,
+        total: 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interchange::hub::ContentBlock;
+
+    fn feed_all(fixture: &str) -> Vec<StreamEvent> {
+        let mut parser = ClaudeStreamParser::new().with_timestamp("2026-07-10T12:00:00Z");
+        fixture
+            .lines()
+            .flat_map(|line| parser.feed_line(line))
+            .collect()
+    }
+
+    #[test]
+    fn init_frame_becomes_session_header() {
+        let events = feed_all(include_str!("tests/fixtures/claude-stream.jsonl"));
+        let header = events
+            .iter()
+            .find_map(|e| match e {
+                StreamEvent::SessionStart(h) => Some(h),
+                _ => None,
+            })
+            .expect("session start");
+        assert_eq!(header.session_id, "c1");
+        assert_eq!(header.source_cli, "claude-code");
+        assert_eq!(header.model.as_deref(), Some("claude-opus-4-6"));
+        assert_eq!(
+            header.project.as_ref().map(|p| p.directory.as_str()),
+            Some("/tmp/proj")
+        );
+    }
+
+    #[test]
+    fn assistant_frame_preserves_original_and_usage() {
+        let events = feed_all(include_str!("tests/fixtures/claude-stream.jsonl"));
+        let msg = events
+            .iter()
+            .find_map(|e| match e {
+                StreamEvent::Message(m) if m.role == "assistant" => Some(m),
+                _ => None,
+            })
+            .expect("assistant message");
+        assert_eq!(msg.api_message_id.as_deref(), Some("msg_01"));
+        assert_eq!(msg.metadata.tokens.as_ref().map(|t| t.input), Some(10));
+        assert!(msg
+            .extensions
+            .pointer("/claude-code/_original_frame/message/id")
+            .is_some());
+        assert!(msg
+            .content
+            .iter()
+            .any(|b| matches!(b, ContentBlock::ToolUse { name, .. } if name == "Bash")));
+    }
+
+    #[test]
+    fn text_deltas_are_incremental() {
+        let events = feed_all(include_str!("tests/fixtures/claude-stream.jsonl"));
+        let deltas: Vec<&StreamEvent> = events
+            .iter()
+            .filter(|e| matches!(e, StreamEvent::Delta { .. }))
+            .collect();
+        assert_eq!(deltas.len(), 2);
+        let combined: String = deltas
+            .iter()
+            .map(|e| match e {
+                StreamEvent::Delta {
+                    text, cumulative, ..
+                } => {
+                    assert!(!cumulative);
+                    text.as_str()
+                }
+                _ => unreachable!(),
+            })
+            .collect();
+        assert_eq!(combined, "Hello");
+    }
+
+    #[test]
+    fn string_content_user_message_is_accepted() {
+        let mut parser = ClaudeStreamParser::new();
+        let events = parser.feed_line(
+            r#"{"type":"user","session_id":"c9","message":{"role":"user","content":"plain text"}}"#,
+        );
+        match &events[0] {
+            StreamEvent::Message(m) => {
+                assert!(
+                    matches!(&m.content[0], ContentBlock::Text { text } if text == "plain text")
+                );
+            }
+            other => panic!("expected message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_stream_event_subtype_passes_through() {
+        let mut parser = ClaudeStreamParser::new();
+        let events = parser.feed_line(
+            r#"{"type":"stream_event","session_id":"c1","event":{"type":"audio_delta","data":"x"}}"#,
+        );
+        assert!(matches!(&events[0], StreamEvent::Passthrough { .. }));
+    }
+}

--- a/src/stream/codex.rs
+++ b/src/stream/codex.rs
@@ -42,7 +42,16 @@ impl CodexStreamParser {
         format!("codex-stream-{}", self.seq)
     }
 
+    /// Wrap content in a message, or pass the frame through when conversion
+    /// produced nothing — an empty `Message` would surface as a hollow row in
+    /// a persisted `.ucf.jsonl`, while passthrough keeps the frame intact.
     fn message(&mut self, role: &str, content: Vec<ContentBlock>, frame: &Value) -> StreamEvent {
+        if content.is_empty() {
+            return StreamEvent::Passthrough {
+                harness: "codex",
+                raw: frame.clone(),
+            };
+        }
         StreamEvent::Message(HubMessage {
             id: self.next_id(),
             api_message_id: None,
@@ -81,22 +90,30 @@ impl CodexStreamParser {
 
         match item_type {
             "assistant_message" => {
-                vec![self.message("assistant", vec![ContentBlock::Text { text }], frame)]
+                let content = if text.is_empty() {
+                    Vec::new()
+                } else {
+                    vec![ContentBlock::Text { text }]
+                };
+                vec![self.message("assistant", content, frame)]
             }
-            "reasoning" => vec![self.message(
-                "assistant",
-                vec![ContentBlock::Thinking {
-                    text,
-                    subject: None,
-                    description: None,
-                    signature: None,
-                    encrypted: false,
-                    encryption_format: None,
-                    encrypted_data: None,
-                    timestamp: None,
-                }],
-                frame,
-            )],
+            "reasoning" => {
+                let content = if text.is_empty() {
+                    Vec::new()
+                } else {
+                    vec![ContentBlock::Thinking {
+                        text,
+                        subject: None,
+                        description: None,
+                        signature: None,
+                        encrypted: false,
+                        encryption_format: None,
+                        encrypted_data: None,
+                        timestamp: None,
+                    }]
+                };
+                vec![self.message("assistant", content, frame)]
+            }
             "command_execution" | "mcp_tool_call" => {
                 let name = if item_type == "command_execution" {
                     "shell".to_string()
@@ -119,6 +136,9 @@ impl CodexStreamParser {
                     .get("exit_code")
                     .and_then(Value::as_i64)
                     .map(|c| c as i32);
+                // MCP tool calls carry no exit code, so a failure there is
+                // only visible through `status`.
+                let status = item.get("status").and_then(Value::as_str);
                 let output = item
                     .get("aggregated_output")
                     .or_else(|| item.get("output"))
@@ -143,9 +163,10 @@ impl CodexStreamParser {
                             tool_use_id: item_id,
                             content: vec![ContentBlock::Text { text: output }],
                             exit_code,
-                            is_error: exit_code.is_some_and(|code| code != 0),
+                            is_error: exit_code.is_some_and(|code| code != 0)
+                                || matches!(status, Some("failed") | Some("error")),
                             interrupted: false,
-                            status: item.get("status").and_then(Value::as_str).map(String::from),
+                            status: status.map(String::from),
                             duration_ms: None,
                             title: None,
                             truncated: false,
@@ -384,6 +405,46 @@ mod tests {
             _ => None,
         });
         assert_eq!(is_error, Some(true));
+    }
+
+    #[test]
+    fn failed_mcp_call_without_exit_code_is_error_result() {
+        let mut parser = CodexStreamParser::new();
+        let events = parser.feed_line(
+            r#"{"type":"item.completed","item":{"id":"item_9","item_type":"mcp_tool_call","tool":"search","arguments":{"q":"x"},"output":"connection refused","status":"failed"}}"#,
+        );
+        let result = events.iter().find_map(|e| match e {
+            StreamEvent::Message(m) => m.content.iter().find_map(|b| match b {
+                ContentBlock::ToolResult {
+                    is_error,
+                    exit_code,
+                    ..
+                } => Some((*is_error, *exit_code)),
+                _ => None,
+            }),
+            _ => None,
+        });
+        assert_eq!(result, Some((true, None)));
+    }
+
+    #[test]
+    fn empty_items_pass_through_instead_of_hollow_messages() {
+        let mut parser = CodexStreamParser::new();
+        for line in [
+            // file_change whose changes all lack a path
+            r#"{"type":"item.completed","item":{"id":"i1","item_type":"file_change","changes":[{"kind":"edit"}]}}"#,
+            // assistant_message / reasoning with empty text
+            r#"{"type":"item.completed","item":{"id":"i2","item_type":"assistant_message","text":""}}"#,
+            r#"{"type":"item.completed","item":{"id":"i3","item_type":"reasoning","text":""}}"#,
+        ] {
+            let events = parser.feed_line(line);
+            assert_eq!(events.len(), 1, "{line}");
+            assert!(
+                matches!(&events[0], StreamEvent::Passthrough { .. }),
+                "expected passthrough for {line}, got {:?}",
+                events[0]
+            );
+        }
     }
 
     #[test]

--- a/src/stream/codex.rs
+++ b/src/stream/codex.rs
@@ -1,0 +1,397 @@
+//! Codex `codex exec --json` adapter.
+//!
+//! Frame reference (current Codex CLI JSONL event stream):
+//! - `{"type":"thread.started","thread_id":"..."}` — session identity
+//! - `{"type":"turn.started"}` / `{"type":"turn.completed","usage":{...}}` /
+//!   `{"type":"turn.failed","error":{...}}` — turn lifecycle
+//! - `{"type":"item.started"|"item.updated"|"item.completed","item":{...}}`
+//!   — items carry `item_type`: `assistant_message`, `reasoning`,
+//!   `command_execution`, `file_change`, `mcp_tool_call`, `error`, …
+//! - `{"type":"error","message":"..."}` — stream-level error
+
+use super::{parse_line, DeltaKind, ParsedLine, StreamEvent, UcfStreamParser};
+use crate::interchange::hub::{
+    ContentBlock, HubEvent, HubMessage, MessageMetadata, SessionHeader, UCF_VERSION,
+};
+use serde_json::Value;
+
+pub struct CodexStreamParser {
+    session_id: String,
+    timestamp: String,
+    seq: u64,
+}
+
+impl CodexStreamParser {
+    pub fn new() -> Self {
+        Self {
+            session_id: String::new(),
+            timestamp: String::new(),
+            seq: 0,
+        }
+    }
+
+    /// Fixed timestamp applied to emitted messages/events; see the Claude
+    /// adapter for the contract.
+    pub fn with_timestamp(mut self, timestamp: impl Into<String>) -> Self {
+        self.timestamp = timestamp.into();
+        self
+    }
+
+    fn next_id(&mut self) -> String {
+        self.seq += 1;
+        format!("codex-stream-{}", self.seq)
+    }
+
+    fn message(&mut self, role: &str, content: Vec<ContentBlock>, frame: &Value) -> StreamEvent {
+        StreamEvent::Message(HubMessage {
+            id: self.next_id(),
+            api_message_id: None,
+            parent_id: None,
+            timestamp: self.timestamp.clone(),
+            completed_at: None,
+            role: role.to_string(),
+            content,
+            metadata: MessageMetadata::default(),
+            extensions: serde_json::json!({"codex": {"_original_frame": frame}}),
+        })
+    }
+
+    fn event(&self, event_type: &str, data: Value) -> StreamEvent {
+        StreamEvent::Event(HubEvent {
+            event_type: event_type.to_string(),
+            timestamp: self.timestamp.clone(),
+            data,
+            extensions: Value::Null,
+        })
+    }
+
+    fn item_completed(&mut self, frame: &Value) -> Vec<StreamEvent> {
+        let item = frame.get("item").unwrap_or(&Value::Null);
+        let item_type = item.get("item_type").and_then(Value::as_str).unwrap_or("");
+        let item_id = item
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let text = item
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+
+        match item_type {
+            "assistant_message" => {
+                vec![self.message("assistant", vec![ContentBlock::Text { text }], frame)]
+            }
+            "reasoning" => vec![self.message(
+                "assistant",
+                vec![ContentBlock::Thinking {
+                    text,
+                    subject: None,
+                    description: None,
+                    signature: None,
+                    encrypted: false,
+                    encryption_format: None,
+                    encrypted_data: None,
+                    timestamp: None,
+                }],
+                frame,
+            )],
+            "command_execution" | "mcp_tool_call" => {
+                let name = if item_type == "command_execution" {
+                    "shell".to_string()
+                } else {
+                    item.get("tool")
+                        .and_then(Value::as_str)
+                        .unwrap_or("mcp")
+                        .to_string()
+                };
+                let input = if item_type == "command_execution" {
+                    serde_json::json!({
+                        "command": item.get("command").cloned().unwrap_or(Value::Null)
+                    })
+                } else {
+                    item.get("arguments")
+                        .cloned()
+                        .unwrap_or_else(|| Value::Object(Default::default()))
+                };
+                let exit_code = item
+                    .get("exit_code")
+                    .and_then(Value::as_i64)
+                    .map(|c| c as i32);
+                let output = item
+                    .get("aggregated_output")
+                    .or_else(|| item.get("output"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                vec![
+                    self.message(
+                        "assistant",
+                        vec![ContentBlock::ToolUse {
+                            id: item_id.clone(),
+                            name,
+                            display_name: None,
+                            description: None,
+                            input,
+                        }],
+                        frame,
+                    ),
+                    self.message(
+                        "user",
+                        vec![ContentBlock::ToolResult {
+                            tool_use_id: item_id,
+                            content: vec![ContentBlock::Text { text: output }],
+                            exit_code,
+                            is_error: exit_code.is_some_and(|code| code != 0),
+                            interrupted: false,
+                            status: item.get("status").and_then(Value::as_str).map(String::from),
+                            duration_ms: None,
+                            title: None,
+                            truncated: false,
+                        }],
+                        frame,
+                    ),
+                ]
+            }
+            "file_change" => {
+                let patches: Vec<ContentBlock> = item
+                    .get("changes")
+                    .and_then(Value::as_array)
+                    .map(|changes| {
+                        changes
+                            .iter()
+                            .filter_map(|change| {
+                                change.get("path").and_then(Value::as_str).map(|path| {
+                                    ContentBlock::Patch {
+                                        path: path.to_string(),
+                                        hash_before: None,
+                                        hash_after: None,
+                                    }
+                                })
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                vec![self.message("assistant", patches, frame)]
+            }
+            "error" => vec![self.event("error", frame.clone())],
+            _ => vec![StreamEvent::Passthrough {
+                harness: "codex",
+                raw: frame.clone(),
+            }],
+        }
+    }
+
+    fn item_updated(&self, frame: &Value) -> Vec<StreamEvent> {
+        let item = frame.get("item").unwrap_or(&Value::Null);
+        let text = item
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        match item.get("item_type").and_then(Value::as_str).unwrap_or("") {
+            // Codex updates carry the full text-so-far, not an append-only
+            // fragment — hence `cumulative: true`.
+            "assistant_message" => vec![StreamEvent::Delta {
+                kind: DeltaKind::Text,
+                text,
+                cumulative: true,
+            }],
+            "reasoning" => vec![StreamEvent::Delta {
+                kind: DeltaKind::Thinking,
+                text,
+                cumulative: true,
+            }],
+            // Tool-ish updates are repeated in full by item.completed.
+            "command_execution" | "mcp_tool_call" | "file_change" => Vec::new(),
+            _ => vec![StreamEvent::Passthrough {
+                harness: "codex",
+                raw: frame.clone(),
+            }],
+        }
+    }
+
+    fn item_started(&self, frame: &Value) -> Vec<StreamEvent> {
+        let item = frame.get("item").unwrap_or(&Value::Null);
+        match item.get("item_type").and_then(Value::as_str).unwrap_or("") {
+            "command_execution" | "mcp_tool_call" | "web_search" => {
+                vec![self.event("tool_start", frame.clone())]
+            }
+            // Message-ish starts carry no data their updates/completion
+            // don't repeat.
+            "assistant_message" | "reasoning" | "file_change" => Vec::new(),
+            _ => vec![StreamEvent::Passthrough {
+                harness: "codex",
+                raw: frame.clone(),
+            }],
+        }
+    }
+}
+
+impl Default for CodexStreamParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UcfStreamParser for CodexStreamParser {
+    fn harness(&self) -> &'static str {
+        "codex"
+    }
+
+    fn feed_line(&mut self, line: &str) -> Vec<StreamEvent> {
+        let frame = match parse_line(line) {
+            ParsedLine::Frame(frame) => frame,
+            ParsedLine::Blank => return Vec::new(),
+            ParsedLine::Raw(raw) => {
+                return vec![StreamEvent::Passthrough {
+                    harness: "codex",
+                    raw: Value::String(raw),
+                }]
+            }
+        };
+
+        match frame.get("type").and_then(Value::as_str).unwrap_or("") {
+            "thread.started" => {
+                if let Some(id) = frame.get("thread_id").and_then(Value::as_str) {
+                    self.session_id = id.to_string();
+                }
+                vec![StreamEvent::SessionStart(SessionHeader {
+                    ucf_version: UCF_VERSION.to_string(),
+                    session_id: self.session_id.clone(),
+                    created_at: self.timestamp.clone(),
+                    updated_at: self.timestamp.clone(),
+                    source_cli: "codex".to_string(),
+                    source_version: String::new(),
+                    project: None,
+                    model: None,
+                    title: None,
+                    slug: None,
+                    parent_session_id: None,
+                    extensions: serde_json::json!({"codex": {"_original_frame": frame}}),
+                })]
+            }
+            "turn.started" => vec![self.event("turn_start", frame)],
+            "turn.completed" => vec![self.event("turn_end", frame)],
+            "turn.failed" | "error" => vec![self.event("error", frame)],
+            "item.started" => self.item_started(&frame),
+            "item.updated" => self.item_updated(&frame),
+            "item.completed" => self.item_completed(&frame),
+            _ => vec![StreamEvent::Passthrough {
+                harness: "codex",
+                raw: frame,
+            }],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn feed_all(fixture: &str) -> Vec<StreamEvent> {
+        let mut parser = CodexStreamParser::new().with_timestamp("2026-07-10T12:00:00Z");
+        fixture
+            .lines()
+            .flat_map(|line| parser.feed_line(line))
+            .collect()
+    }
+
+    #[test]
+    fn command_execution_becomes_linked_tool_pair() {
+        let events = feed_all(include_str!("tests/fixtures/codex-stream.jsonl"));
+        let tool_use = events
+            .iter()
+            .find_map(|e| match e {
+                StreamEvent::Message(m) => m.content.iter().find_map(|b| match b {
+                    ContentBlock::ToolUse {
+                        id, name, input, ..
+                    } => Some((id, name, input)),
+                    _ => None,
+                }),
+                _ => None,
+            })
+            .expect("tool use");
+        assert_eq!(tool_use.0, "item_0");
+        assert_eq!(tool_use.1, "shell");
+        assert_eq!(
+            tool_use.2.get("command").and_then(Value::as_str),
+            Some("ls")
+        );
+
+        let tool_result = events
+            .iter()
+            .find_map(|e| match e {
+                StreamEvent::Message(m) => m.content.iter().find_map(|b| match b {
+                    ContentBlock::ToolResult {
+                        tool_use_id,
+                        exit_code,
+                        is_error,
+                        ..
+                    } => Some((tool_use_id, exit_code, is_error)),
+                    _ => None,
+                }),
+                _ => None,
+            })
+            .expect("tool result");
+        assert_eq!(tool_result.0, "item_0");
+        assert_eq!(*tool_result.1, Some(0));
+        assert!(!tool_result.2);
+    }
+
+    #[test]
+    fn reasoning_item_becomes_thinking_block() {
+        let events = feed_all(include_str!("tests/fixtures/codex-stream.jsonl"));
+        assert!(events.iter().any(|e| matches!(
+            e,
+            StreamEvent::Message(m) if m.content.iter().any(
+                |b| matches!(b, ContentBlock::Thinking { text, .. } if text.contains("Rust crate"))
+            )
+        )));
+    }
+
+    #[test]
+    fn item_updated_is_cumulative_delta() {
+        let events = feed_all(include_str!("tests/fixtures/codex-stream.jsonl"));
+        let delta = events
+            .iter()
+            .find_map(|e| match e {
+                StreamEvent::Delta {
+                    kind,
+                    text,
+                    cumulative,
+                } => Some((kind, text, cumulative)),
+                _ => None,
+            })
+            .expect("delta");
+        assert_eq!(*delta.0, DeltaKind::Text);
+        assert_eq!(delta.1, "Do");
+        assert!(*delta.2);
+    }
+
+    #[test]
+    fn failed_command_is_error_result() {
+        let mut parser = CodexStreamParser::new();
+        let events = parser.feed_line(
+            r#"{"type":"item.completed","item":{"id":"item_9","item_type":"command_execution","command":"false","aggregated_output":"","exit_code":1,"status":"failed"}}"#,
+        );
+        let is_error = events.iter().find_map(|e| match e {
+            StreamEvent::Message(m) => m.content.iter().find_map(|b| match b {
+                ContentBlock::ToolResult { is_error, .. } => Some(*is_error),
+                _ => None,
+            }),
+            _ => None,
+        });
+        assert_eq!(is_error, Some(true));
+    }
+
+    #[test]
+    fn unknown_item_type_passes_through() {
+        let mut parser = CodexStreamParser::new();
+        let events = parser.feed_line(
+            r#"{"type":"item.completed","item":{"id":"item_9","item_type":"hologram","text":"?"}}"#,
+        );
+        assert!(matches!(&events[0], StreamEvent::Passthrough { .. }));
+    }
+}

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1,0 +1,225 @@
+//! Live harness output → UCF stream normalization.
+//!
+//! Transcript conversion (`src/interchange/`) works on completed session
+//! files. This module normalizes the *live* JSONL output of a running
+//! harness (`claude -p --output-format stream-json`, `codex exec --json`)
+//! into UCF-shaped [`StreamEvent`]s, so a consumer never branches on which
+//! harness produced a token. See issue #374.
+//!
+//! Design rules:
+//! - The canonical message/session shapes are the existing UCF hub types
+//!   ([`HubMessage`], [`SessionHeader`]) — no second schema.
+//! - Compliant by default: a frame the adapter does not recognize is never
+//!   dropped. It is emitted verbatim as [`StreamEvent::Passthrough`], and a
+//!   line that fails to parse as JSON is passed through as a raw string.
+//! - Deltas are a separate lightweight variant so attended UIs can render
+//!   tokens as they arrive while headless consumers can ignore them and act
+//!   only on completed [`StreamEvent::Message`]s.
+
+pub mod claude;
+pub mod codex;
+
+use crate::interchange::hub::{HubEvent, HubMessage, SessionHeader};
+use serde_json::Value;
+
+/// What kind of text a [`StreamEvent::Delta`] carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeltaKind {
+    Text,
+    Thinking,
+}
+
+/// A canonical event emitted by every harness stream adapter.
+#[derive(Debug, Clone)]
+pub enum StreamEvent {
+    /// The harness announced its identity (session id, model, cwd, …).
+    SessionStart(SessionHeader),
+    /// A completed message, already UCF-shaped. The original harness frame
+    /// is preserved under `extensions.<harness>._original_frame`.
+    Message(HubMessage),
+    /// An incremental token update. `cumulative` is true when `text` is the
+    /// full text-so-far (Codex `item.updated`) rather than an append-only
+    /// fragment (Claude `text_delta`).
+    Delta {
+        kind: DeltaKind,
+        text: String,
+        cumulative: bool,
+    },
+    /// A lifecycle or status event (`turn_start`, `turn_end`, `agent_end`,
+    /// `tool_start`, `error`). `data` carries the raw harness payload.
+    Event(HubEvent),
+    /// A frame the adapter did not recognize, preserved verbatim.
+    Passthrough { harness: &'static str, raw: Value },
+}
+
+/// Incremental parser over one harness's JSONL output stream.
+///
+/// Feed lines as they arrive; each call returns zero or more canonical
+/// events. Implementations must be infallible: malformed input becomes
+/// [`StreamEvent::Passthrough`], never an error or a silent drop.
+pub trait UcfStreamParser {
+    /// Which harness this adapter understands (UCF `source_cli` value).
+    fn harness(&self) -> &'static str;
+
+    /// Consume one line of harness output.
+    fn feed_line(&mut self, line: &str) -> Vec<StreamEvent>;
+
+    /// Flush any buffered state at end of stream.
+    fn finish(&mut self) -> Vec<StreamEvent> {
+        Vec::new()
+    }
+}
+
+/// Look up the stream adapter for a harness by its UCF `source_cli` name.
+pub fn parser_for(harness: &str) -> Option<Box<dyn UcfStreamParser>> {
+    match harness {
+        "claude" | "claude-code" => Some(Box::new(claude::ClaudeStreamParser::new())),
+        "codex" => Some(Box::new(codex::CodexStreamParser::new())),
+        _ => None,
+    }
+}
+
+/// Outcome of tokenizing one line of harness output.
+enum ParsedLine {
+    /// Blank line — emit nothing.
+    Blank,
+    /// A JSON frame for the adapter to interpret.
+    Frame(Value),
+    /// Not JSON — the adapter must pass it through verbatim.
+    Raw(String),
+}
+
+/// Shared helper: parse a JSONL line, routing blank lines to nothing and
+/// non-JSON lines to passthrough.
+fn parse_line(line: &str) -> ParsedLine {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return ParsedLine::Blank;
+    }
+    match serde_json::from_str::<Value>(trimmed) {
+        Ok(value) => ParsedLine::Frame(value),
+        Err(_) => ParsedLine::Raw(trimmed.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interchange::hub::ContentBlock;
+
+    /// A deliberately harness-blind consumer: everything it learns about the
+    /// run comes from canonical events. This is the #374 acceptance check —
+    /// if this compiles and passes against both fixtures without inspecting
+    /// the harness, adapters have fully normalized their streams.
+    #[derive(Debug, Default)]
+    struct Transcript {
+        session_id: String,
+        texts: Vec<String>,
+        thinking: Vec<String>,
+        tool_calls: Vec<(String, String)>, // (id, name)
+        tool_results: Vec<String>,         // tool_use_id
+        delta_chars: usize,
+        lifecycle: Vec<String>,
+        passthrough: usize,
+    }
+
+    fn consume(events: Vec<StreamEvent>) -> Transcript {
+        let mut t = Transcript::default();
+        for event in events {
+            match event {
+                StreamEvent::SessionStart(header) => t.session_id = header.session_id,
+                StreamEvent::Message(msg) => {
+                    for block in &msg.content {
+                        match block {
+                            ContentBlock::Text { text } => t.texts.push(text.clone()),
+                            ContentBlock::Thinking { text, .. } => t.thinking.push(text.clone()),
+                            ContentBlock::ToolUse { id, name, .. } => {
+                                t.tool_calls.push((id.clone(), name.clone()))
+                            }
+                            ContentBlock::ToolResult { tool_use_id, .. } => {
+                                t.tool_results.push(tool_use_id.clone())
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                StreamEvent::Delta { text, .. } => t.delta_chars += text.len(),
+                StreamEvent::Event(evt) => t.lifecycle.push(evt.event_type),
+                StreamEvent::Passthrough { .. } => t.passthrough += 1,
+            }
+        }
+        t
+    }
+
+    fn run_fixture(harness: &str, fixture: &str) -> Transcript {
+        let mut parser = parser_for(harness).expect("adapter registered");
+        let mut events = Vec::new();
+        for line in fixture.lines() {
+            events.extend(parser.feed_line(line));
+        }
+        events.extend(parser.finish());
+        consume(events)
+    }
+
+    #[test]
+    fn consumer_is_harness_blind_for_claude() {
+        let t = run_fixture(
+            "claude-code",
+            include_str!("tests/fixtures/claude-stream.jsonl"),
+        );
+        assert_eq!(t.session_id, "c1");
+        assert!(t.texts.iter().any(|s| s == "Hello"));
+        assert!(t.texts.iter().any(|s| s == "Done."));
+        assert_eq!(t.tool_calls, vec![("toolu_01".into(), "Bash".into())]);
+        assert_eq!(t.tool_results, vec!["toolu_01".to_string()]);
+        assert!(t.delta_chars > 0, "partial-message deltas surface");
+        assert!(t.lifecycle.contains(&"agent_end".to_string()));
+        assert_eq!(t.passthrough, 1, "unknown frame passes through");
+    }
+
+    #[test]
+    fn consumer_is_harness_blind_for_codex() {
+        let t = run_fixture("codex", include_str!("tests/fixtures/codex-stream.jsonl"));
+        assert_eq!(t.session_id, "t1");
+        assert!(t.texts.iter().any(|s| s == "Done."));
+        assert!(t.thinking.iter().any(|s| s.contains("Rust crate")));
+        assert_eq!(t.tool_calls.len(), 1);
+        assert_eq!(t.tool_results.len(), 1);
+        assert_eq!(
+            t.tool_calls[0].0, t.tool_results[0],
+            "tool result links to its call"
+        );
+        assert!(t.delta_chars > 0, "item.updated surfaces as delta");
+        assert!(t.lifecycle.contains(&"turn_end".to_string()));
+        assert_eq!(t.passthrough, 1, "unknown frame passes through");
+    }
+
+    #[test]
+    fn non_json_line_passes_through_verbatim() {
+        for harness in ["claude-code", "codex"] {
+            let mut parser = parser_for(harness).unwrap();
+            let events = parser.feed_line("not json at all");
+            assert_eq!(events.len(), 1);
+            match &events[0] {
+                StreamEvent::Passthrough { raw, .. } => {
+                    assert_eq!(raw.as_str(), Some("not json at all"))
+                }
+                other => panic!("expected passthrough, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn blank_lines_emit_nothing() {
+        for harness in ["claude-code", "codex"] {
+            let mut parser = parser_for(harness).unwrap();
+            assert!(parser.feed_line("").is_empty());
+            assert!(parser.feed_line("   ").is_empty());
+        }
+    }
+
+    #[test]
+    fn unknown_harness_has_no_parser() {
+        assert!(parser_for("not-a-harness").is_none());
+    }
+}

--- a/src/stream/tests/fixtures/claude-stream.jsonl
+++ b/src/stream/tests/fixtures/claude-stream.jsonl
@@ -1,0 +1,8 @@
+{"type":"system","subtype":"init","session_id":"c1","model":"claude-opus-4-6","cwd":"/tmp/proj","tools":["Bash"],"permissionMode":"default","version":"2.1.90"}
+{"type":"stream_event","session_id":"c1","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hel"}}}
+{"type":"stream_event","session_id":"c1","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"lo"}}}
+{"type":"assistant","session_id":"c1","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-opus-4-6","content":[{"type":"text","text":"Hello"},{"type":"tool_use","id":"toolu_01","name":"Bash","input":{"command":"ls"}}],"stop_reason":"tool_use","usage":{"input_tokens":10,"output_tokens":5}}}
+{"type":"user","session_id":"c1","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01","content":"Cargo.toml\nsrc","is_error":false}]}}
+{"type":"assistant","session_id":"c1","message":{"id":"msg_02","type":"message","role":"assistant","model":"claude-opus-4-6","content":[{"type":"text","text":"Done."}],"stop_reason":"end_turn","usage":{"input_tokens":20,"output_tokens":3}}}
+{"type":"result","subtype":"success","session_id":"c1","is_error":false,"num_turns":2,"duration_ms":1234,"total_cost_usd":0.01,"result":"Done.","usage":{"input_tokens":30,"output_tokens":8}}
+{"type":"future_frame","session_id":"c1","payload":{"x":1}}

--- a/src/stream/tests/fixtures/codex-stream.jsonl
+++ b/src/stream/tests/fixtures/codex-stream.jsonl
@@ -1,0 +1,9 @@
+{"type":"thread.started","thread_id":"t1"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"id":"item_0","item_type":"command_execution","command":"ls","status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_0","item_type":"command_execution","command":"ls","aggregated_output":"Cargo.toml\nsrc\n","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_1","item_type":"reasoning","text":"The repo is a Rust crate."}}
+{"type":"item.updated","item":{"id":"item_2","item_type":"assistant_message","text":"Do"}}
+{"type":"item.completed","item":{"id":"item_2","item_type":"assistant_message","text":"Done."}}
+{"type":"turn.completed","usage":{"input_tokens":30,"cached_input_tokens":10,"output_tokens":8}}
+{"type":"weird.new.event","data":{"y":2}}


### PR DESCRIPTION
## Summary

First PR for #374, taking the maintainer-suggested direction one step further: instead of inventing a Froots-style second schema, the canonical live-event surface reuses the **UCF hub types** (`HubMessage`, `SessionHeader`, `HubEvent`) with a thin `StreamEvent` layer for deltas and lifecycle. One schema for transcripts and live streams; live consumers can persist completed messages straight into `.ucf.jsonl`.

- new `src/stream/` module (separate from `src/interchange/`, per the direction that transcript conversion and live streaming should not be conflated — it consumes hub types but shares no converter state)
- `ClaudeStreamParser` for `claude -p --output-format stream-json`: `system.init` → `SessionStart`, `assistant`/`user` frames → UCF `Message`s, `stream_event` text/thinking deltas → `Delta`, `result` → `agent_end` event; per-block conversion delegates to the existing interchange converter so the live and transcript paths cannot drift
- `CodexStreamParser` for `codex exec --json`: `thread.started` → `SessionStart`, turn lifecycle → events, `item.completed` items → UCF messages (`assistant_message` → text, `reasoning` → thinking, `command_execution`/`mcp_tool_call` → linked `tool_use` + `tool_result` pair, `file_change` → patch blocks), `item.updated` → cumulative deltas
- **compliant by default**: unknown frame types, unknown `stream_event` subtypes, unknown item types, and non-JSON lines are never dropped — they surface as `StreamEvent::Passthrough` verbatim, and every converted message carries its original frame under `extensions.<harness>._original_frame`

## Acceptance criteria from #374

- [x] Canonical event types defined in one place (`stream::StreamEvent`, backed by UCF hub types)
- [x] ≥2 harness adapters emitting only canonical events (Claude stream-json, Codex exec JSON)
- [x] Consumer contains zero harness-specific branching — proven by a shared harness-blind consumer test run against both fixtures
- [x] Works identically for attended and headless runs — deltas are a separate variant; headless consumers act only on completed `Message`s
- [ ] Special-UI tool call re-routing (question/plan channel) — deliberately deferred to the follow-up PR that adds the consumer integration; the events already flow through as ordinary tool calls so nothing is lost meanwhile

## Validation

- `cargo test`: 698 passed (15 new), 3 ignored
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- fixtures: `src/stream/tests/fixtures/{claude,codex}-stream.jsonl`, each ending in a deliberately unknown frame that must survive as passthrough

Refs #374
