### PR TITLE
ci: make release-artifact smoke test run against the right tag (was pinned to stale v0.0.0)

### DIFF
--- a/.github/workflows/binary-smoke-test.yml
+++ b/.github/workflows/binary-smoke-test.yml
@@ -8,14 +8,31 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to test (e.g., v0.0.0)'
+        description: 'Release tag to test (e.g., v0.1.95)'
         required: true
-        default: 'v0.0.0'
         type: string
-  # Also run after release binaries are uploaded
-  workflow_run:
-    workflows: ["Upload Release Binaries"]
-    types: [completed]
+  # Called by the release pipeline (release-please.yml) and the manual backfill
+  # (upload-release-binaries.yml) with the exact tag whose artifacts were just
+  # uploaded.
+  #
+  # Previously this used `workflow_run` on "Upload Release Binaries" completing.
+  # That was doubly broken: (1) automated releases upload binaries from within
+  # the "Release Please" workflow, not "Upload Release Binaries", so the trigger
+  # never fired on an automated release; and (2) a `workflow_run` event carries
+  # no inputs, so the tag always fell back to the pinned `v0.0.0` default —
+  # meaning every "Upload Release Binaries" completion re-smoke-tested the stale
+  # v0.0.0 release instead of the tag that was actually just uploaded. (`v0.0.0`
+  # is a real published release, so those runs passed — they just tested the
+  # wrong, old artifacts.) Being *called* with the tag fixes both — see #401 §1.
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to test'
+        required: true
+        type: string
+
+permissions:
+  contents: read
 
 jobs:
   smoke-test:
@@ -32,22 +49,35 @@ jobs:
           - os: macos-latest
             artifact: unleash-macos-aarch64
             splash: splash-macos-aarch64
-          # macos x86_64 requires paid runners (-large/-intel), skip for now
-          # - os: macos-15-large
+          # KNOWN COVERAGE GAP — macos-x86_64 (Intel): `upload-release`/`build-release`
+          # ship `unleash-macos-x86_64` + `splash-macos-x86_64`, but no free
+          # GitHub-hosted runner executes them natively (arm64 `macos-latest`
+          # can't run Intel binaries without Rosetta plumbing, and Intel lanes
+          # `macos-13`/`macos-*-large`/`-intel` are retired or paid). This lane
+          # is therefore intentionally omitted, so the Intel artifact is BUILT
+          # but not smoke-tested. Reopen condition: a free Intel runner becomes
+          # available, or the Intel artifact is dropped from the release. Do not
+          # mark #401 §1 "every shipped Linux/macOS artifact is smoke-tested"
+          # closed while this gap stands.
+          # - os: <free-intel-runner-when-available>
           #   artifact: unleash-macos-x86_64
           #   splash: splash-macos-x86_64
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.artifact }}
 
     steps:
-      - name: Determine tag
+      - name: Resolve tag
         id: tag
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
-          if [ -n "${{ github.event.inputs.tag }}" ]; then
-            echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-          else
-            echo "tag=v0.0.0" >> $GITHUB_OUTPUT
+          # Fail loudly on a missing tag instead of falling back to a stale
+          # default and smoke-testing the wrong release's artifacts.
+          if [ -z "$TAG" ]; then
+            echo "::error::No release tag supplied. This workflow must be called or dispatched with the tag whose artifacts were uploaded."
+            exit 1
           fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Download unleash binary
         run: |
@@ -120,14 +150,18 @@ jobs:
       - name: Install dependencies
         run: apk add --no-cache curl file bash
 
-      - name: Determine tag
+      - name: Resolve tag
         id: tag
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
-          if [ -n "${{ github.event.inputs.tag }}" ]; then
-            echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-          else
-            echo "tag=v0.0.0" >> $GITHUB_OUTPUT
+          # Fail loudly on a missing tag instead of falling back to a stale
+          # default and smoke-testing the wrong release's artifacts.
+          if [ -z "$TAG" ]; then
+            echo "::error::No release tag supplied. This workflow must be called or dispatched with the tag whose artifacts were uploaded."
+            exit 1
           fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Download unleash binary
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -208,3 +208,17 @@ jobs:
             binaries/splash-macos-x86_64
             binaries/splash-macos-aarch64
             binaries/checksums.txt
+
+  # Smoke-test the freshly-published artifacts on real platforms — part of the
+  # release contract (#401 §1). Runs only when a release was actually created,
+  # after binaries are uploaded, with the exact tag. A failure turns the release
+  # pipeline red as an escalation signal (the release and binaries are already
+  # published by this point, so this reports rather than blocks).
+  smoke-test-release:
+    needs: [release-please, upload-release]
+    if: ${{ needs.release-please.outputs.release_created }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/binary-smoke-test.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/trailer-hygiene.yml
+++ b/.github/workflows/trailer-hygiene.yml
@@ -2,6 +2,13 @@ name: Trailer Hygiene
 
 on:
   pull_request:
+    # `edited` is required: this check inspects the PR *body* for a
+    # "Generated with [Claude Code]" footer, but the default pull_request
+    # activity types (opened/synchronize/reopened) don't include body edits.
+    # Without `edited`, a body-only correction can't rerun the check — it stays
+    # red until an unrelated push, which is a confusing no-op-push dance
+    # (observed on #415).
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read

--- a/.github/workflows/upload-release-binaries.yml
+++ b/.github/workflows/upload-release-binaries.yml
@@ -105,3 +105,13 @@ jobs:
             binaries/splash-macos-x86_64
             binaries/splash-macos-aarch64
             binaries/checksums.txt
+
+  # After a manual backfill upload, smoke-test the artifacts with the same tag,
+  # mirroring the automated release path (release-please.yml).
+  smoke-test:
+    needs: upload
+    permissions:
+      contents: read
+    uses: ./.github/workflows/binary-smoke-test.yml
+    with:
+      tag: ${{ github.event.inputs.tag_name }}


### PR DESCRIPTION
Addresses part of #401 §1 ("Make release artifact smoke testing part of the release contract"). **Not** claiming that checkbox fully closed — see the documented Intel residual.

## The bug: the smoke test tested the wrong tag (and never ran on automated releases)

Two independent defects in `binary-smoke-test.yml`:

1. **Trigger miswiring.** It fired on `workflow_run` of **"Upload Release Binaries"**. But automated releases build *and* upload binaries from within the **"Release Please"** workflow (`build-release` → `upload-release`, gated on `release_created`). "Upload Release Binaries" is a manual (`workflow_dispatch`) backfill — so the smoke test **never fired on an automated release**.
2. **Stale-tag fallback.** A `workflow_run` event carries no `inputs`, so `github.event.inputs.tag` was empty and the tag resolved to the pinned **`v0.0.0`** default. Every "Upload Release Binaries" completion therefore re-smoke-tested the **stale `v0.0.0` release** instead of the tag that was actually just uploaded.

To be precise (verified via `gh`): `v0.0.0` **is a real published release** — 9 assets, published `2026-03-30T17:35:44Z` — and prior `workflow_run` smoke runs **passed** against it. The defect is not that the download failed; it's that the smoke test kept validating the *old, wrong* artifacts and never the current release's.

## Fix

- **`binary-smoke-test.yml`** → reusable workflow: `workflow_call` with a **required** `tag` input (kept `workflow_dispatch`; **removed** the broken `workflow_run`). The tag step **fails loudly only on an empty tag** (a misconfigured call). It does **not** reject any specific value — `v0.0.0` is a legitimate tag.
- **`release-please.yml`** → new `smoke-test-release` job: `needs: [release-please, upload-release]`, `if: release_created`, `uses: ./.github/workflows/binary-smoke-test.yml` with `tag: ${{ needs.release-please.outputs.tag_name }}`. Smoke-testing is now part of the **automated** release contract; a failure turns the pipeline red as an escalation signal (release + binaries are already published at that point, so it reports rather than blocks).
- **`upload-release-binaries.yml`** → new `smoke-test` job so the **manual** backfill self-verifies with the same tag.

## Documented residual (does NOT close the checkbox)

`build-release`/`upload-release` ship `unleash-macos-x86_64` + `splash-macos-x86_64`, but **no free GitHub-hosted runner executes Intel macOS binaries natively** (arm64 `macos-latest` can't; Intel lanes `macos-13`/`-large`/`-intel` are retired or paid). That lane stays omitted, now with an **explicit documented exception + reopen condition** in the matrix (replacing the vague "skip for now" comment). The Intel artifact is **built but not smoke-tested** — so #401 §1 ("every shipped Linux/macOS artifact") is **not** marked done. Suggest a tracker sub-item.

## Companion (verified)

`trailer-hygiene.yml` inspects the PR **body**, but `pull_request` without `types` omits `edited` — so a body-only correction can't rerun the check (observed first-hand on #415: it needed an unrelated no-op push). Added `types: [opened, synchronize, reopened, edited]`.

## Evidence

Workflow triggers can't execute inside a PR, so:
- `actionlint` clean under CI's exact config (`shellcheck -e SC2086,SC2155`) across all four changed workflows, including cross-file resolution of the reusable-workflow `uses:` calls.
- Empty-tag guard unit-tested locally: empty → reject (exit 1); `v0.0.0` and `v0.1.95` → accepted.

## Scope / no duplication

No overlap with open PRs #404–#407, #411, #413, #408 or issues #410/#412/#414 (#408 is #374 feature scope). Deliberately **not** the `cargo test --all-targets` gate (§1 box 1) — that is a separate, higher-effort item and is not bundled here. (For the record, hai-pilgrim's hermeticity ordering note was specifically about making `test_supercompact.sh` hermetic before wiring it as required CI — not about this workflow.)