### PR TITLE
test: serialize env-mutating tests with one crate-wide lock

### DIFF
--- a/src/interchange/sessions.rs
+++ b/src/interchange/sessions.rs
@@ -878,17 +878,16 @@ fn discover_ucf() -> Vec<SessionInfo> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
 
-    // Multiple tests in this module mutate UNLEASH_REINDEX_BINARY (and
-    // related env) around a `trigger_background_reindex` fork+exec. Cargo
+    // Multiple tests in this module mutate UNLEASH_REINDEX_BINARY and
+    // XDG_DATA_HOME around a `trigger_background_reindex` fork+exec. Cargo
     // runs tests on a thread pool by default, so two such tests racing can
     // leave the spawned child reading the OTHER test's env. We saw this as
     // intermittent flake-check failures on
-    // `test_trigger_background_reindex_sets_lock_path_env_var`.
-    // Acquire this mutex at the start of any test that mutates the shared
-    // env to serialize them.
-    static ENV_MUTATION_LOCK: Mutex<()> = Mutex::new(());
+    // `test_trigger_background_reindex_sets_lock_path_env_var`, and later
+    // cross-MODULE: this module swapping XDG_DATA_HOME mid-skillsync-sync
+    // (flake-check run 29565535983). Hence the CRATE-wide `test_env::lock()`
+    // — a module-local mutex cannot exclude other modules.
 
     #[test]
     fn test_find_session_with_cli_prefix() {
@@ -909,7 +908,7 @@ mod tests {
 
     #[test]
     fn test_overlay_search_index_fills_missing_name() {
-        let _env_lock = ENV_MUTATION_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _env_lock = crate::test_env::lock();
         let mut sessions = vec![
             SessionInfo {
                 cli: "claude".into(),
@@ -1023,7 +1022,7 @@ mod tests {
 
     #[test]
     fn test_trigger_background_reindex_sets_lock_path_env_var() {
-        let _env_lock = ENV_MUTATION_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _env_lock = crate::test_env::lock();
         // The child process needs UNLEASH_REINDEX_LOCK_PATH to clean up the lock
         // file on exit. We stub the child with a tiny shell script that asserts
         // the env var is set and points at the expected file. If the env var is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,24 @@ pub mod agents;
 #[cfg(feature = "tui")]
 mod ansi;
 mod auth;
+
+/// Crate-wide lock for tests that mutate process-global environment variables
+/// (`HOME`, `XDG_DATA_HOME`, `UNLEASH_*`, …). Module-local locks are NOT
+/// enough: cargo runs test modules in one process with a shared environment,
+/// so two modules each holding their own mutex still race each other (caught
+/// live by flake-check run 29565535983: sessions.rs swapped XDG_DATA_HOME
+/// mid-skillsync-sync). Every env-mutating test must take THIS lock.
+#[cfg(test)]
+pub(crate) mod test_env {
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    pub(crate) fn lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+    }
+}
 mod cli;
 pub mod config;
 mod hooks;

--- a/src/skillsync/cross_harness_tests.rs
+++ b/src/skillsync/cross_harness_tests.rs
@@ -8,15 +8,12 @@ mod tests {
     use std::ffi::OsString;
     use std::fs;
     use std::path::{Path, PathBuf};
-    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use std::sync::MutexGuard;
 
-    fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
+    // Crate-wide lock: sessions.rs tests mutate XDG_DATA_HOME too, and a
+    // module-local mutex cannot exclude them (proven flake, run 29565535983).
     fn env_guard() -> MutexGuard<'static, ()> {
-        env_lock().lock().unwrap_or_else(|err| err.into_inner())
+        crate::test_env::lock()
     }
 
     fn fixture(name: &str) -> Skill {


### PR DESCRIPTION
## The flake

Daily flake-check run 29565535983 caught `skillsync::cross_harness_tests::tests::sync_delete_orphans_removes_sandboxed_targets_and_manifest_entry` flipping ok → FAILED on iteration 18/20 — the `deleted orphan minimal-skill from hub` change line never fired.

## Root cause: two module-LOCAL env locks

- skillsync tests serialize their `HOME`/`XDG_DATA_HOME` mutation behind `cross_harness_tests::env_lock()`
- sessions.rs tests serialize their `XDG_DATA_HOME`/`UNLEASH_REINDEX_BINARY` mutation behind `ENV_MUTATION_LOCK` (added by #245 for the intra-module race)

But cargo runs both modules in **one process with one shared environment**, so the two groups exclude only themselves, not each other. When the sessions.rs overlay test swapped `XDG_DATA_HOME` mid-`skillsync::sync`, the hub dir (`dirs::data_local_dir()`) resolved outside the test sandbox and the orphan-delete branch never ran.

## Fix

One crate-wide `test_env::lock()` (`#[cfg(test)]` module in lib.rs); both test modules now take that lock. Module doc comments updated to say why a local mutex is insufficient — so the next env-mutating test module reaches for the shared one.

## Evidence

- 728 lib tests green ×6 consecutive full-suite runs locally
- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean
- The fix is structural: a single mutex provably excludes the cross-module interleaving; the 1-in-20 CI reproduction rate makes brute-force re-runs weak evidence either way, which is why the argument is by construction

Same bug class as #245 (`std::env` mutation racing a parallel test pool), one level up: cross-module instead of cross-test.