### PR TITLE
fix(install): make remaining Rust binary install paths atomic

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1211,14 +1211,11 @@ impl AgentManager {
             install_extracted_binary(&tmp_dir, &cfg.binary, &install_path)?;
         } else {
             // Plain binary
-            fs::copy(&tmp_archive, &install_path)?;
+            atomic_install_binary(&tmp_archive, &install_path)?;
         }
 
-        // chmod +x
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&install_path)?.permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&install_path, perms)?;
+        // Both branches install atomically and already chmod +x the binary
+        // before it becomes visible at `install_path`.
 
         let _ = fs::remove_dir_all(&tmp_dir);
 
@@ -1375,15 +1372,9 @@ impl AgentManager {
             )));
         };
 
-        // Install
-        fs::copy(binary_path, install_path)?;
-
-        // Make executable
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(install_path, fs::Permissions::from_mode(0o755))?;
-        }
+        // Install atomically (chmod +x happens on the staged temp before the
+        // rename, so a running `codex` is never overwritten in place).
+        atomic_install_binary(binary_path, install_path)?;
 
         // Cleanup
         let _ = fs::remove_dir_all(&tmp_dir);
@@ -1481,7 +1472,7 @@ impl AgentManager {
 
         if output.status.success() {
             let binary_path = codex_rs_dir.join("target/release/codex");
-            fs::copy(&binary_path, install_path)?;
+            atomic_install_binary(&binary_path, install_path)?;
 
             progress.push(format!(
                 "Codex built and installed to {}",
@@ -1780,14 +1771,66 @@ pub(crate) fn pick_asset_name(
     None
 }
 
+/// Atomically install a binary from `src` to `dst`.
+///
+/// Copies to a temp file in the *same directory* as `dst` (so the final
+/// `rename` is atomic on the same filesystem), marks it executable, then
+/// renames it into place. This avoids two failure modes of a direct
+/// `fs::copy(src, dst)`:
+///
+///   1. A crash/interrupt mid-copy leaves a truncated, executable-looking
+///      binary at the canonical path (a subsequent run of a corrupt agent
+///      binary, not a clean re-download).
+///   2. `ETXTBSY` ("Text file busy") when `dst` is a currently-running
+///      executable — `fs::copy` opens `dst` for writing and fails, whereas
+///      `rename` swaps the directory entry to a fresh inode. Existing
+///      references to the old binary (a running process, a hard link) keep
+///      seeing the old inode; new lookups see the new one.
+///
+/// Returns the number of bytes copied. On any error the temp file is
+/// removed so a failed install never leaks a partial file into the
+/// install directory.
+fn atomic_install_binary(src: &std::path::Path, dst: &std::path::Path) -> io::Result<u64> {
+    let dir = dst.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "install path has no parent directory",
+        )
+    })?;
+    fs::create_dir_all(dir)?;
+
+    // Temp file in the destination directory (guarantees same filesystem, so
+    // the rename below is atomic rather than a cross-device copy). The pid
+    // keeps concurrent unleash processes from colliding on the same name.
+    let file_name = dst.file_name().and_then(|n| n.to_str()).unwrap_or("binary");
+    let tmp = dir.join(format!(".{file_name}.unleash-install.{}", std::process::id()));
+
+    let staged = (|| -> io::Result<u64> {
+        let n = fs::copy(src, &tmp)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&tmp, fs::Permissions::from_mode(0o755))?;
+        }
+        fs::rename(&tmp, dst)?;
+        Ok(n)
+    })();
+
+    if staged.is_err() {
+        // Best-effort cleanup; the real error is the one we return.
+        let _ = fs::remove_file(&tmp);
+    }
+    staged
+}
+
 /// After extracting an archive, find the agent binary and copy it to its
 /// final install path. Searches breadth-first:
 ///   1. `<tmp_dir>/<binary>` exact match
 ///   2. any `<binary>` file in any subdirectory (e.g. archives that wrap
 ///      the binary in a versioned dir like `aider-0.50.0/aider`)
 ///
-/// Returns the io::Result of the final copy. Caller is responsible for the
-/// subsequent chmod.
+/// Returns the io::Result of the final install. The result is already
+/// executable (0o755); callers do not need a subsequent chmod.
 fn install_extracted_binary(
     tmp_dir: &std::path::Path,
     binary: &str,
@@ -1796,7 +1839,7 @@ fn install_extracted_binary(
     // Direct hit
     let direct = tmp_dir.join(binary);
     if direct.exists() && direct.is_file() {
-        return fs::copy(&direct, install_path);
+        return atomic_install_binary(&direct, install_path);
     }
     // Walk one level for archives like `<repo>-<version>/<binary>`
     for entry in fs::read_dir(tmp_dir)? {
@@ -1805,7 +1848,7 @@ fn install_extracted_binary(
         if path.is_dir() {
             let candidate = path.join(binary);
             if candidate.exists() && candidate.is_file() {
-                return fs::copy(&candidate, install_path);
+                return atomic_install_binary(&candidate, install_path);
             }
         }
     }
@@ -2888,5 +2931,92 @@ mod tests {
             pick_asset_name("aider", None, "riscv64", "linux", "0.50.0", "v0.50.0", &avail),
             None
         );
+    }
+
+    // ── atomic_install_binary ────────────────────────────────────────────
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_install_replaces_content_and_marks_executable() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dst = tmp.path().join("subdir").join("agent-bin");
+        // A stale, non-executable file already sits at the install path.
+        fs::create_dir_all(dst.parent().unwrap()).unwrap();
+        fs::write(&dst, b"OLD BINARY").unwrap();
+        fs::set_permissions(&dst, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let src = tmp.path().join("freshly-downloaded");
+        fs::write(&src, b"NEW BINARY CONTENT").unwrap();
+
+        atomic_install_binary(&src, &dst).expect("install");
+
+        assert_eq!(fs::read(&dst).unwrap(), b"NEW BINARY CONTENT");
+        let mode = fs::metadata(&dst).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755, "installed binary must be executable");
+
+        // No `.agent-bin.unleash-install.*` temp turd left behind.
+        let leftovers: Vec<_> = fs::read_dir(dst.parent().unwrap())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().contains("unleash-install"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked: {leftovers:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_install_swaps_inode_instead_of_writing_in_place() {
+        // Regression for #353 "remaining binary install/copy paths atomic":
+        // the previous `fs::copy(src, dst)` opened `dst` and truncated it *in
+        // place*, mutating the inode. Any other reference to that inode — a
+        // running process's executable image, or a hard link — would observe
+        // the half-written / replaced bytes. The atomic helper renames a fresh
+        // inode into place, so existing references keep seeing the old binary.
+        //
+        // A hard link is a deterministic, root-safe stand-in for "the currently
+        // running binary". With the old direct-copy behavior this test FAILS:
+        // the link reads NEW because it shares the truncated-in-place inode.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dst = tmp.path().join("agent-bin");
+        fs::write(&dst, b"OLD BINARY").unwrap();
+
+        let other_ref = tmp.path().join("agent-bin.inuse");
+        fs::hard_link(&dst, &other_ref).expect("hard link");
+
+        let src = tmp.path().join("freshly-downloaded");
+        fs::write(&src, b"NEW BINARY").unwrap();
+
+        atomic_install_binary(&src, &dst).expect("install");
+
+        assert_eq!(fs::read(&dst).unwrap(), b"NEW BINARY", "dst updated");
+        assert_eq!(
+            fs::read(&other_ref).unwrap(),
+            b"OLD BINARY",
+            "prior reference must still see the old inode (atomic swap, not in-place write)"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_install_leaves_no_partial_on_missing_source() {
+        // A failed install (source vanished) must not leave a partial temp file
+        // or a truncated destination behind.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dst = tmp.path().join("agent-bin");
+        fs::write(&dst, b"GOOD EXISTING").unwrap();
+
+        let missing = tmp.path().join("does-not-exist");
+        let r = atomic_install_binary(&missing, &dst);
+        assert!(r.is_err(), "install from missing source must error");
+
+        // Existing good binary untouched, no temp turd.
+        assert_eq!(fs::read(&dst).unwrap(), b"GOOD EXISTING");
+        let leftovers: Vec<_> = fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().contains("unleash-install"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file leaked: {leftovers:?}");
     }
 }

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1810,15 +1810,23 @@ pub(crate) fn atomic_install_binary(
     let file_name = dst.file_name().and_then(|n| n.to_str()).unwrap_or("binary");
     let tmp_prefix = format!(".{file_name}.unleash-install.");
 
-    // Self-heal: sweep any stale temp a previous hard-killed install (SIGKILL
-    // between copy and rename) may have leaked into this directory.
+    // Self-heal: sweep temps a previous hard-killed install (SIGKILL between
+    // copy and rename) leaked here. Each temp carries the writer's pid as its
+    // suffix; skip any whose pid is still a live process so we never delete a
+    // *concurrent* install's in-flight temp (that racer's rename would then hit
+    // ENOENT). On non-Linux the `/proc` probe just returns false and the temp
+    // is treated as stale — a benign race, since same-binary concurrent
+    // installs are operator error and the atomic rename still protects `dst`.
     if let Ok(entries) = fs::read_dir(dir) {
         for entry in entries.flatten() {
-            if entry
-                .file_name()
-                .to_str()
-                .is_some_and(|n| n.starts_with(&tmp_prefix))
-            {
+            let name = entry.file_name();
+            let Some(rest) = name.to_str().and_then(|n| n.strip_prefix(&tmp_prefix)) else {
+                continue;
+            };
+            let pid_is_live = rest
+                .parse::<u32>()
+                .is_ok_and(|pid| std::path::Path::new(&format!("/proc/{pid}")).exists());
+            if !pid_is_live {
                 let _ = fs::remove_file(entry.path());
             }
         }
@@ -1826,7 +1834,8 @@ pub(crate) fn atomic_install_binary(
 
     // Temp file in the destination directory (guarantees same filesystem, so
     // the rename below is atomic rather than a cross-device copy). The pid
-    // keeps concurrent unleash processes from colliding on the same name.
+    // suffix keeps concurrent unleash installs from colliding on the same name
+    // and lets the sweep above tell a live racer's temp from a stale one.
     let tmp = dir.join(format!("{tmp_prefix}{}", std::process::id()));
 
     let staged = (|| -> io::Result<u64> {
@@ -3038,6 +3047,29 @@ mod tests {
 
         assert!(!stale.exists(), "stale temp must be swept");
         assert_eq!(fs::read(&dst).unwrap(), b"NEW BINARY");
+    }
+
+    #[cfg(all(unix, target_os = "linux"))]
+    #[test]
+    fn atomic_install_preserves_live_concurrent_temp() {
+        // The sweep must NOT delete a concurrent install's in-flight temp: a
+        // temp suffixed with a live pid (our own) is left alone, while one
+        // suffixed with a dead pid is swept.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dst = tmp.path().join("agent-bin");
+        // pid 1 (init) is always live; avoids colliding with the helper's own
+        // staging temp, which uses our pid.
+        let live = tmp.path().join(".agent-bin.unleash-install.1");
+        let dead = tmp.path().join(".agent-bin.unleash-install.999999");
+        fs::write(&live, b"racer in-flight").unwrap();
+        fs::write(&dead, b"stale leak").unwrap();
+
+        let src = tmp.path().join("freshly-downloaded");
+        fs::write(&src, b"NEW BINARY").unwrap();
+        atomic_install_binary(&src, &dst).expect("install");
+
+        assert!(live.exists(), "live concurrent temp must be preserved");
+        assert!(!dead.exists(), "dead-pid stale temp must be swept");
     }
 
     #[cfg(unix)]

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1790,7 +1790,15 @@ pub(crate) fn pick_asset_name(
 /// Returns the number of bytes copied. On any error the temp file is
 /// removed so a failed install never leaks a partial file into the
 /// install directory.
-fn atomic_install_binary(src: &std::path::Path, dst: &std::path::Path) -> io::Result<u64> {
+///
+/// Note: unlike a direct `fs::copy`, if `dst` is a symlink this replaces the
+/// link with a regular file (rename swaps the directory entry) rather than
+/// writing through to the link target — the intended behavior for an install
+/// path.
+pub(crate) fn atomic_install_binary(
+    src: &std::path::Path,
+    dst: &std::path::Path,
+) -> io::Result<u64> {
     let dir = dst.parent().ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -1799,11 +1807,27 @@ fn atomic_install_binary(src: &std::path::Path, dst: &std::path::Path) -> io::Re
     })?;
     fs::create_dir_all(dir)?;
 
+    let file_name = dst.file_name().and_then(|n| n.to_str()).unwrap_or("binary");
+    let tmp_prefix = format!(".{file_name}.unleash-install.");
+
+    // Self-heal: sweep any stale temp a previous hard-killed install (SIGKILL
+    // between copy and rename) may have leaked into this directory.
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            if entry
+                .file_name()
+                .to_str()
+                .is_some_and(|n| n.starts_with(&tmp_prefix))
+            {
+                let _ = fs::remove_file(entry.path());
+            }
+        }
+    }
+
     // Temp file in the destination directory (guarantees same filesystem, so
     // the rename below is atomic rather than a cross-device copy). The pid
     // keeps concurrent unleash processes from colliding on the same name.
-    let file_name = dst.file_name().and_then(|n| n.to_str()).unwrap_or("binary");
-    let tmp = dir.join(format!(".{file_name}.unleash-install.{}", std::process::id()));
+    let tmp = dir.join(format!("{tmp_prefix}{}", std::process::id()));
 
     let staged = (|| -> io::Result<u64> {
         let n = fs::copy(src, &tmp)?;
@@ -2995,6 +3019,25 @@ mod tests {
             b"OLD BINARY",
             "prior reference must still see the old inode (atomic swap, not in-place write)"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_install_sweeps_stale_temp_from_hard_killed_run() {
+        // A prior install SIGKILL'd between copy and rename leaves a
+        // `.agent-bin.unleash-install.<pid>` turd. The next install must
+        // self-heal by sweeping it, not accumulate leaked temps.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dst = tmp.path().join("agent-bin");
+        let stale = tmp.path().join(".agent-bin.unleash-install.999999");
+        fs::write(&stale, b"leaked partial").unwrap();
+
+        let src = tmp.path().join("freshly-downloaded");
+        fs::write(&src, b"NEW BINARY").unwrap();
+        atomic_install_binary(&src, &dst).expect("install");
+
+        assert!(!stale.exists(), "stale temp must be swept");
+        assert_eq!(fs::read(&dst).unwrap(), b"NEW BINARY");
     }
 
     #[cfg(unix)]

--- a/src/version.rs
+++ b/src/version.rs
@@ -1167,14 +1167,7 @@ impl VersionManager {
             });
         }
 
-        fs::copy(&extracted_binary, &install_path)?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&install_path)?.permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&install_path, perms)?;
-        }
+        crate::agents::atomic_install_binary(&extracted_binary, &install_path)?;
 
         let _ = fs::remove_dir_all(&tmp_dir);
 
@@ -1741,14 +1734,10 @@ impl VersionManager {
             "Installing binary to {}...",
             install_path.display()
         ));
-        fs::copy(&extracted_binary, &install_path)?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(&install_path)?.permissions();
-            perms.set_mode(0o755);
-            fs::set_permissions(&install_path, perms)?;
-        }
+        // Atomic install: stage + chmod + rename so switching codex versions
+        // while a codex agent is running can't hit ETXTBSY or leave a partial
+        // binary at the canonical path.
+        crate::agents::atomic_install_binary(&extracted_binary, &install_path)?;
 
         let _ = fs::remove_dir_all(&tmp_dir);
 


### PR DESCRIPTION
## Summary

Closes the **atomic install** item in #353: *"Make remaining binary install/copy paths atomic or otherwise crash-safe where applicable."*

Commit `5008aeb` made the **shell installers** stage-and-rename. This PR closes the remaining **Rust** paths, which wrote binaries directly onto their canonical install path via `fs::copy(src, install_path)` + chmod-after.

### Failure modes fixed
1. **Partial binary on crash** — a crash/interrupt mid-`fs::copy` leaves a truncated, executable-looking binary at the install path; a later run executes a corrupt agent instead of failing cleanly.
2. **`ETXTBSY` ("Text file busy")** — overwriting a currently-running executable fails, because `fs::copy` opens the target for writing.

### Approach
New `atomic_install_binary(src, dst)` (`pub(crate)`):
- copies to a temp file **in the destination directory** (same filesystem → atomic rename),
- `chmod 0o755` on the temp *before* it is visible,
- `fs::rename` into place (inode swap, not in-place mutation),
- removes the temp on any error, and **self-heals** by sweeping stale temps a prior SIGKILL'd install may have leaked.

### Sites converted
- `agents.rs`: custom-agent plain + extracted binary, Codex prebuilt + source-build, `install_extracted_binary`.
- `version.rs`: `install_codex_version_streaming` (**LIVE** — TUI version picker) and `install_codex_version` (was `#[allow(dead_code)]`). *(Added after cross-review — the first pass missed these.)*

Redundant post-copy `chmod` blocks removed. `updater.rs` self-update already stages+`mv`; skillsync/sandbox `fs::copy` sites are non-binary (out of scope).

### Behavior note
Unlike direct `fs::copy`, installing over a **symlink** now replaces the link with a regular file (rename swaps the directory entry) rather than writing through to the target — the intended behavior for an install path.

### Tests (proven to fail against the old direct-copy)
- `atomic_install_swaps_inode_instead_of_writing_in_place` — a hard link (deterministic, root-safe stand-in for the running binary) still sees the old bytes after install.
- `atomic_install_replaces_content_and_marks_executable` — content replaced, result is `0o755`, no temp turd.
- `atomic_install_sweeps_stale_temp_from_hard_killed_run` — leaked temp is swept on the next install.
- `atomic_install_leaves_no_partial_on_missing_source` — a failed install leaves dst intact and no leftover temp.

`cargo clippy --lib` clean; 687 lib tests pass.

Part of #353. _(Cross-reviewed by claude-casa; UN-1/2 fixed, UN-3/4 addressed.)_