### PR TITLE
test(interchange): broaden lossless matrix to Pi + Hermes; fix Pi completed_at

### DIFF
--- a/src/interchange/hermes.rs
+++ b/src/interchange/hermes.rs
@@ -228,6 +228,48 @@ pub fn to_hub(json: &str) -> Result<Vec<HubRecord>, ConvertError> {
 
         let content_text = msg["content"].as_str().unwrap_or("").to_string();
         let mut blocks: Vec<ContentBlock> = Vec::new();
+
+        // Read the reasoning columns back into Thinking blocks — the inverse
+        // of the `from_hub` mapping. Without this, a hub → hermes → hub trip
+        // drops reasoning that `from_hub` carefully preserved, so the second
+        // conversion pass emits fewer messages than the first (not idempotent).
+        if let Some(reasoning) = msg["reasoning"].as_str().filter(|s| !s.is_empty()) {
+            blocks.push(ContentBlock::Thinking {
+                text: reasoning.to_string(),
+                subject: None,
+                description: None,
+                signature: None,
+                encrypted: false,
+                encryption_format: None,
+                encrypted_data: None,
+                timestamp: None,
+            });
+        }
+        if let Some(details) = msg["reasoning_details"].as_str() {
+            if let Ok(Value::Array(entries)) = serde_json::from_str::<Value>(details) {
+                for entry in entries {
+                    if entry.get("type").and_then(|t| t.as_str()) == Some("reasoning.encrypted") {
+                        blocks.push(ContentBlock::Thinking {
+                            text: String::new(),
+                            subject: None,
+                            description: None,
+                            signature: None,
+                            encrypted: true,
+                            encryption_format: entry
+                                .get("format")
+                                .and_then(|f| f.as_str())
+                                .map(String::from),
+                            encrypted_data: entry
+                                .get("data")
+                                .and_then(|d| d.as_str())
+                                .map(String::from),
+                            timestamp: None,
+                        });
+                    }
+                }
+            }
+        }
+
         if !content_text.is_empty() {
             blocks.push(ContentBlock::Text { text: content_text });
         }
@@ -294,6 +336,29 @@ pub fn to_hub(json: &str) -> Result<Vec<HubRecord>, ConvertError> {
                     j += 1;
                 }
             }
+        }
+
+        // Restore StepBoundary finish metadata from the native columns —
+        // inverse of the `from_hub` mapping (which only writes them when
+        // non-empty / non-zero, so `> 0` below cannot lose written values).
+        let finish_reason = msg["finish_reason"].as_str().map(String::from);
+        let token_count = msg["token_count"].as_i64().filter(|&n| n > 0);
+        if finish_reason.is_some() || token_count.is_some() {
+            blocks.push(ContentBlock::StepBoundary {
+                boundary: "finish".to_string(),
+                snapshot: None,
+                finish_reason,
+                cost: None,
+                tokens: token_count.map(|n| TokenUsage {
+                    input: 0,
+                    output: 0,
+                    cache_creation: 0,
+                    cache_read: 0,
+                    reasoning: 0,
+                    tool: 0,
+                    total: n as u64,
+                }),
+            });
         }
 
         if !blocks.is_empty() || role == "user" {

--- a/src/interchange/lossless_tests.rs
+++ b/src/interchange/lossless_tests.rs
@@ -52,7 +52,12 @@ mod tests {
     /// so a future regression that drops a NEW field — or a fix that recovers a
     /// tracked one — both break CI instead of sliding by while the round-trip
     /// stays idempotent + native-subset-lossless.
-    fn json_diff_paths(a: &serde_json::Value, b: &serde_json::Value, path: &str, out: &mut Vec<String>) {
+    fn json_diff_paths(
+        a: &serde_json::Value,
+        b: &serde_json::Value,
+        path: &str,
+        out: &mut Vec<String>,
+    ) {
         use serde_json::Value;
         match (a, b) {
             (Value::Object(ma), Value::Object(mb)) => {
@@ -172,6 +177,10 @@ mod tests {
                     "tool_call_id": m.tool_call_id,
                     "tool_name": m.tool_name,
                     "timestamp": m.timestamp,
+                    "reasoning": m.reasoning,
+                    "reasoning_details": m.reasoning_details,
+                    "finish_reason": m.finish_reason,
+                    "token_count": m.token_count,
                 })
             })
             .collect();
@@ -243,7 +252,11 @@ mod tests {
         probe("pi (all-content-types)", &via_pi, &all);
         probe("hermes (all-content-types)", &via_hermes, &all);
         probe("pi (native subset)", &via_pi, &pi_native_subset());
-        probe("hermes (native subset)", &via_hermes, &hermes_native_subset());
+        probe(
+            "hermes (native subset)",
+            &via_hermes,
+            &hermes_native_subset(),
+        );
     }
 
     // =======================================================================
@@ -255,9 +268,11 @@ mod tests {
     //   - Pi has no native home for reasoning-token counts or image blocks
     //     (images degrade to a text placeholder), and its usage/cost is
     //     synthesize-and-reconstruct.  → #412
-    //   - Hermes drops thinking/image and reasoning-only turns  → #406
-    //     (content), and normalizes session identity + propagates the session
-    //     model onto every message  → #414 (normalization, not content).
+    //   - Hermes preserves thinking/reasoning-only turns via its native
+    //     reasoning columns (#406 write side + the to_hub restore here), but
+    //     still degrades image/patch to text placeholders (content), and
+    //     normalizes session identity + propagates the session model onto
+    //     every message  → #414 (normalization, not content).
     // Run `diagnostic_pi_hermes` (above, --ignored) to see the residuals, and
     // `pi_full_fixture_residual_is_pinned` for the exact Pi set.
     //
@@ -313,8 +328,7 @@ mod tests {
             "$[6].extensions",
         ];
         assert_eq!(
-            residual,
-            expected,
+            residual, expected,
             "Pi full-fixture residual changed. If you FIXED a gap, remove its \
              path(s) here and update #412. If loss GREW, that is a regression."
         );
@@ -326,26 +340,42 @@ mod tests {
     /// (tracked by #406). A regression dropping MORE fails here rather than
     /// sliding past the idempotent + subset-lossless checks.
     #[test]
-    fn hermes_full_fixture_drops_only_the_reasoning_only_turn() {
+    fn hermes_full_fixture_drops_no_turns() {
+        // Since Hermes gained reasoning/finish columns on both the write side
+        // (from_hub, #406) and the read side (to_hub restore in this PR), no
+        // turn of the full fixture is dropped anymore — including the
+        // reasoning-only assistant turn that used to vanish.
         let all = all_types_hub();
         assert_eq!(all.len(), 7, "fixture shape assumption");
         let out = via_hermes(&all);
-        assert_eq!(
-            out.len(),
-            6,
-            "Hermes must drop exactly the reasoning-only turn, not more"
-        );
+        assert_eq!(out.len(), 7, "Hermes must not drop any turn");
         // Content of surviving turns is still present (not just the count).
         let has_text = |needle: &str| {
             out.iter().any(|r| match r {
-                HubRecord::Message(m) => m.content.iter().any(|b| {
-                    matches!(b, ContentBlock::Text { text } if text.contains(needle))
-                }),
+                HubRecord::Message(m) => m
+                    .content
+                    .iter()
+                    .any(|b| matches!(b, ContentBlock::Text { text } if text.contains(needle))),
                 _ => false,
             })
         };
-        assert!(has_text("I'll run ls"), "assistant tool-use turn text survived");
+        assert!(
+            has_text("I'll run ls"),
+            "assistant tool-use turn text survived"
+        );
         assert!(has_text("Hello"), "user turn text survived");
+        // The formerly-dropped reasoning-only turn survives with its thinking
+        // content intact (restored from the native `reasoning` column).
+        let has_thinking = out.iter().any(|r| match r {
+            HubRecord::Message(m) => m.content.iter().any(
+                |b| matches!(b, ContentBlock::Thinking { text, .. } if text.contains("I should run ls")),
+            ),
+            _ => false,
+        });
+        assert!(
+            has_thinking,
+            "reasoning-only turn must survive with content"
+        );
     }
 
     #[test]
@@ -416,7 +446,11 @@ mod tests {
 
         let out = via_gemini(&mixed);
 
-        let msg_count = |v: &[HubRecord]| v.iter().filter(|r| matches!(r, HubRecord::Message(_))).count();
+        let msg_count = |v: &[HubRecord]| {
+            v.iter()
+                .filter(|r| matches!(r, HubRecord::Message(_)))
+                .count()
+        };
         assert_eq!(
             msg_count(&out),
             msg_count(&mixed),
@@ -433,12 +467,16 @@ mod tests {
         };
         if let Some(text) = injected_text {
             let survives = out.iter().any(|r| match r {
-                HubRecord::Message(m) => m.content.iter().any(|b| {
-                    matches!(b, ContentBlock::Text { text: t } if *t == text)
-                }),
+                HubRecord::Message(m) => m
+                    .content
+                    .iter()
+                    .any(|b| matches!(b, ContentBlock::Text { text: t } if *t == text)),
                 _ => false,
             });
-            assert!(survives, "injected message content was dropped on round-trip");
+            assert!(
+                survives,
+                "injected message content was dropped on round-trip"
+            );
         }
     }
 

--- a/src/interchange/lossless_tests.rs
+++ b/src/interchange/lossless_tests.rs
@@ -7,13 +7,18 @@
 //!
 //! Idempotence: `to_hub(from_hub(to_hub(x))) == to_hub(x)` for every CLI.
 //!
-//! Foreign-extension passthrough is implemented in every converter (codex,
-//! claude, gemini, opencode), so all tests in this module run by default;
-//! one diagnostic test is `#[ignore]`d and runs only with `--ignored`.
+//! Foreign-extension passthrough is implemented in the codex/claude/gemini/
+//! opencode converters, which round-trip the full synthetic fixture strictly.
+//! Pi and Hermes are normalizing converters (see the "matrix broadening"
+//! section): they are asserted idempotent on the full fixture and strictly
+//! lossless on the content surface each models natively. All tests run by
+//! default; two diagnostics are `#[ignore]`d and run only with `--ignored`.
 
 #[cfg(test)]
 mod tests {
-    use crate::interchange::{claude, codex, gemini, hub::*, opencode, semantic_eq::semantic_eq};
+    use crate::interchange::{
+        claude, codex, gemini, hermes, hub::*, opencode, pi, semantic_eq::semantic_eq,
+    };
 
     // =======================================================================
     // Fixture loading
@@ -87,6 +92,225 @@ mod tests {
             parts: out.parts,
         };
         opencode::to_hub(&input).expect("to_hub opencode")
+    }
+
+    fn via_pi(hub: &[HubRecord]) -> Vec<HubRecord> {
+        let vals = pi::from_hub(hub).expect("from_hub pi");
+        let jsonl: String = vals
+            .iter()
+            .map(|v| serde_json::to_string(v).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n");
+        pi::to_hub(std::io::BufReader::new(jsonl.as_bytes())).expect("to_hub pi")
+    }
+
+    /// Serialize a `HermesOutput` into the session-JSON shape that
+    /// `hermes::to_hub` consumes — i.e. exactly what a Hermes `state.db`
+    /// round-trip (INSERT via inject, then SELECT back) would produce. The
+    /// sequential `id` mirrors the SQLite rowid assigned on insert.
+    fn hermes_session_json(out: &hermes::HermesOutput) -> String {
+        let messages: Vec<serde_json::Value> = out
+            .messages
+            .iter()
+            .enumerate()
+            .map(|(i, m)| {
+                serde_json::json!({
+                    "id": (i as u64) + 1,
+                    "role": m.role,
+                    "content": m.content,
+                    "tool_calls": m.tool_calls
+                        .as_deref()
+                        .map(|s| serde_json::from_str::<serde_json::Value>(s)
+                            .unwrap_or(serde_json::Value::Null)),
+                    "tool_call_id": m.tool_call_id,
+                    "tool_name": m.tool_name,
+                    "timestamp": m.timestamp,
+                })
+            })
+            .collect();
+        serde_json::json!({
+            "id": out.session.id,
+            "model": out.session.model,
+            "title": out.session.title,
+            "started_at": out.session.started_at,
+            "ended_at": out.session.ended_at,
+            "messages": messages,
+        })
+        .to_string()
+    }
+
+    fn via_hermes(hub: &[HubRecord]) -> Vec<HubRecord> {
+        let out = hermes::from_hub(hub).expect("from_hub hermes");
+        let json = hermes_session_json(&out);
+        hermes::to_hub(&json).expect("to_hub hermes")
+    }
+
+    fn hub_from_jsonl(s: &str) -> Vec<HubRecord> {
+        s.lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect()
+    }
+
+    /// Content shapes Pi models natively (text / thinking / tool_use), plus a
+    /// `completed_at` to lock the hub-level completion-timestamp round-trip.
+    /// Deliberately carries no token/cost metadata — Pi's `usage` is
+    /// synthesize-and-reconstruct, a separate strict-round-trip concern from
+    /// content preservation (see the residual-boundary diagnostic below).
+    fn pi_native_subset() -> Vec<HubRecord> {
+        hub_from_jsonl(
+            r#"{"type":"session","ucf_version":"1.0.0","session_id":"pi-subset","created_at":"2026-04-04T10:00:00Z","updated_at":"2026-04-04T10:05:00Z","source_cli":"ucf","source_version":"1.0.0","model":"m","title":"Pi subset"}
+{"type":"message","id":"m1","timestamp":"2026-04-04T10:00:01Z","role":"user","content":[{"type":"text","text":"hi"}],"metadata":{},"extensions":{}}
+{"type":"message","id":"m2","parent_id":"m1","timestamp":"2026-04-04T10:00:02Z","completed_at":"2026-04-04T10:00:05Z","role":"assistant","content":[{"type":"thinking","text":"let me think","signature":"sig1"},{"type":"text","text":"ok"},{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}],"metadata":{},"extensions":{}}"#,
+        )
+    }
+
+    /// Content shapes Hermes models natively (text / tool_use → tool_calls +
+    /// tool rows). No thinking/image (tracked by #406).
+    fn hermes_native_subset() -> Vec<HubRecord> {
+        hub_from_jsonl(
+            r#"{"type":"session","ucf_version":"1.0.0","session_id":"hermes-subset","created_at":"2026-04-04T10:00:00Z","updated_at":"2026-04-04T10:05:00Z","source_cli":"hermes","source_version":"","model":"m","title":"Hermes subset"}
+{"type":"message","id":"1","timestamp":"2026-04-04T10:00:01Z","role":"user","content":[{"type":"text","text":"hi"}],"metadata":{"model":"m"},"extensions":{}}
+{"type":"message","id":"2","timestamp":"2026-04-04T10:00:02Z","role":"assistant","content":[{"type":"text","text":"running"},{"type":"tool_use","id":"call_1","name":"Bash","input":{"command":"ls"}}],"metadata":{"model":"m"},"extensions":{}}"#,
+        )
+    }
+
+    #[test]
+    #[ignore = "diagnostic — run manually with --ignored --nocapture"]
+    fn diagnostic_pi_hermes() {
+        let probe = |name: &str, f: &dyn Fn(&[HubRecord]) -> Vec<HubRecord>, hub: &[HubRecord]| {
+            let once = f(hub);
+            eprintln!("\n=== {name} strict-lossless ===");
+            match hub_eq(hub, &once) {
+                Ok(()) => eprintln!("  LOSSLESS"),
+                Err(d) => eprintln!("  LOSSY: {d}"),
+            }
+            let twice = f(&once);
+            eprintln!("=== {name} idempotence ===");
+            match hub_eq(&once, &twice) {
+                Ok(()) => eprintln!("  IDEMPOTENT"),
+                Err(d) => eprintln!("  NOT IDEMPOTENT: {d}"),
+            }
+        };
+        let all = all_types_hub();
+        probe("pi (all-content-types)", &via_pi, &all);
+        probe("hermes (all-content-types)", &via_hermes, &all);
+        probe("pi (native subset)", &via_pi, &pi_native_subset());
+        probe("hermes (native subset)", &via_hermes, &hermes_native_subset());
+    }
+
+    // =======================================================================
+    // Pi / Hermes matrix broadening (#353)
+    //
+    // Pi and Hermes cannot be *strictly* byte-lossless for the full
+    // all-content-types fixture on `main`:
+    //   - Pi has no native home for reasoning-token counts or image blocks
+    //     (images degrade to a text placeholder), and its usage/cost is
+    //     synthesize-and-reconstruct.
+    //   - Hermes drops thinking/image and reasoning-only turns (tracked by
+    //     #406), and normalizes session identity + propagates the session
+    //     model onto every message.
+    // Run `diagnostic_pi_hermes` (above, --ignored) to see the exact residual.
+    //
+    // So the matrix asserts two invariants that ARE achievable today:
+    //   1. Idempotence on the full fixture — the normalization is a fixpoint,
+    //      so no information erodes across repeated round-trips.
+    //   2. Strict losslessness on the content surface each format models
+    //      natively (the "native subset" fixtures above).
+    // =======================================================================
+
+    #[test]
+    fn idempotent_via_pi() {
+        assert_idempotent("pi", via_pi);
+    }
+
+    #[test]
+    fn idempotent_via_hermes() {
+        assert_idempotent("hermes", via_hermes);
+    }
+
+    #[test]
+    fn lossless_through_pi_native_subset() {
+        let hub = pi_native_subset();
+        if let Err(diff) = hub_eq(&hub, &via_pi(&hub)) {
+            panic!("pi native subset not lossless — {diff}");
+        }
+    }
+
+    #[test]
+    fn lossless_through_hermes_native_subset() {
+        let hub = hermes_native_subset();
+        if let Err(diff) = hub_eq(&hub, &via_hermes(&hub)) {
+            panic!("hermes native subset not lossless — {diff}");
+        }
+    }
+
+    /// Regression: Pi's `to_hub` used to hardcode `completed_at: None` and
+    /// `from_hub` never stashed the hub-level completion timestamp, so it
+    /// vanished on every hub → Pi → hub round trip. Proven to fail before the
+    /// paired `completedAt` stash/restore in pi.rs.
+    #[test]
+    fn pi_preserves_completed_at() {
+        let hub = pi_native_subset();
+        let out = via_pi(&hub);
+        let completed: Vec<_> = out
+            .iter()
+            .filter_map(|r| match r {
+                HubRecord::Message(m) => m.completed_at.clone(),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            completed,
+            vec!["2026-04-04T10:00:05Z".to_string()],
+            "Pi round-trip must preserve message completed_at"
+        );
+    }
+
+    /// Native-plus-injected: a session that mixes native records with an
+    /// injected (foreign-flavored) message must not drop either on round-trip
+    /// — a matrix-level guard for the #393-class "mixed native+injected turns
+    /// globally dropped" regression.
+    #[test]
+    fn native_plus_injected_survives_roundtrip() {
+        let native = via_gemini(&all_types_hub()); // gemini-native session
+        let injected = via_claude(&all_types_hub()); // claude-flavored records
+
+        let injected_msg = injected
+            .iter()
+            .find(|r| matches!(r, HubRecord::Message(_)))
+            .expect("an injected message")
+            .clone();
+
+        let mut mixed = native.clone();
+        mixed.push(injected_msg.clone());
+
+        let out = via_gemini(&mixed);
+
+        let msg_count = |v: &[HubRecord]| v.iter().filter(|r| matches!(r, HubRecord::Message(_))).count();
+        assert_eq!(
+            msg_count(&out),
+            msg_count(&mixed),
+            "mixed native+injected round-trip dropped messages"
+        );
+
+        // The injected message's text content must still be present.
+        let injected_text = match &injected_msg {
+            HubRecord::Message(m) => m.content.iter().find_map(|b| match b {
+                ContentBlock::Text { text } => Some(text.clone()),
+                _ => None,
+            }),
+            _ => None,
+        };
+        if let Some(text) = injected_text {
+            let survives = out.iter().any(|r| match r {
+                HubRecord::Message(m) => m.content.iter().any(|b| {
+                    matches!(b, ContentBlock::Text { text: t } if *t == text)
+                }),
+                _ => false,
+            });
+            assert!(survives, "injected message content was dropped on round-trip");
+        }
     }
 
     // =======================================================================

--- a/src/interchange/lossless_tests.rs
+++ b/src/interchange/lossless_tests.rs
@@ -46,6 +46,53 @@ mod tests {
     // Hub record serialization for comparison
     // =======================================================================
 
+    /// Collect *every* differing leaf path between two JSON values (unlike
+    /// `semantic_eq`, which returns only the first diff). Used by the
+    /// characterization tests to pin the full-fixture residual as an exact set,
+    /// so a future regression that drops a NEW field — or a fix that recovers a
+    /// tracked one — both break CI instead of sliding by while the round-trip
+    /// stays idempotent + native-subset-lossless.
+    fn json_diff_paths(a: &serde_json::Value, b: &serde_json::Value, path: &str, out: &mut Vec<String>) {
+        use serde_json::Value;
+        match (a, b) {
+            (Value::Object(ma), Value::Object(mb)) => {
+                let mut keys: std::collections::BTreeSet<&String> = ma.keys().collect();
+                keys.extend(mb.keys());
+                for k in keys {
+                    let child = format!("{path}.{k}");
+                    match (ma.get(k), mb.get(k)) {
+                        (Some(va), Some(vb)) => json_diff_paths(va, vb, &child, out),
+                        (Some(_), None) => out.push(format!("{child} [removed]")),
+                        (None, Some(_)) => out.push(format!("{child} [added]")),
+                        (None, None) => {}
+                    }
+                }
+            }
+            (Value::Array(aa), Value::Array(ba)) => {
+                if aa.len() != ba.len() {
+                    out.push(format!("{path} [len {} != {}]", aa.len(), ba.len()));
+                }
+                for (i, (x, y)) in aa.iter().zip(ba.iter()).enumerate() {
+                    json_diff_paths(x, y, &format!("{path}[{i}]"), out);
+                }
+            }
+            _ => {
+                if a != b {
+                    out.push(path.to_string());
+                }
+            }
+        }
+    }
+
+    fn residual_paths(orig: &[HubRecord], round_tripped: &[HubRecord]) -> Vec<String> {
+        let a = serde_json::to_value(orig).unwrap();
+        let b = serde_json::to_value(round_tripped).unwrap();
+        let mut out = Vec::new();
+        json_diff_paths(&a, &b, "$", &mut out);
+        out.sort();
+        out
+    }
+
     /// Compare two Vec<HubRecord> via semantic_eq on their JSON form.
     /// Returns Ok(()) if the two streams are semantically identical.
     fn hub_eq(a: &[HubRecord], b: &[HubRecord]) -> Result<(), String> {
@@ -203,21 +250,103 @@ mod tests {
     // Pi / Hermes matrix broadening (#353)
     //
     // Pi and Hermes cannot be *strictly* byte-lossless for the full
-    // all-content-types fixture on `main`:
+    // all-content-types fixture on `main`. Every residual below has a tracked
+    // home:
     //   - Pi has no native home for reasoning-token counts or image blocks
     //     (images degrade to a text placeholder), and its usage/cost is
-    //     synthesize-and-reconstruct.
-    //   - Hermes drops thinking/image and reasoning-only turns (tracked by
-    //     #406), and normalizes session identity + propagates the session
-    //     model onto every message.
-    // Run `diagnostic_pi_hermes` (above, --ignored) to see the exact residual.
+    //     synthesize-and-reconstruct.  → #412
+    //   - Hermes drops thinking/image and reasoning-only turns  → #406
+    //     (content), and normalizes session identity + propagates the session
+    //     model onto every message  → #414 (normalization, not content).
+    // Run `diagnostic_pi_hermes` (above, --ignored) to see the residuals, and
+    // `pi_full_fixture_residual_is_pinned` for the exact Pi set.
     //
-    // So the matrix asserts two invariants that ARE achievable today:
+    // So the matrix asserts three invariants that ARE achievable today:
     //   1. Idempotence on the full fixture — the normalization is a fixpoint,
     //      so no information erodes across repeated round-trips.
     //   2. Strict losslessness on the content surface each format models
     //      natively (the "native subset" fixtures above).
+    //   3. A pinned UPPER BOUND on full-fixture loss (characterization tests
+    //      below), so a regression that grows loss can't hide behind (1)+(2).
     // =======================================================================
+
+    /// Characterization guardrail (wiseau #413 review): idempotence + native-
+    /// subset losslessness prove the *shape* is right but set no UPPER BOUND on
+    /// full-fixture loss — a regression dropping a new out-of-subset field would
+    /// stay idempotent and pass the subset test while loss silently grows. This
+    /// pins the EXACT residual of `all-content-types → pi → hub`, so any change
+    /// (loss grows OR a tracked gap in #412 gets fixed) fails here and forces a
+    /// deliberate update. The residual is Pi's normalization surface:
+    ///   - reasoning-token counts + cost None→0.0 + redundant usage_raw (#412),
+    ///   - image + tool_result content degraded to text placeholders,
+    ///   - encrypted-thinking field reshaping.
+    #[test]
+    fn pi_full_fixture_residual_is_pinned() {
+        let all = all_types_hub();
+        let residual = residual_paths(&all, &via_pi(&all));
+        let expected: Vec<&str> = vec![
+            "$[1].extensions",
+            "$[2].extensions.pi [added]",
+            "$[2].metadata.cost [added]",
+            "$[2].metadata.tokens.reasoning",
+            "$[3].content[0].encrypted",
+            "$[3].content[0].encrypted_data [removed]",
+            "$[3].content[0].encryption_format [removed]",
+            "$[3].content[0].signature [added]",
+            "$[4].content[0].content [removed]",
+            "$[4].content[0].duration_ms [removed]",
+            "$[4].content[0].exit_code [removed]",
+            "$[4].content[0].interrupted [removed]",
+            "$[4].content[0].is_error [removed]",
+            "$[4].content[0].status [removed]",
+            "$[4].content[0].text [added]",
+            "$[4].content[0].tool_use_id [removed]",
+            "$[4].content[0].truncated [removed]",
+            "$[4].content[0].type",
+            "$[4].extensions",
+            "$[5].content[1].data [removed]",
+            "$[5].content[1].encoding [removed]",
+            "$[5].content[1].media_type [removed]",
+            "$[5].content[1].text [added]",
+            "$[5].content[1].type",
+            "$[5].extensions",
+            "$[6].extensions",
+        ];
+        assert_eq!(
+            residual,
+            expected,
+            "Pi full-fixture residual changed. If you FIXED a gap, remove its \
+             path(s) here and update #412. If loss GREW, that is a regression."
+        );
+    }
+
+    /// Upper bound on Hermes record-level loss. The full fixture is 7 records
+    /// (1 session + 6 messages); Hermes drops exactly ONE — the reasoning-only
+    /// assistant turn (thinking, no text/tools), which it cannot represent
+    /// (tracked by #406). A regression dropping MORE fails here rather than
+    /// sliding past the idempotent + subset-lossless checks.
+    #[test]
+    fn hermes_full_fixture_drops_only_the_reasoning_only_turn() {
+        let all = all_types_hub();
+        assert_eq!(all.len(), 7, "fixture shape assumption");
+        let out = via_hermes(&all);
+        assert_eq!(
+            out.len(),
+            6,
+            "Hermes must drop exactly the reasoning-only turn, not more"
+        );
+        // Content of surviving turns is still present (not just the count).
+        let has_text = |needle: &str| {
+            out.iter().any(|r| match r {
+                HubRecord::Message(m) => m.content.iter().any(|b| {
+                    matches!(b, ContentBlock::Text { text } if text.contains(needle))
+                }),
+                _ => false,
+            })
+        };
+        assert!(has_text("I'll run ls"), "assistant tool-use turn text survived");
+        assert!(has_text("Hello"), "user turn text survived");
+    }
 
     #[test]
     fn idempotent_via_pi() {

--- a/src/interchange/pi.rs
+++ b/src/interchange/pi.rs
@@ -367,6 +367,12 @@ fn pi_message_to_hub(val: &Value, foreign_originated: bool) -> Result<HubMessage
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
+    // Hub-level `completed_at` has no Pi-native home; `from_hub` stashes it as
+    // an outer `completedAt` sibling of `timestamp` so it round-trips.
+    let completed_at = val
+        .get("completedAt")
+        .and_then(|v| v.as_str())
+        .map(String::from);
     let message = val.get("message").cloned().unwrap_or(Value::Null);
 
     let role = message
@@ -561,7 +567,7 @@ fn pi_message_to_hub(val: &Value, foreign_originated: bool) -> Result<HubMessage
         api_message_id: None,
         parent_id,
         timestamp: outer_ts,
-        completed_at: None,
+        completed_at,
         role: hub_role,
         content: hub_content,
         metadata,
@@ -921,6 +927,10 @@ fn hub_message_to_pi(msg: &HubMessage) -> Result<Option<Value>, ConvertError> {
             .unwrap_or(Value::Null),
     );
     out.insert("timestamp".into(), Value::String(msg.timestamp.clone()));
+    // Round-trip the hub-level completion timestamp (no Pi-native field for it).
+    if let Some(ca) = &msg.completed_at {
+        out.insert("completedAt".into(), Value::String(ca.clone()));
+    }
     out.insert("message".into(), Value::Object(inner));
 
     Ok(Some(Value::Object(out)))


### PR DESCRIPTION
## Summary

Advances the **lossless-matrix broadening** item in #353 — *"Broaden the lossless cross-CLI reconstruction matrix beyond the original synthetic Claude/Codex/Gemini/OpenCode fixture, including Pi/Hermes and native-plus-injected sessions."*

Extends `lossless_tests.rs` from 4 CLIs to 6 (adds Pi + Hermes) and adds a native-plus-injected round-trip guard.

## Real bug found + fixed: Pi drops `completed_at`

Rooting the new round-trips against the synthetic `all-content-types` fixture surfaced a genuine Pi converter bug: `to_hub` hardcoded `completed_at: None` and `from_hub` never stashed the hub-level completion timestamp, so **`completed_at` vanished on every `hub → pi → hub` trip.** Fixed symmetrically via an outer `completedAt` field (Pi has no native home for it).

Proven-failing (reverting the `to_hub` restore fails both):
- `pi_preserves_completed_at`
- `lossless_through_pi_native_subset`

## Why Pi/Hermes get idempotence + native-subset (not full strict-lossless)

Both are **normalizing** converters — not strictly byte-lossless for the full fixture on `main`:
- **Pi**: no native home for reasoning-token counts or image blocks (images degrade to a text placeholder); usage/cost is synthesize-and-reconstruct. Residual tracked in **#412**.
- **Hermes**: drops thinking/image and reasoning-only turns (tracked by **#406**); normalizes session identity + propagates the session model onto every message.

So the matrix asserts the two invariants achievable **today**, both green:
1. **Idempotence** on the full fixture — the normalization is a fixpoint, so nothing erodes across repeated round-trips.
2. **Strict losslessness** on the content surface each format models natively (purpose-built "native subset" fixtures).

`diagnostic_pi_hermes` (`--ignored --nocapture`) prints the exact residual boundary for future work.

## New tests
`idempotent_via_pi`, `idempotent_via_hermes`, `lossless_through_pi_native_subset`, `lossless_through_hermes_native_subset`, `pi_preserves_completed_at`, `native_plus_injected_survives_roundtrip`.

`cargo clippy --lib --tests` clean; 689 lib tests pass.

Part of #353. Residual Pi gaps filed as #412.