### PR TITLE
fix(crossload): keep cache fresh across same-day edits and every compact + manual refresh button

### DIFF
--- a/plugins/bundled/supercompact/hooks-handlers/supercompact-compact.sh
+++ b/plugins/bundled/supercompact/hooks-handlers/supercompact-compact.sh
@@ -273,6 +273,21 @@ fi
 
 log "JSONL replaced successfully"
 
+# Invalidate any cached crossloads of this session. The transcript was just
+# rewritten in place, so a previously-crossloaded target (codex/gemini/...) now
+# points at pre-compact content — reusing it would resume a stale, often
+# over-budget conversation. A compact is a significant checkpoint, so we bust
+# the cache explicitly here rather than relying on the mtime freshness heuristic.
+# Best-effort: never block the restart on it. The source_id is the JSONL stem.
+SOURCE_ID=$(basename "${JSONL_FILE}" .jsonl)
+if [[ -n "${SOURCE_ID}" ]] && command -v unleash &>/dev/null; then
+  if unleash sessions crossload-bust "claude:${SOURCE_ID}" >/dev/null 2>&1; then
+    log "Crossload cache invalidated for claude:${SOURCE_ID}"
+  else
+    log "WARN: crossload-bust failed for claude:${SOURCE_ID} (non-fatal)"
+  fi
+fi
+
 # Clean up old backups (keep last 3 of each type)
 for pattern in ".pre-compact-full" ".pre-supercompact"; do
   ls -t "${JSONL_FILE}${pattern}"* 2>/dev/null | tail -n +4 | tr '\n' '\0' | xargs -0 rm -f 2>/dev/null || true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -816,6 +816,16 @@ pub enum SessionsAction {
         #[arg(long)]
         gc: bool,
     },
+
+    /// Evict cached crossloads for a session (all targets)
+    ///
+    /// Fired automatically at compaction checkpoints — a compact rewrites the
+    /// source transcript, so any cached crossload of it is now stale. Also
+    /// runnable by hand: `unleash sessions crossload-bust claude:abc12345`.
+    CrossloadBust {
+        /// Session identifier in `<cli>:<source_id>` form (e.g. claude:abc12345)
+        target: String,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -826,6 +826,18 @@ pub enum SessionsAction {
         /// Session identifier in `<cli>:<source_id>` form (e.g. claude:abc12345)
         target: String,
     },
+
+    /// Force crossloads to re-inject from current content (the manual button)
+    ///
+    /// Freshness normally handles itself (per-edit timestamp + per-compact
+    /// eviction). This is the escape hatch when it hasn't caught up: it drops
+    /// cached target sessions so the next `unleash <cli> -x …` rebuilds from
+    /// the live source. With a TARGET (`<cli>:<source_id>`) it refreshes just
+    /// that session; with no target it clears the entire crossload cache.
+    CrossloadRefresh {
+        /// Optional session id in `<cli>:<source_id>` form; omit to refresh all
+        target: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -13,6 +13,47 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use which::which;
 
+/// Default PreCompact hook script. Fires on EVERY compact (native or
+/// supercompact) and does two things:
+///  1. Evicts any cached crossloads of the session being compacted, so the next
+///     `unleash <cli> -x claude:<id>` re-injects from the compacted transcript
+///     instead of resuming a pre-compact (stale, often over-budget) target
+///     session. A compact is a significant checkpoint — this guarantees
+///     freshness independent of the mtime heuristic in inject::inject_session.
+///  2. Returns the "compaction complete" control message to Claude.
+///
+/// Kept as a const so `install_default_hooks` and `refresh_default_hook_scripts`
+/// share one source of truth.
+const DEFAULT_COMPACT_NOTIFY_SCRIPT: &str = r#"#!/usr/bin/env bash
+# compact-notify.sh - Evict stale crossload cache for this session, then tell
+# Claude compaction is complete. Fires on every compact via the PreCompact hook.
+
+set -uo pipefail
+
+# Read the hook payload (Claude Code pipes JSON: session_id, transcript_path, …).
+# Best-effort cache eviction — never let it break the hook's control output.
+payload="$(cat)"
+if command -v unleash >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+  src_id="$(printf '%s' "$payload" | jq -r '.transcript_path // empty' 2>/dev/null)"
+  if [ -n "$src_id" ]; then
+    src_id="$(basename "$src_id" .jsonl 2>/dev/null)"
+  else
+    src_id="$(printf '%s' "$payload" | jq -r '.session_id // empty' 2>/dev/null)"
+  fi
+  if [ -n "$src_id" ]; then
+    unleash sessions crossload-bust "claude:${src_id}" >/dev/null 2>&1 || true
+  fi
+fi
+
+# Output format for Claude Code hooks
+cat <<'EOF'
+{
+  "continue": true,
+  "message": "COMPACT COMPLETE. Previous context has been summarized. Continue with your current task."
+}
+EOF
+"#;
+
 /// Claude Code installation info
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClaudeInstallation {
@@ -398,29 +439,34 @@ impl HookManager {
     /// Install default hooks
     pub fn install_default_hooks(&self) -> io::Result<()> {
         // Install PreCompact hook
-        let compact_script = r#"#!/usr/bin/env bash
-# compact-notify.sh - Notify Claude that compaction is complete
-#
-# This hook runs after conversation compaction and returns a message
-# to help Claude understand what happened.
-
-set -euo pipefail
-
-# Output format for Claude Code hooks
-cat <<'EOF'
-{
-  "continue": true,
-  "message": "COMPACT COMPLETE. Previous context has been summarized. Continue with your current task."
-}
-EOF
-"#;
-
-        let script_path = self.install_hook_script("compact-notify.sh", compact_script)?;
+        let script_path =
+            self.install_hook_script("compact-notify.sh", DEFAULT_COMPACT_NOTIFY_SCRIPT)?;
         self.register_hook(HookEvent::PreCompact, script_path.to_str().unwrap(), None)?;
 
         println!("Installed default hooks:");
         println!("  - PreCompact: {}", script_path.display());
 
+        Ok(())
+    }
+
+    /// Rewrite the on-disk content of default (non-plugin) hook scripts to match
+    /// the current embedded versions, without touching settings.json
+    /// registration. Called on every launch so that fixes to a default hook
+    /// script (e.g. the crossload-cache eviction added to compact-notify.sh)
+    /// reach installs that already have the hook registered — `install_default_hooks`
+    /// itself only runs when the hook is *absent* (see launcher.rs).
+    ///
+    /// Idempotent and cheap: only writes when the content actually differs.
+    /// Skips silently if the hook was never installed (nothing to refresh).
+    pub fn refresh_default_hook_scripts(&self) -> io::Result<()> {
+        let path = self.hook_script_path("compact-notify.sh");
+        if !path.exists() {
+            return Ok(());
+        }
+        let current = fs::read_to_string(&path).unwrap_or_default();
+        if current != DEFAULT_COMPACT_NOTIFY_SCRIPT {
+            self.install_hook_script("compact-notify.sh", DEFAULT_COMPACT_NOTIFY_SCRIPT)?;
+        }
         Ok(())
     }
 
@@ -643,6 +689,39 @@ mod tests {
         HookEvent::UserPromptSubmit,
         HookEvent::SessionEnd,
     ];
+
+    #[test]
+    fn default_compact_hook_busts_crossload_cache() {
+        // The universal PreCompact hook must evict the crossload cache so a
+        // compact — native OR supercompact — forces a fresh crossload.
+        assert!(
+            DEFAULT_COMPACT_NOTIFY_SCRIPT.contains("crossload-bust"),
+            "compact-notify.sh must invoke `unleash sessions crossload-bust`"
+        );
+        // Must still emit the completion control message.
+        assert!(DEFAULT_COMPACT_NOTIFY_SCRIPT.contains("COMPACT COMPLETE"));
+    }
+
+    #[test]
+    fn refresh_default_hook_scripts_heals_stale_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mgr = test_manager(tmp.path());
+
+        // No hook installed yet → refresh is a silent no-op (nothing to heal).
+        mgr.refresh_default_hook_scripts().unwrap();
+        assert!(!mgr.hook_script_path("compact-notify.sh").exists());
+
+        // Simulate an OLD install: a compact-notify.sh without the bust logic.
+        let stale = "#!/usr/bin/env bash\necho stale\n";
+        mgr.install_hook_script("compact-notify.sh", stale).unwrap();
+
+        // Refresh must rewrite it to the current embedded version.
+        mgr.refresh_default_hook_scripts().unwrap();
+        let healed =
+            fs::read_to_string(mgr.hook_script_path("compact-notify.sh")).unwrap();
+        assert_eq!(healed, DEFAULT_COMPACT_NOTIFY_SCRIPT);
+        assert!(healed.contains("crossload-bust"));
+    }
 
     #[test]
     fn test_hook_event_roundtrip_all_variants() {

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -717,8 +717,7 @@ mod tests {
 
         // Refresh must rewrite it to the current embedded version.
         mgr.refresh_default_hook_scripts().unwrap();
-        let healed =
-            fs::read_to_string(mgr.hook_script_path("compact-notify.sh")).unwrap();
+        let healed = fs::read_to_string(mgr.hook_script_path("compact-notify.sh")).unwrap();
         assert_eq!(healed, DEFAULT_COMPACT_NOTIFY_SCRIPT);
         assert!(healed.contains("crossload-bust"));
     }

--- a/src/interchange/crossload_index.rs
+++ b/src/interchange/crossload_index.rs
@@ -99,6 +99,36 @@ impl CrossloadIndex {
     pub fn remove(&mut self, source_cli: &str, source_id: &str, target_cli: &str) {
         self.entries.remove(&key(source_cli, source_id, target_cli));
     }
+
+    /// Remove every cached crossload whose source is `<source_cli>:<source_id>`,
+    /// regardless of target. Returns the number of entries dropped.
+    ///
+    /// Used at compaction checkpoints: a compact rewrites the source transcript
+    /// in place, so any previously-cached crossload of that session now points
+    /// at pre-compact (stale, often over-budget) content. Evicting here forces
+    /// the next crossload to re-inject from the compacted source, independent of
+    /// the mtime-based freshness heuristic in `inject::inject_session`.
+    pub fn invalidate_source(&mut self, source_cli: &str, source_id: &str) -> usize {
+        // The `->` terminator keeps this from matching a longer source_id that
+        // merely shares this one as a prefix.
+        let prefix = format!("{source_cli}:{source_id}->");
+        let before = self.entries.len();
+        self.entries.retain(|k, _| !k.starts_with(&prefix));
+        before - self.entries.len()
+    }
+}
+
+/// Evict all cached crossloads whose source is `<source_cli>:<source_id>` and
+/// persist the result. Returns the number of entries removed (0 if none). Only
+/// writes when something was actually removed, so the common "nothing cached"
+/// path stays side-effect-free.
+pub fn bust_source(source_cli: &str, source_id: &str) -> io::Result<usize> {
+    let mut index = load();
+    let removed = index.invalidate_source(source_cli, source_id);
+    if removed > 0 {
+        save(&index)?;
+    }
+    Ok(removed)
 }
 
 /// True if the entry still points at a live target. File-backed targets check
@@ -318,6 +348,39 @@ mod tests {
         assert!(idx.lookup("a", "b", "c").is_some());
         idx.remove("a", "b", "c");
         assert!(idx.lookup("a", "b", "c").is_none());
+    }
+
+    #[test]
+    fn invalidate_source_evicts_all_targets_for_one_source() {
+        let mut idx = CrossloadIndex::default();
+        // Same source, two targets — both must go.
+        idx.record("claude", "hai", "codex", "t1".into(), "/tmp/t1".into(), None);
+        idx.record("claude", "hai", "gemini", "t2".into(), "/tmp/t2".into(), None);
+        // Different source that shares "hai" as a prefix — must be untouched
+        // (the `->` terminator guards against prefix bleed).
+        idx.record(
+            "claude",
+            "hai-2",
+            "codex",
+            "t3".into(),
+            "/tmp/t3".into(),
+            None,
+        );
+        // Unrelated source — untouched.
+        idx.record("codex", "other", "claude", "t4".into(), String::new(), None);
+
+        let removed = idx.invalidate_source("claude", "hai");
+        assert_eq!(removed, 2, "both claude:hai targets should be evicted");
+        assert!(idx.lookup("claude", "hai", "codex").is_none());
+        assert!(idx.lookup("claude", "hai", "gemini").is_none());
+        assert!(
+            idx.lookup("claude", "hai-2", "codex").is_some(),
+            "prefix-sharing source must survive"
+        );
+        assert!(idx.lookup("codex", "other", "claude").is_some());
+
+        // Second bust is a no-op.
+        assert_eq!(idx.invalidate_source("claude", "hai"), 0);
     }
 
     #[test]

--- a/src/interchange/crossload_index.rs
+++ b/src/interchange/crossload_index.rs
@@ -116,6 +116,14 @@ impl CrossloadIndex {
         self.entries.retain(|k, _| !k.starts_with(&prefix));
         before - self.entries.len()
     }
+
+    /// Drop every cached crossload entry. Returns the number removed. Backs the
+    /// manual `crossload-refresh` button (no target = clear the whole cache).
+    pub fn clear(&mut self) -> usize {
+        let n = self.entries.len();
+        self.entries.clear();
+        n
+    }
 }
 
 /// Evict all cached crossloads whose source is `<source_cli>:<source_id>` and
@@ -125,6 +133,17 @@ impl CrossloadIndex {
 pub fn bust_source(source_cli: &str, source_id: &str) -> io::Result<usize> {
     let mut index = load();
     let removed = index.invalidate_source(source_cli, source_id);
+    if removed > 0 {
+        save(&index)?;
+    }
+    Ok(removed)
+}
+
+/// Clear the entire crossload cache and persist. Returns the number of entries
+/// removed. Only writes when something was actually removed.
+pub fn bust_all() -> io::Result<usize> {
+    let mut index = load();
+    let removed = index.clear();
     if removed > 0 {
         save(&index)?;
     }
@@ -354,8 +373,22 @@ mod tests {
     fn invalidate_source_evicts_all_targets_for_one_source() {
         let mut idx = CrossloadIndex::default();
         // Same source, two targets — both must go.
-        idx.record("claude", "hai", "codex", "t1".into(), "/tmp/t1".into(), None);
-        idx.record("claude", "hai", "gemini", "t2".into(), "/tmp/t2".into(), None);
+        idx.record(
+            "claude",
+            "hai",
+            "codex",
+            "t1".into(),
+            "/tmp/t1".into(),
+            None,
+        );
+        idx.record(
+            "claude",
+            "hai",
+            "gemini",
+            "t2".into(),
+            "/tmp/t2".into(),
+            None,
+        );
         // Different source that shares "hai" as a prefix — must be untouched
         // (the `->` terminator guards against prefix bleed).
         idx.record(
@@ -381,6 +414,17 @@ mod tests {
 
         // Second bust is a no-op.
         assert_eq!(idx.invalidate_source("claude", "hai"), 0);
+    }
+
+    #[test]
+    fn clear_evicts_everything() {
+        let mut idx = CrossloadIndex::default();
+        idx.record("claude", "a", "codex", "t1".into(), "/tmp/t1".into(), None);
+        idx.record("codex", "b", "claude", "t2".into(), String::new(), None);
+        assert_eq!(idx.clear(), 2);
+        assert!(idx.lookup("claude", "a", "codex").is_none());
+        assert!(idx.lookup("codex", "b", "claude").is_none());
+        assert_eq!(idx.clear(), 0, "second clear is a no-op");
     }
 
     #[test]

--- a/src/interchange/sessions.rs
+++ b/src/interchange/sessions.rs
@@ -714,7 +714,18 @@ fn format_epoch_ms(ms: u64) -> String {
     let remaining_days = days - years * 365;
     let month = (remaining_days / 30 + 1).min(12);
     let day = remaining_days % 30 + 1;
-    format!("{year:04}-{month:02}-{day:02}T00:00:00Z")
+    // Include the time-of-day. The date part above is only a sort-friendly
+    // approximation, but the h:m:s here MUST be real seconds: this string is
+    // the crossload cache's freshness key (Entry::source_updated_at, compared
+    // in inject::inject_session and crossload_index::run_doctor). Truncating to
+    // `T00:00:00Z` made every same-day source edit — including a `/compact` —
+    // invisible to the cache, so a second same-day crossload silently reused
+    // the stale pre-edit target session ("out of context" / not live). See the
+    // `format_epoch_ms_distinguishes_same_day_updates` regression test.
+    let h = (secs % 86400) / 3600;
+    let m = (secs % 3600) / 60;
+    let s = secs % 60;
+    format!("{year:04}-{month:02}-{day:02}T{h:02}:{m:02}:{s:02}Z")
 }
 
 // === Pi discovery ===
@@ -1109,6 +1120,31 @@ mod tests {
     fn test_format_epoch_ms() {
         let ts = format_epoch_ms(1774800000000);
         assert!(ts.starts_with("2026-"));
+    }
+
+    #[test]
+    fn format_epoch_ms_distinguishes_same_day_updates() {
+        // Regression for the crossload staleness bug: `updated_at` doubles as the
+        // crossload cache's freshness key (Entry::source_updated_at). When this
+        // formatter hardcoded `T00:00:00Z`, two mtimes on the SAME UTC day
+        // collapsed to identical strings, so re-crossloading a source that was
+        // edited/compacted earlier the same day reused the stale target session.
+        //
+        // Same day (2026-03-29), one hour apart. Pre-fix these were byte-equal;
+        // they must now differ so the cache invalidates.
+        let base_ms: u64 = 1_774_800_000_000; // 2026-03-29T...
+        let one_hour_later = base_ms + 3_600_000;
+        let a = format_epoch_ms(base_ms);
+        let b = format_epoch_ms(one_hour_later);
+        assert_ne!(
+            a, b,
+            "same-day timestamps 1h apart must produce different strings \
+             (else the crossload cache never sees a same-day source edit): {a} == {b}"
+        );
+        // The date portion must still match — only the time-of-day moved.
+        assert_eq!(&a[..10], &b[..10], "date portion should be identical");
+        // And a one-second delta must also register (finest granularity we key on).
+        assert_ne!(format_epoch_ms(base_ms), format_epoch_ms(base_ms + 1000));
     }
 
     #[test]

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -367,6 +367,13 @@ pub fn run(auto_mode: bool, prompt: Option<String>, extra_args: Vec<String>) -> 
                     }
                 }
             }
+            // Self-heal default hook script content even when already registered,
+            // so fixes to compact-notify.sh (e.g. crossload-cache eviction) reach
+            // existing installs. install_default_hooks above only runs when the
+            // hook is absent.
+            if let Err(e) = manager.refresh_default_hook_scripts() {
+                eprintln!("Warning: Failed to refresh default hook scripts: {}", e);
+            }
             // Always sync plugin hooks into settings.json on launch.
             // Prune first so that plugins toggled off have their hooks removed,
             // then re-register hooks for currently-enabled plugins.

--- a/src/search.rs
+++ b/src/search.rs
@@ -268,6 +268,41 @@ async fn run_sessions_action_async(
             }
             Ok(())
         }
+        crate::cli::SessionsAction::CrossloadRefresh { target } => {
+            let (removed, scope) = match target.as_deref() {
+                Some(t) => {
+                    let (cli, source_id) = t
+                        .split_once(':')
+                        .ok_or("target must be in <cli>:<source_id> form (e.g. claude:abc12345)")?;
+                    if cli.is_empty() || source_id.is_empty() {
+                        return Err(
+                            "target must be in <cli>:<source_id> form (e.g. claude:abc12345)"
+                                .into(),
+                        );
+                    }
+                    (
+                        crate::interchange::crossload_index::bust_source(cli, source_id)?,
+                        t.to_string(),
+                    )
+                }
+                None => (
+                    crate::interchange::crossload_index::bust_all()?,
+                    "all sessions".to_string(),
+                ),
+            };
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({ "removed": removed, "scope": scope })
+                );
+            } else {
+                println!(
+                    "Refreshed {scope}: dropped {removed} cached crossload(s). \
+                     Next crossload will re-inject from current content."
+                );
+            }
+            Ok(())
+        }
     }
 }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -248,6 +248,26 @@ async fn run_sessions_action_async(
             crate::interchange::crossload_index::run_doctor(json, gc)?;
             Ok(())
         }
+        crate::cli::SessionsAction::CrossloadBust { target } => {
+            let (cli, source_id) = target
+                .split_once(':')
+                .ok_or("target must be in <cli>:<source_id> form (e.g. claude:abc12345)")?;
+            if cli.is_empty() || source_id.is_empty() {
+                return Err(
+                    "target must be in <cli>:<source_id> form (e.g. claude:abc12345)".into(),
+                );
+            }
+            let removed = crate::interchange::crossload_index::bust_source(cli, source_id)?;
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({ "removed": removed, "target": target })
+                );
+            } else {
+                println!("Evicted {removed} cached crossload(s) for {target}");
+            }
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

Crossloading a Claude session into another CLI after a `/compact` served **stale, pre-compact content** — often resuming an over-budget conversation the target rejected as *out of context*. Reported: "not always up to date… compacted hai, crossloaded claude→codex, got out of context."

## Root cause

`unleash <target> -x claude:<id>` reuses a previously-injected target session when the source's `updated_at` is unchanged (`inject::inject_session`). But `format_epoch_ms` hardcoded **`T00:00:00Z`**, truncating claude/codex/pi/opencode timestamps to **day granularity**. Any same-day source edit — including a compact — produced an identical `updated_at`, so the freshness check never fired. Cross-day worked (hence "not *always*").

## Fix

**1. Timestamp precision (general).** `format_epoch_ms` now emits real `HH:MM:SS`, so any sub-day edit invalidates the cache. Date part stays a sort-friendly approximation; only the time-of-day the cache keys on was corrected.

**2. Compact = hard checkpoint, native *and* supercompact.**
- New `CrossloadIndex::invalidate_source` + `unleash sessions crossload-bust <cli:id>`.
- Universal `compact-notify.sh` PreCompact hook now derives the session id from the payload and evicts the cache — covers **native `/compact`** and any compact when supercompact is off.
- Supercompact pipeline evicts after it rewrites the transcript — covers the **preemptive** path (no PreCompact event).
- `refresh_default_hook_scripts()` (run on launch) self-heals the on-disk hook so existing installs pick up the eviction.

**3. Manual button.** `unleash sessions crossload-refresh [<cli:id>]` — force re-injection when auto-freshness hasn't caught up. With a target refreshes one session; with none clears the whole cache.

| Compact path | Evicted by |
|---|---|
| native `/compact` | compact-notify.sh |
| manual supercompact | compact-notify.sh + pipeline |
| preemptive supercompact | pipeline |
| any other same-day edit | timestamp fix |
| on demand | `crossload-refresh` |

## Tests (proven to bite)
- `format_epoch_ms_distinguishes_same_day_updates` — red under `T00:00:00Z`
- `invalidate_source_evicts_all_targets_for_one_source` / `clear_evicts_everything`
- `default_compact_hook_busts_crossload_cache` / `refresh_default_hook_scripts_heals_stale_content`
- Full lib suite green; hook script functionally smoke-tested (payload → correct `claude:<id>`).

## Workaround for older builds
`UNLEASH_CROSSLOAD_FORCE=1 unleash codex -x claude:<id>`