### PR TITLE
Transport explicit Clanker character identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The first argument is always a **profile name**. The eight default profiles (`cl
 ```bash
 unleash claude -m opus -c              # Continue last Claude session with Opus
 unleash codex --safe                   # Run Codex with approval prompts
-unleash clanker --name hai             # Run Clanker as the named character
+unleash clanker --name Cleo            # Run Clanker as the Chloe character alias
 unleash gemini -p "fix the tests"     # Gemini headless mode
 unleash hermes -m claude-sonnet-4      # Hermes with a model override
 unleash work                           # Run a custom "work" profile
@@ -155,6 +155,13 @@ Version filtering:
 - **Blacklist mode** (default for Claude): All versions allowed except known-bad ones
 - **Whitelist mode** (default for Codex): Only verified versions allowed
 - Version lists are maintained in `Cargo.toml` and compiled into the binary
+
+Clanker updates are source builds from the current head of the private
+`heiervang-technologies/clanker-code` `clanker` branch. They require
+authenticated Git access plus Rust/Cargo, and currently have no signed release
+artifact or historical version picker. Unleash records the exact installed
+commit and treats that receipt as valid only while its owned binary still
+reports the recorded product version.
 
 ## Extended Capabilities
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **unleash** is...
   
-* an **agent CLI version manager**. `nvm` for AI agents — claude code, codex, antigravity, gemini, opencode, pi, hermes — with a rich TUI
+* an **agent CLI version manager**. `nvm` for AI agents — claude code, codex, clanker code, antigravity, gemini, opencode, pi, hermes — with a rich TUI
 
 * a compatibility layer that lets you start in claude code, then continue where you left off in codex.
 
@@ -42,6 +42,7 @@ docker run -it --rm -e ANTHROPIC_API_KEY -e CLAUDE_CODE_OAUTH_TOKEN -e OPENAI_AP
 unleash          # Launch TUI (profiles, versions, settings)
 unleash claude   # Start Claude with unleash features
 unleash codex    # Start Codex with unleash features
+unleash clanker  # Start Clanker Code with unleash features
 unleash agy      # Start Antigravity CLI with unleash features
 unleash gemini   # Start Gemini CLI with unleash features
 unleash opencode # Start OpenCode with unleash features
@@ -80,11 +81,12 @@ Add a matching profile at `~/.config/unleash/profiles/aider.toml` (any built-in 
 unleash <profile> [unified flags] [-- agent-specific flags]
 ```
 
-The first argument is always a **profile name**. The seven default profiles (`claude`, `codex`, `agy`, `gemini`, `opencode`, `pi`, `hermes`) map to their respective agents. Custom profiles can target any agent with custom settings — see [`docs/custom-agents.md`](docs/custom-agents.md).
+The first argument is always a **profile name**. The eight default profiles (`claude`, `codex`, `clanker`, `agy`, `gemini`, `opencode`, `pi`, `hermes`) map to their respective agents. Custom profiles can target any agent with custom settings — see [`docs/custom-agents.md`](docs/custom-agents.md).
 
 ```bash
 unleash claude -m opus -c              # Continue last Claude session with Opus
 unleash codex --safe                   # Run Codex with approval prompts
+unleash clanker --name hai             # Run Clanker as the named character
 unleash gemini -p "fix the tests"     # Gemini headless mode
 unleash hermes -m claude-sonnet-4      # Hermes with a model override
 unleash work                           # Run a custom "work" profile
@@ -114,13 +116,13 @@ unleash claude -m opus -- --effort max --verbose
 
 ### How Translation Works
 
-| unleash | Claude | Codex | Antigravity (`agy`) | Gemini | OpenCode | Pi | Hermes |
-|---------|--------|-------|---------------------|--------|----------|----|--------|
-| `-p <prompt>` | `-p <prompt>` | `exec <prompt>` | `-p <prompt>` | `-p <prompt>` | `run <prompt>` | `-p <prompt>` | `-z <prompt>` |
-| `-c` | `--continue` | `resume --last` | `--continue` | `--resume latest` | `--continue` | `--continue` | `--continue` |
-| `-r [id]` | `--resume [id]` | `resume [id]` | `--conversation [id]` | `--resume [id]` | `-s <id>` | `--session <id>` | `--resume [id]` |
-| `--fork` | `--fork-session` | `fork` subcommand | *(unsupported)* | *(unsupported)* | `--fork` | `--fork` | `--worktree` |
-| *(default)* | `--dangerously-skip-permissions` | `--dangerously-bypass-approvals-and-sandbox` | `--dangerously-skip-permissions` | `--yolo` | *(no-op)* | *(no-op)* | `--yolo` |
+| unleash | Claude | Codex | Clanker | Antigravity (`agy`) | Gemini | OpenCode | Pi | Hermes |
+|---------|--------|-------|---------|---------------------|--------|----------|----|--------|
+| `-p <prompt>` | `-p <prompt>` | `exec <prompt>` | `exec <prompt>` | `-p <prompt>` | `-p <prompt>` | `run <prompt>` | `-p <prompt>` | `-z <prompt>` |
+| `-c` | `--continue` | `resume --last` | `resume --last` | `--continue` | `--resume latest` | `--continue` | `--continue` | `--continue` |
+| `-r [id]` | `--resume [id]` | `resume [id]` | `resume [id]` | `--conversation [id]` | `--resume [id]` | `-s <id>` | `--session <id>` | `--resume [id]` |
+| `--fork` | `--fork-session` | `fork` subcommand | `fork` subcommand | *(unsupported)* | *(unsupported)* | `--fork` | `--fork` | `--worktree` |
+| *(default)* | `--dangerously-skip-permissions` | `--dangerously-bypass-approvals-and-sandbox` | `--dangerously-bypass-approvals-and-sandbox` | `--dangerously-skip-permissions` | `--yolo` | *(no-op)* | *(no-op)* | `--yolo` |
 
 ### Management Commands
 
@@ -129,6 +131,7 @@ unleash                    # Launch TUI
 unleash update             # Update all agents (parallel progress bars)
 unleash update --check     # Check for updates without installing
 unleash update codex       # Update a specific agent
+unleash update clanker     # Build and atomically install the current Clanker fork
 unleash version            # Show installed versions
 unleash version --list     # List available versions
 unleash auth               # Check authentication status
@@ -137,10 +140,11 @@ unleash agents status      # Show all agent versions and update status
 
 ## Version Management
 
-unleash manages versions for all seven built-in agent CLIs:
+unleash manages versions for all eight built-in agent CLIs:
 
 - **Claude Code**: Native binary (GCS) or npm install
 - **Codex**: Prebuilt binary from GitHub releases, cargo build fallback
+- **Clanker Code**: Fork-owned `clanker` branch source build with atomic install and revision receipt
 - **Antigravity CLI** (`agy`): AUR helper (`yay`/`paru`) on Arch; download from antigravity.google elsewhere
 - **Gemini CLI**: npm install
 - **OpenCode**: Built-in `opencode upgrade` command

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,6 +1,6 @@
 # Unleash CLI Reference
 
-Unified CLI manager for AI code agents (Claude, Codex, Antigravity, Gemini, OpenCode, Pi, Hermes).
+Unified CLI manager for AI code agents (Claude, Codex, Clanker, Antigravity, Gemini, OpenCode, Pi, Hermes).
 
 ## Usage
 
@@ -17,6 +17,7 @@ A profile maps to an installed agent CLI. Run `unleash agents status` to see ava
 ```bash
 unleash claude              # Launch Claude Code
 unleash codex -a            # Launch Codex in auto-mode
+unleash clanker --name hai  # Launch a named Clanker character
 unleash gemini -p "fix it"  # Headless Gemini prompt
 ```
 
@@ -39,14 +40,14 @@ unleash gemini -p "fix it"  # Headless Gemini prompt
 
 How unified flags map to each agent's native CLI:
 
-| unleash | Claude | Codex | Antigravity (`agy`) | Gemini | OpenCode | Pi | Hermes |
-|---------|--------|-------|---------------------|--------|----------|----|--------|
-| `-p <prompt>` | `-p <prompt>` | `exec <prompt>` | `-p <prompt>` | `-p <prompt>` | `run <prompt>` | `-p <prompt>` | `-z <prompt>` |
-| `-c` | `--continue` | `resume --last` | `--continue` | `--resume latest` | `--continue` | `--continue` | `--continue` |
-| `-r [id]` | `--resume [id]` | `resume [id]` | `--conversation [id]` | `--resume [id]` | `-s <id>` | `--session <id>` | `--resume [id]` |
-| `--fork` | `--fork-session` | `fork` subcommand | *(unsupported)* | *(unsupported)* | `--fork` | `--fork` | `--worktree` |
-| *(default)* | `--dangerously-skip-permissions` | `--dangerously-bypass-approvals-and-sandbox` | `--dangerously-skip-permissions` | `--yolo` | *(no-op)* | *(no-op)* | `--yolo` |
-| `--safe` | *(omits above)* | *(omits above)* | *(omits above)* | *(omits above)* | *(no-op)* | *(no-op)* | *(omits above)* |
+| unleash | Claude | Codex | Clanker | Antigravity (`agy`) | Gemini | OpenCode | Pi | Hermes |
+|---------|--------|-------|---------|---------------------|--------|----------|----|--------|
+| `-p <prompt>` | `-p <prompt>` | `exec <prompt>` | `exec <prompt>` | `-p <prompt>` | `-p <prompt>` | `run <prompt>` | `-p <prompt>` | `-z <prompt>` |
+| `-c` | `--continue` | `resume --last` | `resume --last` | `--continue` | `--resume latest` | `--continue` | `--continue` | `--continue` |
+| `-r [id]` | `--resume [id]` | `resume [id]` | `resume [id]` | `--conversation [id]` | `--resume [id]` | `-s <id>` | `--session <id>` | `--resume [id]` |
+| `--fork` | `--fork-session` | `fork` subcommand | `fork` subcommand | *(unsupported)* | *(unsupported)* | `--fork` | `--fork` | `--worktree` |
+| *(default)* | `--dangerously-skip-permissions` | `--dangerously-bypass-approvals-and-sandbox` | `--dangerously-bypass-approvals-and-sandbox` | `--dangerously-skip-permissions` | `--yolo` | *(no-op)* | *(no-op)* | `--yolo` |
+| `--safe` | *(omits above)* | *(omits above)* | *(omits above)* | *(omits above)* | *(omits above)* | *(no-op)* | *(no-op)* | *(omits above)* |
 
 ## Passthrough
 
@@ -73,6 +74,7 @@ unleash update -c           # Update all installed agent CLIs
 unleash update -a           # Update unleash + all agent CLIs
 unleash update claude       # Update only Claude
 unleash update claude codex # Update Claude and Codex
+unleash update clanker      # Build and atomically install the current Clanker fork
 unleash update --check      # Dry run, show available updates
 ```
 
@@ -170,7 +172,8 @@ unleash convert --from claude --to passthrough session.jsonl        # markdown t
 
 Required:
 - `--from <format>`: source format. One of: `claude` (alias `claude-code`),
-  `codex`, `gemini` (aliases `gemini-cli`, `antigravity`, `antigravity-cli`,
+  `codex`, `clanker` (alias `clanker-code`; same session format as Codex),
+  `gemini` (aliases `gemini-cli`, `antigravity`, `antigravity-cli`,
   `agy` — same JSON schema), `opencode`, `pi` (alias `pi-coding-agent`),
   `hermes` (alias `hermes-agent`), or `hub` / `ucf`.
 - `<input>`: path to the input file (positional)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -17,7 +17,7 @@ A profile maps to an installed agent CLI. Run `unleash agents status` to see ava
 ```bash
 unleash claude              # Launch Claude Code
 unleash codex -a            # Launch Codex in auto-mode
-unleash clanker --name hai  # Launch a named Clanker character
+unleash clanker --name Cleo # Launch the Chloe character alias
 unleash gemini -p "fix it"  # Headless Gemini prompt
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,7 @@ plugin's manifest with TUI controls.
 └── profiles/                # One TOML file per profile
     ├── claude.toml
     ├── codex.toml
+    ├── clanker.toml
     ├── agy.toml
     ├── gemini.toml
     ├── opencode.toml
@@ -40,7 +41,7 @@ plugin's manifest with TUI controls.
     └── hermes.toml
 ```
 
-`profiles/` is seeded with the seven default profiles on first run. Add
+`profiles/` is seeded with the eight default profiles on first run. Add
 extra `<name>.toml` files for custom profiles or custom agents — the
 filename (without `.toml`) becomes the subcommand name (e.g.
 `aider.toml` → `unleash aider`).

--- a/docs/crossload.md
+++ b/docs/crossload.md
@@ -6,7 +6,7 @@ losing context.
 
 ## How It Works
 
-1. **Discovery** -- `unleash sessions` scans session stores for all installed CLIs (claude/codex/gemini/opencode/pi/hermes; agy shares the Gemini path)
+1. **Discovery** -- `unleash sessions` scans session stores for all installed CLIs (claude/codex/clanker/gemini/opencode/pi/hermes; Clanker shares the Codex path and agy shares the Gemini path)
 2. **Hub conversion** -- source format is converted to Universal Chat Format (`.ucf.jsonl`)
 3. **Target injection** -- hub format is converted to the target CLI's native format
 4. **Resume** -- target CLI launches with the injected session
@@ -14,7 +14,7 @@ losing context.
 ### Hub-and-Spoke Architecture
 
 ```
-Claude JSONL  <-->  Hub (.ucf.jsonl)  <-->  Codex JSONL
+Claude JSONL  <-->  Hub (.ucf.jsonl)  <-->  Codex/Clanker JSONL
                          |
                          |---->  Gemini JSON  (agy shares this path)
                          |---->  OpenCode SQLite

--- a/docs/crossload.md
+++ b/docs/crossload.md
@@ -6,7 +6,7 @@ losing context.
 
 ## How It Works
 
-1. **Discovery** -- `unleash sessions` scans session stores for all installed CLIs (claude/codex/clanker/gemini/opencode/pi/hermes; Clanker shares the Codex path and agy shares the Gemini path)
+1. **Discovery** -- `unleash sessions` scans the physical Claude, Codex, Gemini, OpenCode, Pi, and Hermes stores. Clanker uses the Codex-format store, so it does not add a second scan or a distinct session label. Antigravity (`agy`) storage is separate and is not discoverable as Gemini data (#307).
 2. **Hub conversion** -- source format is converted to Universal Chat Format (`.ucf.jsonl`)
 3. **Target injection** -- hub format is converted to the target CLI's native format
 4. **Resume** -- target CLI launches with the injected session
@@ -16,11 +16,15 @@ losing context.
 ```
 Claude JSONL  <-->  Hub (.ucf.jsonl)  <-->  Codex/Clanker JSONL
                          |
-                         |---->  Gemini JSON  (agy shares this path)
+                         |---->  Gemini JSON
                          |---->  OpenCode SQLite
                          |---->  Pi JSON
                          |---->  Hermes JSON
 ```
+
+Antigravity is intentionally outside the injection spokes: its server-side
+cascade validation blocks synthetic sessions, so crossload falls back to a
+rendered prompt instead (#307).
 
 O(N) converters instead of O(N²) direct pairs. The hub format is JSONL for
 corruption recovery, with minimal extensions (~10% overhead).

--- a/docs/custom-agents.md
+++ b/docs/custom-agents.md
@@ -1,6 +1,6 @@
 # Custom Agent CLIs
 
-unleash supports any agent CLI as a first-class profile — alongside the seven built-in agents (`claude`, `codex`, `agy`, `gemini`, `opencode`, `pi`, `hermes`). Custom agents get:
+unleash supports any agent CLI as a first-class profile — alongside the eight built-in agents (`claude`, `codex`, `clanker`, `agy`, `gemini`, `opencode`, `pi`, `hermes`). Custom agents get:
 
 - Launchable as `unleash <name>`
 - Polyfilled unified flags (`-c`, `-r`, `-p`, `-m`, `--auto`, …)

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -55,6 +55,7 @@ runtime environment.
 | `AGENT_UNLEASH` | Set to `1` when running under the unleash wrapper |
 | `AGENT_WRAPPER_PID` | PID of the wrapper process (used by plugins and Hyprland focus) |
 | `UNLEASH_POLYFILL_ACTIVE` | Set to `1` when polyfill flag translation is active |
+| `CLANKER_ID` | Canonical character id exported only after an explicit Codex/Clanker `--name` is resolved by the configured target binary. Bare launches do not resolve or replace this variable. |
 | `DISABLE_TELEMETRY` | Blocks all Claude Code analytics/telemetry (set to `1`) |
 | `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | Blocks Claude Code analytics, auto-updates, release notes, feature flags (set to `1`) |
 | `GEMINI_TELEMETRY_ENABLED` | Gemini CLI telemetry master switch (set to `false`) |

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -51,11 +51,11 @@ runtime environment.
 
 | Variable | Purpose |
 |----------|---------|
-| `AGENT_CMD` | Which agent binary is running (`claude`, `codex`, `agy`, `gemini`, `opencode`, `pi`, `hermes`, or a custom-agent name) |
+| `AGENT_CMD` | Which agent binary is running (`claude`, `codex`, `clanker`, `agy`, `gemini`, `opencode`, `pi`, `hermes`, or a custom-agent name) |
 | `AGENT_UNLEASH` | Set to `1` when running under the unleash wrapper |
 | `AGENT_WRAPPER_PID` | PID of the wrapper process (used by plugins and Hyprland focus) |
 | `UNLEASH_POLYFILL_ACTIVE` | Set to `1` when polyfill flag translation is active |
-| `CLANKER_ID` | Canonical character id exported only after an explicit Codex/Clanker `--name` is resolved by the configured target binary. Bare launches do not resolve or replace this variable. |
+| `CLANKER_ID` | Canonical character id exported only after an explicit Clanker `--name` is resolved by the configured target binary. Bare launches do not resolve or replace this variable. |
 | `DISABLE_TELEMETRY` | Blocks all Claude Code analytics/telemetry (set to `1`) |
 | `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | Blocks Claude Code analytics, auto-updates, release notes, feature flags (set to `1`) |
 | `GEMINI_TELEMETRY_ENABLED` | Gemini CLI telemetry master switch (set to `false`) |

--- a/docs/extensions/configuration.md
+++ b/docs/extensions/configuration.md
@@ -48,7 +48,7 @@ enabled_plugins = []        # Empty = all bundled enabled; non-empty = only-thes
 
 ### Profiles (`~/.config/unleash/profiles/`)
 
-Each profile is a `.toml` file in `~/.config/unleash/profiles/`. The seven default profiles (`claude.toml`, `codex.toml`, `agy.toml`, `gemini.toml`, `opencode.toml`, `pi.toml`, `hermes.toml`) are created automatically on first run.
+Each profile is a `.toml` file in `~/.config/unleash/profiles/`. The eight default profiles (`claude.toml`, `codex.toml`, `clanker.toml`, `agy.toml`, `gemini.toml`, `opencode.toml`, `pi.toml`, `hermes.toml`) are created automatically on first run.
 
 **Example profile (`claude.toml`):**
 ```toml

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Unleash is a unified CLI manager for AI code agents — Claude Code, Codex, Antigravity (`agy`), Gemini CLI, OpenCode, Pi, and Hermes. It wraps these CLIs with a TUI, profiles, version management, and a plugin system.
+Unleash is a unified CLI manager for AI code agents — Claude Code, Codex, Clanker Code, Antigravity (`agy`), Gemini CLI, OpenCode, Pi, and Hermes. It wraps these CLIs with a TUI, profiles, version management, and a plugin system.
 
 ## Prerequisites
 
@@ -40,12 +40,13 @@ Navigation:
 
 ## Pick a Profile
 
-Unleash ships with seven default profiles:
+Unleash ships with eight default profiles:
 
 | Profile | Agent |
 |---------|-------|
 | `claude` | Claude Code |
 | `codex` | Codex CLI |
+| `clanker` | Clanker Code |
 | `agy` | Antigravity CLI |
 | `gemini` | Gemini CLI |
 | `opencode` | OpenCode |
@@ -57,6 +58,7 @@ Launch directly from the command line:
 ```bash
 unleash claude
 unleash codex
+unleash clanker
 unleash agy
 unleash gemini
 unleash opencode

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,8 @@ Unleash is a unified CLI manager for AI code agents — Claude Code, Codex, Clan
 - **curl** or **wget**
 - **git**
 - **Node.js / npm** — required for Claude Code and Gemini CLI
-- **Rust / Cargo** — optional, only needed to build from source
+- **Rust / Cargo** — optional for Unleash itself, but required to install or update Clanker Code
+- **Authenticated Git access to `heiervang-technologies/clanker-code`** — required for the private Clanker source build
 
 ## Install
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -4,12 +4,13 @@ Profiles control how Unleash launches agent CLIs. Each profile is a TOML file in
 
 ## Basics
 
-Unleash creates seven default profiles on first run:
+Unleash creates eight default profiles on first run:
 
 | Profile    | Theme     |
 |------------|-----------|
 | `claude`   | `orange`  |
 | `codex`    | `#aaaaaa` |
+| `clanker`  | `#d4a017` |
 | `agy`      | `#9b51e0` |
 | `gemini`   | `#4285f4` |
 | `opencode` | `#10b981` |

--- a/scripts/demo/install-splash.tape
+++ b/scripts/demo/install-splash.tape
@@ -11,14 +11,18 @@ Type "target/release/splash"
 Enter
 Sleep 2s
 
-# Splash picker cycles through all 7 supported agents.
-# Order (from src/bin/splash.rs): claude → codex → antigravity → opencode → pi → hermes → gemini → claude
+# Splash picker cycles through all 8 supported agents.
+# Order (from src/bin/splash.rs): claude → codex → clanker → antigravity → opencode → pi → hermes → gemini → claude
 
 # claude → codex (grey)
 Right
 Sleep 1.2s
 
-# codex → antigravity (purple)
+# codex → clanker (gold)
+Right
+Sleep 1.2s
+
+# clanker → antigravity (blue)
 Right
 Sleep 1.2s
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 # install.sh - Install unleash
 #
 # This script:
-# 1. Detects supported agent CLIs (Claude, Codex, Gemini, OpenCode)
+# 1. Detects supported agent CLIs (Claude, Codex, Clanker, Gemini, OpenCode)
 # 2. Builds the CLI binaries (if cargo available)
 # 3. Creates symlinks in ~/.local/bin/
 # 4. Installs plugins to ~/.local/share/unleash/plugins
@@ -47,6 +47,7 @@ install_binary_atomic() {
 declare -A AGENT_BINARIES=(
     [claude]="Claude Code"
     [codex]="Codex"
+    [clanker]="Clanker Code"
     [gemini]="Gemini CLI"
     [opencode]="OpenCode"
     [pi]="Pi"
@@ -56,7 +57,7 @@ declare -A AGENT_BINARIES=(
 # Detect installed agent CLIs
 detect_agents() {
     local found=0
-    for bin in claude codex gemini opencode pi hermes; do
+    for bin in claude codex clanker gemini opencode pi hermes; do
         local display="${AGENT_BINARIES[$bin]}"
         if command -v "$bin" &> /dev/null; then
             local version
@@ -69,7 +70,7 @@ detect_agents() {
     if [[ $found -eq 0 ]]; then
         warn "No supported agent CLIs found"
         echo "    Install agents via: unleash agents update <name>"
-        echo "    Supported: claude, codex, gemini, opencode, pi, hermes"
+        echo "    Supported: claude, codex, clanker, gemini, opencode, pi, hermes"
     else
         info "$found agent CLI(s) detected"
     fi
@@ -249,7 +250,7 @@ echo "╰───────────────────────�
 echo ""
 echo "CLI Commands:"
 echo "  unleash              - Launch TUI for profile/version management"
-echo "  unleash <agent>      - Start an agent (claude, codex, gemini, opencode, pi, hermes)"
+echo "  unleash <agent>      - Start an agent (claude, codex, clanker, gemini, opencode, pi, hermes)"
 echo "  unleash agents       - Manage agent CLI installations and versions"
 echo ""
 echo "Helper Commands:"

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -404,7 +404,7 @@ impl AgentDefinition {
                     "--sandbox".to_string(),
                     "workspace-write".to_string(),
                 ),
-                name_flag: None,
+                name_flag: Some("--name".to_string()),
                 add_dir_flag: Some("--add-dir".to_string()),
                 approval_mode_flag: Some("-a".to_string()),
                 worktree_flag: None,

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -21,6 +21,7 @@ pub enum AgentType {
     Unleash,
     Claude,
     Codex,
+    Clanker,
     Antigravity,
     Gemini,
     OpenCode,
@@ -35,6 +36,7 @@ impl AgentType {
         &[
             AgentType::Claude,
             AgentType::Codex,
+            AgentType::Clanker,
             AgentType::Antigravity,
             AgentType::OpenCode,
             AgentType::Pi,
@@ -47,8 +49,10 @@ impl AgentType {
     pub fn all_with_custom(custom: &[AgentDefinition]) -> Vec<AgentType> {
         let mut types: Vec<AgentType> = Self::builtin().to_vec();
         for def in custom {
-            if let AgentType::Custom(_) = &def.agent_type {
-                types.push(def.agent_type.clone());
+            if let AgentType::Custom(name) = &def.agent_type {
+                if Self::from_str(name).is_none() {
+                    types.push(def.agent_type.clone());
+                }
             }
         }
         types
@@ -66,6 +70,7 @@ impl AgentType {
             AgentType::Unleash => Cow::Borrowed("Unleash"),
             AgentType::Claude => Cow::Borrowed("Claude Code"),
             AgentType::Codex => Cow::Borrowed("Codex"),
+            AgentType::Clanker => Cow::Borrowed("Clanker Code"),
             AgentType::Antigravity => Cow::Borrowed("Antigravity CLI"),
             AgentType::Gemini => Cow::Borrowed("Gemini CLI"),
             AgentType::OpenCode => Cow::Borrowed("OpenCode"),
@@ -82,6 +87,7 @@ impl AgentType {
         match s.to_lowercase().as_str() {
             "claude" | "claude-code" => Some(AgentType::Claude),
             "codex" => Some(AgentType::Codex),
+            "clanker" | "clanker-code" => Some(AgentType::Clanker),
             "antigravity" | "antigravity-cli" | "agy" => Some(AgentType::Antigravity),
             "gemini" | "gemini-cli" => Some(AgentType::Gemini),
             "opencode" | "open-code" => Some(AgentType::OpenCode),
@@ -97,6 +103,7 @@ impl AgentType {
             AgentType::Unleash => "unleash",
             AgentType::Claude => "claude",
             AgentType::Codex => "codex",
+            AgentType::Clanker => "clanker",
             AgentType::Antigravity => "antigravity",
             AgentType::Gemini => "gemini",
             AgentType::OpenCode => "opencode",
@@ -331,6 +338,7 @@ impl AgentDefinition {
             ),
             AgentType::Claude => Self::claude(),
             AgentType::Codex => Self::codex(),
+            AgentType::Clanker => Self::clanker(),
             AgentType::Antigravity => Self::antigravity(),
             AgentType::Gemini => Self::gemini(),
             AgentType::OpenCode => Self::opencode(),
@@ -414,6 +422,22 @@ impl AgentDefinition {
             npm_package: None,
             enabled: true,
         }
+    }
+
+    /// Create the Clanker Code definition.
+    ///
+    /// Clanker is a Codex-compatible fork, but it is independently installed
+    /// and updated from the fork's release branch. Keep its launch grammar in
+    /// sync with Codex while preserving Clanker's explicit character selector.
+    pub fn clanker() -> Self {
+        let mut definition = Self::codex();
+        definition.agent_type = AgentType::Clanker;
+        definition.name = "Clanker Code".to_string();
+        definition.binary = "clanker".to_string();
+        definition.description = "Heiervang Technologies' character-first Codex fork".to_string();
+        definition.polyfill.name_flag = Some("--name".to_string());
+        definition.github_repo = Some(crate::clanker::REPOSITORY.to_string());
+        definition
     }
 
     /// Create Antigravity CLI agent definition
@@ -647,6 +671,7 @@ impl AgentManager {
         // Register default agents
         manager.register_agent(AgentDefinition::claude());
         manager.register_agent(AgentDefinition::codex());
+        manager.register_agent(AgentDefinition::clanker());
         manager.register_agent(AgentDefinition::gemini());
         manager.register_agent(AgentDefinition::antigravity());
         manager.register_agent(AgentDefinition::opencode());
@@ -661,7 +686,7 @@ impl AgentManager {
         if let Ok(mgr) = crate::config::ProfileManager::new() {
             if let Ok(app_config) = mgr.load_app_config() {
                 for custom in &app_config.custom_agents {
-                    if !custom.enabled {
+                    if !custom.enabled || AgentType::from_str(&custom.name).is_some() {
                         continue;
                     }
                     manager.register_agent(AgentDefinition::from_custom_config(custom));
@@ -688,6 +713,7 @@ impl AgentManager {
         };
         manager.register_agent(AgentDefinition::claude());
         manager.register_agent(AgentDefinition::codex());
+        manager.register_agent(AgentDefinition::clanker());
         manager.register_agent(AgentDefinition::gemini());
         manager.register_agent(AgentDefinition::antigravity());
         manager.register_agent(AgentDefinition::opencode());
@@ -715,7 +741,20 @@ impl AgentManager {
 
     /// List all registered agents
     pub fn list_agents(&self) -> Vec<&AgentDefinition> {
-        self.agents.values().collect()
+        let mut agents = Vec::with_capacity(self.agents.len());
+        for agent_type in AgentType::builtin() {
+            if let Some(agent) = self.agents.get(agent_type) {
+                agents.push(agent);
+            }
+        }
+        let mut custom: Vec<_> = self
+            .agents
+            .values()
+            .filter(|agent| matches!(agent.agent_type, AgentType::Custom(_)))
+            .collect();
+        custom.sort_by(|left, right| left.name.cmp(&right.name));
+        agents.extend(custom);
+        agents
     }
 
     /// Resolve a user-supplied name to an AgentType.
@@ -956,6 +995,20 @@ impl AgentManager {
 
     /// Get latest version from GitHub
     pub fn get_latest_version(&mut self, agent_type: AgentType) -> io::Result<Option<String>> {
+        if agent_type == AgentType::Clanker {
+            let revision = crate::clanker::latest_revision()?;
+            let version = crate::clanker::revision_label(&revision).to_string();
+            let entry = self.versions.entry(agent_type).or_default();
+            entry.latest = Some(version.clone());
+            entry.last_checked = Some(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+            );
+            return Ok(Some(version));
+        }
+
         let agent = self
             .agents
             .get(&agent_type)
@@ -1008,6 +1061,12 @@ impl AgentManager {
 
     /// Check if an update is available
     pub fn check_update(&mut self, agent_type: AgentType) -> io::Result<bool> {
+        if agent_type == AgentType::Clanker {
+            let latest = crate::clanker::latest_revision()?;
+            let installed = self.get_installed_version(AgentType::Clanker)?;
+            return Ok(installed.is_none() || crate::clanker::update_available(&latest));
+        }
+
         let installed = self.get_installed_version(agent_type.clone())?;
         let latest = self.get_latest_version(agent_type)?;
 
@@ -1030,6 +1089,7 @@ impl AgentManager {
             )),
             AgentType::Claude => self.update_claude(),
             AgentType::Codex => self.update_codex(),
+            AgentType::Clanker => self.update_clanker(),
             AgentType::Antigravity => self.update_antigravity(),
             AgentType::Gemini => self.update_npm_agent("@google/gemini-cli", "Gemini CLI"),
             AgentType::OpenCode => self.update_opencode(),
@@ -1270,6 +1330,16 @@ impl AgentManager {
         }
 
         Self::build_codex_from_source(&install_path)
+    }
+
+    fn update_clanker(&self) -> io::Result<String> {
+        let outcome = crate::clanker::install_latest()?;
+        Ok(format!(
+            "Clanker Code {} ({}) installed to {}",
+            outcome.product_version,
+            crate::clanker::revision_label(&outcome.revision),
+            outcome.install_path.display()
+        ))
     }
 
     /// Download and install prebuilt Codex binary from GitHub releases
@@ -2615,6 +2685,64 @@ mod tests {
         );
         assert_eq!(pi.binary, "pi");
         assert_eq!(pi.agent_type, AgentType::Pi);
+    }
+
+    #[test]
+    fn clanker_is_first_class_and_ranked_directly_after_codex() {
+        let builtins = AgentType::builtin();
+        assert_eq!(builtins[1], AgentType::Codex);
+        assert_eq!(builtins[2], AgentType::Clanker);
+        assert!(
+            builtins
+                .iter()
+                .position(|agent| *agent == AgentType::Clanker)
+                < builtins.iter().position(|agent| *agent == AgentType::Pi)
+        );
+        assert!(
+            builtins
+                .iter()
+                .position(|agent| *agent == AgentType::Clanker)
+                < builtins
+                    .iter()
+                    .position(|agent| *agent == AgentType::Hermes)
+        );
+        assert_eq!(AgentType::from_str("clanker"), Some(AgentType::Clanker));
+        assert_eq!(
+            AgentType::from_str("clanker-code"),
+            Some(AgentType::Clanker)
+        );
+    }
+
+    #[test]
+    fn clanker_definition_uses_fork_binary_repository_and_name_flag() {
+        let clanker = AgentDefinition::clanker();
+        assert_eq!(clanker.agent_type, AgentType::Clanker);
+        assert_eq!(clanker.binary, "clanker");
+        assert_eq!(
+            clanker.github_repo.as_deref(),
+            Some(crate::clanker::REPOSITORY)
+        );
+        assert!(clanker.npm_package.is_none());
+        assert_eq!(clanker.polyfill.name_flag.as_deref(), Some("--name"));
+        assert!(matches!(
+            clanker.polyfill.headless,
+            HeadlessStrategy::Subcommand(ref command) if command == "exec"
+        ));
+    }
+
+    #[test]
+    fn legacy_custom_clanker_is_suppressed_from_builtin_picker_order() {
+        let mut legacy = AgentDefinition::clanker();
+        legacy.agent_type = AgentType::Custom("clanker".to_string());
+        let types = AgentType::all_with_custom(&[legacy]);
+        assert_eq!(
+            types
+                .iter()
+                .filter(|agent| **agent == AgentType::Clanker)
+                .count(),
+            1
+        );
+        assert!(!types.contains(&AgentType::Custom("clanker".to_string())));
     }
 
     #[test]

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -412,7 +412,7 @@ impl AgentDefinition {
                     "--sandbox".to_string(),
                     "workspace-write".to_string(),
                 ),
-                name_flag: Some("--name".to_string()),
+                name_flag: None,
                 add_dir_flag: Some("--add-dir".to_string()),
                 approval_mode_flag: Some("-a".to_string()),
                 worktree_flag: None,

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -814,6 +814,16 @@ impl AgentManager {
             .get(&agent_type)
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Agent not found"))?;
 
+        if agent_type == AgentType::Clanker {
+            let version = crate::clanker::installed_product_version();
+            let entry = self.versions.entry(agent_type).or_default();
+            entry.installed = version.clone();
+            entry.binary_path = version
+                .as_ref()
+                .and_then(|_| dirs::home_dir().map(|home| home.join(".local/bin/clanker")));
+            return Ok(version);
+        }
+
         if agent_type == AgentType::Antigravity {
             // Prefer the CLI binary version. The desktop Antigravity app and
             // the `agy` companion CLI use different version lines, and this
@@ -999,7 +1009,9 @@ impl AgentManager {
             let revision = crate::clanker::latest_revision()?;
             let version = crate::clanker::revision_label(&revision).to_string();
             let entry = self.versions.entry(agent_type).or_default();
-            entry.latest = Some(version.clone());
+            // Cache the full revision for equality checks. The abbreviated
+            // label is presentation-only and cannot be revision authority.
+            entry.latest = Some(revision);
             entry.last_checked = Some(
                 std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
@@ -1704,18 +1716,46 @@ impl AgentManager {
                 .get_installed_version(agent_type.clone())
                 .ok()
                 .flatten();
-            let latest = self
+            let latest_revision = self
                 .versions
                 .get(&agent_type)
                 .and_then(|v| v.latest.clone());
-            let update_available = match (&installed, &latest) {
-                (Some(i), Some(l)) => crate::version::version_less_than(i, l),
-                _ => false,
+            let installed_revision = (agent_type == AgentType::Clanker)
+                .then(crate::clanker::installed_revision)
+                .flatten();
+            let update_available = status_update_available(
+                &agent_type,
+                installed.as_deref(),
+                latest_revision.as_deref(),
+                installed_revision.as_deref(),
+            );
+            let latest = if agent_type == AgentType::Clanker {
+                latest_revision
+                    .as_deref()
+                    .map(crate::clanker::revision_label)
+                    .map(str::to_string)
+            } else {
+                latest_revision
             };
             results.push((agent_type, installed, latest, update_available));
         }
 
         results
+    }
+}
+
+fn status_update_available(
+    agent_type: &AgentType,
+    installed_version: Option<&str>,
+    latest: Option<&str>,
+    installed_revision: Option<&str>,
+) -> bool {
+    match agent_type {
+        AgentType::Clanker => latest.is_some_and(|revision| installed_revision != Some(revision)),
+        _ => match (installed_version, latest) {
+            (Some(installed), Some(latest)) => crate::version::version_less_than(installed, latest),
+            _ => false,
+        },
     }
 }
 
@@ -2727,6 +2767,31 @@ mod tests {
         assert!(matches!(
             clanker.polyfill.headless,
             HeadlessStrategy::Subcommand(ref command) if command == "exec"
+        ));
+    }
+
+    #[test]
+    fn clanker_status_compares_revisions_instead_of_product_semver() {
+        let latest = "40e7d1c0d9b0621d756eb14a5aa7735466aca0a9";
+        let prior = "1111111111111111111111111111111111111111";
+
+        assert!(!status_update_available(
+            &AgentType::Clanker,
+            Some("0.1.0+codex.0.143.0"),
+            Some(latest),
+            Some(latest),
+        ));
+        assert!(status_update_available(
+            &AgentType::Clanker,
+            Some("999.0.0"),
+            Some(latest),
+            Some(prior),
+        ));
+        assert!(status_update_available(
+            &AgentType::Clanker,
+            Some("999.0.0"),
+            Some(latest),
+            None,
         ));
     }
 

--- a/src/bin/splash.rs
+++ b/src/bin/splash.rs
@@ -49,6 +49,14 @@ fn agents() -> Vec<Agent> {
             accent: Color::Rgb(140, 140, 140),
         },
         Agent {
+            name: "clanker",
+            theme: AgentTheme::Shift(ThemeShift {
+                hue: 35.23,
+                sat_scale: 1.0,
+            }),
+            accent: Color::Rgb(212, 160, 23),
+        },
+        Agent {
             name: "antigravity",
             theme: AgentTheme::Gradient(unleash::theme::GradientTheme::antigravity()),
             accent: Color::Rgb(0x30, 0x80, 0xe0),

--- a/src/clanker.rs
+++ b/src/clanker.rs
@@ -54,7 +54,11 @@ pub(crate) fn latest_revision() -> io::Result<String> {
 }
 
 pub(crate) fn installed_revision() -> Option<String> {
-    read_receipt(&receipt_path()).map(|receipt| receipt.revision)
+    installed_receipt().map(|receipt| receipt.revision)
+}
+
+pub(crate) fn installed_product_version() -> Option<String> {
+    installed_receipt().map(|receipt| receipt.product_version)
 }
 
 pub(crate) fn update_available(latest_revision: &str) -> bool {
@@ -128,7 +132,7 @@ fn install_latest_in(home: &Path) -> io::Result<InstallOutcome> {
     strip_binary_if_available(&built_binary)?;
 
     let product_version = probe_product_version(&built_binary)?;
-    let install_path = home.join(".local/bin/clanker");
+    let install_path = install_path_for(home);
     crate::agents::atomic_install_binary(&built_binary, &install_path)?;
 
     let receipt = InstallReceipt {
@@ -293,14 +297,31 @@ fn probe_product_version(binary: &Path) -> io::Result<String> {
     Ok(version.to_string())
 }
 
-fn receipt_path() -> PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".local/share/unleash/clanker-install.json")
-}
-
 fn receipt_path_for(home: &Path) -> PathBuf {
     home.join(".local/share/unleash/clanker-install.json")
+}
+
+fn install_path_for(home: &Path) -> PathBuf {
+    home.join(".local/bin/clanker")
+}
+
+fn installed_receipt() -> Option<InstallReceipt> {
+    let home = dirs::home_dir()?;
+    installed_receipt_for(&home)
+}
+
+/// Return a receipt only when it still describes the binary Unleash owns.
+///
+/// The receipt is revision authority, not merely a cache: a missing or
+/// replaced binary must never make an update check report "up to date".
+fn installed_receipt_for(home: &Path) -> Option<InstallReceipt> {
+    let receipt = read_receipt(&receipt_path_for(home))?;
+    let binary = install_path_for(home);
+    if !binary.is_file() {
+        return None;
+    }
+    let product_version = probe_product_version(&binary).ok()?;
+    (product_version == receipt.product_version).then_some(receipt)
 }
 
 fn write_receipt(path: &Path, receipt: &InstallReceipt) -> io::Result<()> {
@@ -440,5 +461,43 @@ mod tests {
         invalid.repository = "openai/codex".to_string();
         write_receipt(&path, &invalid).unwrap();
         assert_eq!(read_receipt(&path), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn installed_receipt_requires_the_owned_matching_binary() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let receipt = InstallReceipt {
+            schema_version: RECEIPT_SCHEMA_VERSION,
+            repository: REPOSITORY.to_string(),
+            branch: RELEASE_BRANCH.to_string(),
+            revision: REVISION.to_string(),
+            product_version: "0.1.0+codex.0.143.0".to_string(),
+        };
+        write_receipt(&receipt_path_for(temp.path()), &receipt).unwrap();
+
+        assert_eq!(installed_receipt_for(temp.path()), None);
+
+        let binary = install_path_for(temp.path());
+        fs::create_dir_all(binary.parent().unwrap()).unwrap();
+        fs::write(
+            &binary,
+            "#!/bin/sh\nprintf '%s\\n' 'Clanker Code 0.1.0+codex.0.143.0'\n",
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&binary, permissions).unwrap();
+
+        assert_eq!(installed_receipt_for(temp.path()), Some(receipt.clone()));
+
+        fs::write(
+            &binary,
+            "#!/bin/sh\nprintf '%s\\n' 'Clanker Code 0.1.0+codex.replaced'\n",
+        )
+        .unwrap();
+        assert_eq!(installed_receipt_for(temp.path()), None);
     }
 }

--- a/src/clanker.rs
+++ b/src/clanker.rs
@@ -1,0 +1,444 @@
+//! First-class Clanker Code source installation and revision tracking.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub(crate) const REPOSITORY: &str = "heiervang-technologies/clanker-code";
+pub(crate) const REPOSITORY_URL: &str =
+    "https://github.com/heiervang-technologies/clanker-code.git";
+pub(crate) const RELEASE_BRANCH: &str = "clanker";
+
+const RECEIPT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InstallReceipt {
+    schema_version: u32,
+    repository: String,
+    branch: String,
+    revision: String,
+    product_version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InstallOutcome {
+    pub revision: String,
+    pub product_version: String,
+    pub install_path: PathBuf,
+}
+
+pub(crate) fn revision_label(revision: &str) -> &str {
+    revision.get(..12).unwrap_or(revision)
+}
+
+pub(crate) fn latest_revision() -> io::Result<String> {
+    let output = Command::new("git")
+        .args([
+            "ls-remote",
+            "--exit-code",
+            REPOSITORY_URL,
+            &format!("refs/heads/{RELEASE_BRANCH}"),
+        ])
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "failed to resolve {REPOSITORY}/{RELEASE_BRANCH}: {}. \
+             Authenticate Git for the private Clanker Code repository and retry",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    parse_ls_remote(&output.stdout)
+}
+
+pub(crate) fn installed_revision() -> Option<String> {
+    read_receipt(&receipt_path()).map(|receipt| receipt.revision)
+}
+
+pub(crate) fn update_available(latest_revision: &str) -> bool {
+    installed_revision().as_deref() != Some(latest_revision)
+}
+
+pub(crate) fn install_latest() -> io::Result<InstallOutcome> {
+    let home = dirs::home_dir()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Home dir not found"))?;
+    install_latest_in(&home)
+}
+
+fn install_latest_in(home: &Path) -> io::Result<InstallOutcome> {
+    ensure_build_dependencies()?;
+
+    let cache_root = home.join(".cache/unleash");
+    let source_dir = cache_root.join("clanker-source");
+    let target_dir = cache_root.join("clanker-target");
+    fs::create_dir_all(&cache_root)?;
+
+    prepare_source_checkout(&source_dir)?;
+    let revision = git_stdout(&source_dir, &["rev-parse", "HEAD"])?;
+    validate_revision(&revision)?;
+
+    let codex_rs = source_dir.join("codex-rs");
+    if !codex_rs.join("cli/Cargo.toml").is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "Clanker Code checkout is missing {}",
+                codex_rs.join("cli/Cargo.toml").display()
+            ),
+        ));
+    }
+
+    let status = Command::new("cargo")
+        .args([
+            "build",
+            "--locked",
+            "--release",
+            "-p",
+            "codex-cli",
+            "--bin",
+            "clanker",
+            "-j",
+            "2",
+        ])
+        .current_dir(&codex_rs)
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .env("CARGO_PROFILE_RELEASE_LTO", "off")
+        .env("CARGO_PROFILE_RELEASE_CODEGEN_UNITS", "16")
+        .status()?;
+    if !status.success() {
+        return Err(io::Error::other(format!(
+            "failed to build Clanker Code revision {}",
+            revision_label(&revision)
+        )));
+    }
+
+    let built_binary = target_dir.join("release/clanker");
+    if !built_binary.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "Clanker Code build succeeded but {} was not produced",
+                built_binary.display()
+            ),
+        ));
+    }
+
+    strip_binary_if_available(&built_binary)?;
+
+    let product_version = probe_product_version(&built_binary)?;
+    let install_path = home.join(".local/bin/clanker");
+    crate::agents::atomic_install_binary(&built_binary, &install_path)?;
+
+    let receipt = InstallReceipt {
+        schema_version: RECEIPT_SCHEMA_VERSION,
+        repository: REPOSITORY.to_string(),
+        branch: RELEASE_BRANCH.to_string(),
+        revision: revision.clone(),
+        product_version: product_version.clone(),
+    };
+    write_receipt(&receipt_path_for(home), &receipt)?;
+
+    Ok(InstallOutcome {
+        revision,
+        product_version,
+        install_path,
+    })
+}
+
+fn ensure_build_dependencies() -> io::Result<()> {
+    for binary in ["git", "cargo"] {
+        if which::which(binary).is_err() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!(
+                    "{binary} is required to install Clanker Code from {REPOSITORY}/{RELEASE_BRANCH}"
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn prepare_source_checkout(source_dir: &Path) -> io::Result<()> {
+    if source_dir.join(".git").is_dir() {
+        let origin = git_stdout(source_dir, &["remote", "get-url", "origin"])?;
+        if !is_expected_origin(&origin) {
+            return Err(io::Error::other(format!(
+                "refusing to update unmanaged checkout {} with origin {:?}; expected {}",
+                source_dir.display(),
+                origin,
+                REPOSITORY_URL
+            )));
+        }
+
+        run_git(
+            source_dir,
+            &["fetch", "--prune", "--depth", "1", "origin", RELEASE_BRANCH],
+        )?;
+        run_git(
+            source_dir,
+            &["checkout", "--detach", "--force", "FETCH_HEAD"],
+        )?;
+        return Ok(());
+    }
+
+    if source_dir.exists() {
+        return Err(io::Error::other(format!(
+            "refusing to replace non-Git path {}",
+            source_dir.display()
+        )));
+    }
+
+    let parent = source_dir.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Clanker source path has no parent",
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+    let output = Command::new("git")
+        .args([
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            RELEASE_BRANCH,
+            "--single-branch",
+            REPOSITORY_URL,
+        ])
+        .arg(source_dir)
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "failed to clone {REPOSITORY}: {}. \
+             Authenticate Git for the private Clanker Code repository and retry",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+fn run_git(current_dir: &Path, args: &[&str]) -> io::Result<()> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(current_dir)
+        .output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "git {} failed in {}: {}",
+            args.join(" "),
+            current_dir.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )))
+    }
+}
+
+fn git_stdout(current_dir: &Path, args: &[&str]) -> io::Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(current_dir)
+        .output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "git {} failed in {}: {}",
+            args.join(" "),
+            current_dir.display(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn strip_binary_if_available(binary: &Path) -> io::Result<()> {
+    let Ok(strip) = which::which("strip") else {
+        return Ok(());
+    };
+    let mut command = Command::new(strip);
+    #[cfg(target_os = "macos")]
+    command.arg("-x");
+    #[cfg(not(target_os = "macos"))]
+    command.arg("--strip-all");
+    let output = command.arg(binary).output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "failed to strip Clanker Code binary: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )))
+    }
+}
+
+fn probe_product_version(binary: &Path) -> io::Result<String> {
+    let output = Command::new(binary).arg("--version").output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "new Clanker Code binary failed its version probe: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    let line = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let version = line.strip_prefix("Clanker Code ").ok_or_else(|| {
+        io::Error::other(format!("unexpected Clanker Code version output: {line}"))
+    })?;
+    if version.is_empty() {
+        return Err(io::Error::other(
+            "Clanker Code version output did not contain a version",
+        ));
+    }
+    Ok(version.to_string())
+}
+
+fn receipt_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".local/share/unleash/clanker-install.json")
+}
+
+fn receipt_path_for(home: &Path) -> PathBuf {
+    home.join(".local/share/unleash/clanker-install.json")
+}
+
+fn write_receipt(path: &Path, receipt: &InstallReceipt) -> io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Clanker install receipt has no parent",
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+    let tmp = parent.join(format!(".clanker-install.{}.tmp", std::process::id()));
+    let bytes = serde_json::to_vec_pretty(receipt)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    fs::write(&tmp, bytes)?;
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+fn read_receipt(path: &Path) -> Option<InstallReceipt> {
+    let bytes = fs::read(path).ok()?;
+    if bytes.len() > 16 * 1024 {
+        return None;
+    }
+    let receipt: InstallReceipt = serde_json::from_slice(&bytes).ok()?;
+    if receipt.schema_version != RECEIPT_SCHEMA_VERSION
+        || receipt.repository != REPOSITORY
+        || receipt.branch != RELEASE_BRANCH
+        || validate_revision(&receipt.revision).is_err()
+        || receipt.product_version.is_empty()
+    {
+        return None;
+    }
+    Some(receipt)
+}
+
+fn parse_ls_remote(stdout: &[u8]) -> io::Result<String> {
+    let text = std::str::from_utf8(stdout)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    let mut lines = text.lines();
+    let line = lines
+        .next()
+        .ok_or_else(|| io::Error::other("Clanker Code branch did not resolve to a revision"))?;
+    if lines.next().is_some() {
+        return Err(io::Error::other(
+            "Clanker Code branch resolution returned multiple revisions",
+        ));
+    }
+    let mut fields = line.split_whitespace();
+    let revision = fields
+        .next()
+        .ok_or_else(|| io::Error::other("Clanker Code revision was missing"))?;
+    let reference = fields
+        .next()
+        .ok_or_else(|| io::Error::other("Clanker Code branch reference was missing"))?;
+    if fields.next().is_some() || reference != format!("refs/heads/{RELEASE_BRANCH}") {
+        return Err(io::Error::other(
+            "Clanker Code branch resolution returned an unexpected reference",
+        ));
+    }
+    validate_revision(revision)?;
+    Ok(revision.to_string())
+}
+
+fn validate_revision(revision: &str) -> io::Result<()> {
+    if revision.len() == 40
+        && revision
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "invalid Clanker Code Git revision {revision:?}"
+        )))
+    }
+}
+
+fn is_expected_origin(origin: &str) -> bool {
+    matches!(
+        origin.trim_end_matches('/').trim_end_matches(".git"),
+        "https://github.com/heiervang-technologies/clanker-code"
+            | "git@github.com:heiervang-technologies/clanker-code"
+            | "ssh://git@github.com/heiervang-technologies/clanker-code"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const REVISION: &str = "40e7d1c0d9b0621d756eb14a5aa7735466aca0a9";
+
+    #[test]
+    fn parses_exact_release_branch_revision() {
+        let output = format!("{REVISION}\trefs/heads/clanker\n");
+        assert_eq!(parse_ls_remote(output.as_bytes()).unwrap(), REVISION);
+        assert_eq!(revision_label(REVISION), "40e7d1c0d9b0");
+    }
+
+    #[test]
+    fn rejects_ambiguous_or_noncanonical_revision_output() {
+        assert!(parse_ls_remote(b"BAD\trefs/heads/clanker\n").is_err());
+        assert!(parse_ls_remote(format!("{REVISION}\trefs/heads/main\n").as_bytes()).is_err());
+        assert!(parse_ls_remote(
+            format!("{REVISION}\trefs/heads/clanker\n{REVISION}\trefs/heads/main\n").as_bytes()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn validates_supported_origin_forms() {
+        assert!(is_expected_origin(REPOSITORY_URL));
+        assert!(is_expected_origin(
+            "git@github.com:heiervang-technologies/clanker-code.git"
+        ));
+        assert!(is_expected_origin(
+            "ssh://git@github.com/heiervang-technologies/clanker-code"
+        ));
+        assert!(!is_expected_origin("https://github.com/openai/codex.git"));
+    }
+
+    #[test]
+    fn receipt_round_trips_and_rejects_wrong_authority() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("clanker-install.json");
+        let receipt = InstallReceipt {
+            schema_version: RECEIPT_SCHEMA_VERSION,
+            repository: REPOSITORY.to_string(),
+            branch: RELEASE_BRANCH.to_string(),
+            revision: REVISION.to_string(),
+            product_version: "0.1.0+codex.0.143.0".to_string(),
+        };
+        write_receipt(&path, &receipt).unwrap();
+        assert_eq!(read_receipt(&path), Some(receipt.clone()));
+
+        let mut invalid = receipt;
+        invalid.repository = "openai/codex".to_string();
+        write_receipt(&path, &invalid).unwrap();
+        assert_eq!(read_receipt(&path), None);
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -129,7 +129,7 @@ pub struct PolyfillArgs {
     #[arg(long)]
     pub sandbox: bool,
 
-    /// Session name
+    /// Session or character name (agent-specific)
     #[arg(long)]
     pub name: Option<String>,
 
@@ -352,6 +352,14 @@ impl PolyfillArgs {
                         }
                     } else {
                         polyfill.worktree = Some(String::new()); // no name
+                    }
+                }
+                "-u" | "--ucf" => {
+                    if let Some(val) = args.get(i + 1).filter(|val| !val.starts_with('-')) {
+                        polyfill.ucf = Some(val.clone());
+                        i += 1;
+                    } else {
+                        polyfill.ucf = Some(String::new());
                     }
                 }
                 "-x" | "--crossload" => {
@@ -1194,6 +1202,19 @@ mod tests {
         let (polyfill, _) = PolyfillArgs::parse_from_raw(&args);
         assert_eq!(polyfill.model, Some("opus".to_string()));
         assert_eq!(polyfill.prompt, Some("fix bug".to_string()));
+    }
+
+    #[test]
+    fn test_parse_ucf_split_and_equals_syntax() {
+        let split: Vec<String> = vec!["--ucf".into(), "lineage".into()];
+        let (polyfill, passthrough) = PolyfillArgs::parse_from_raw(&split);
+        assert_eq!(polyfill.ucf.as_deref(), Some("lineage"));
+        assert!(passthrough.is_empty());
+
+        let equals: Vec<String> = vec!["--ucf=lineage".into()];
+        let (polyfill, passthrough) = PolyfillArgs::parse_from_raw(&equals);
+        assert_eq!(polyfill.ucf.as_deref(), Some("lineage"));
+        assert!(passthrough.is_empty());
     }
 
     fn no_defaults() -> crate::config::ProfileDefaults {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -532,11 +532,11 @@ impl PolyfillArgs {
 #[command(author = "Heiervang Technologies")]
 #[command(version)]
 #[command(
-    about = "unleash - Extended CLI for AI Code Agents\n\nRun a profile:  unleash <profile> [flags] [-- passthrough]\nDefault profiles: claude, codex, antigravity, gemini, opencode\n\nRun 'unleash <profile> --help' for unified flag details."
+    about = "unleash - Extended CLI for AI Code Agents\n\nRun a profile:  unleash <profile> [flags] [-- passthrough]\nDefault profiles: claude, codex, clanker, antigravity, gemini, opencode, pi, hermes\n\nRun 'unleash <profile> --help' for unified flag details."
 )]
 #[command(long_about = r#"unleash - Extended CLI for AI Code Agents
 
-A wrapper for AI code agents (Claude, Codex, Antigravity, Gemini, OpenCode) with extended features:
+A wrapper for AI code agents (Claude, Codex, Clanker, Antigravity, Gemini, OpenCode, Pi, Hermes) with extended features:
   - Unified flags that work across all agents (polyfill layer)
   - Self-restart capability for MCP server reloading
   - Plugin system integration (loads from plugins/bundled/)
@@ -553,7 +553,7 @@ ARGUMENT LAYERS:
 
 USAGE:
   unleash              Opens TUI for profile and version management
-  unleash <profile>    Run a profile (claude, codex, antigravity, gemini, opencode, or custom)
+  unleash <profile>    Run a profile (claude, codex, clanker, antigravity, gemini, opencode, pi, hermes, or custom)
 
 UNIFIED FLAGS (before --):
   --safe                       Restore approval prompts (permissions bypassed by default)
@@ -613,7 +613,7 @@ pub enum Commands {
         action: Option<HooksAction>,
     },
 
-    /// Manage code agents (Claude, Codex, Antigravity, Gemini, OpenCode)
+    /// Manage code agents (Claude, Codex, Clanker, Antigravity, Gemini, OpenCode, Pi, Hermes)
     Agents {
         #[command(subcommand)]
         action: Option<AgentsAction>,
@@ -627,7 +627,7 @@ pub enum Commands {
     ///   unleash install codex claude # Install Codex and Claude
     ///   unleash install --all        # Install all agent CLIs
     Install {
-        /// Agents to install (e.g. claude, codex, antigravity, gemini, opencode)
+        /// Agents to install (e.g. claude, codex, clanker, antigravity, gemini, opencode)
         #[arg(conflicts_with = "all")]
         agents: Vec<String>,
 
@@ -644,7 +644,7 @@ pub enum Commands {
     ///   unleash uninstall gemini       # Uninstall Gemini CLI
     ///   unleash uninstall --all        # Uninstall all agent CLIs
     Uninstall {
-        /// Agents to uninstall (e.g. claude, codex, antigravity, gemini, opencode)
+        /// Agents to uninstall (e.g. claude, codex, clanker, antigravity, gemini, opencode)
         #[arg(conflicts_with = "all")]
         agents: Vec<String>,
 
@@ -660,7 +660,7 @@ pub enum Commands {
     /// -a/--all: update unleash + all installed agent CLIs
     /// Positional args: update specific agents (e.g. 'unleash update claude codex')
     Update {
-        /// Specific agents to update (e.g. claude, codex, antigravity, gemini, opencode)
+        /// Specific agents to update (e.g. claude, codex, clanker, antigravity, gemini, opencode)
         #[arg(conflicts_with_all = ["clis", "all"])]
         agents: Vec<String>,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -187,6 +187,17 @@ impl Profile {
                 env: default_env(),
             },
             Self {
+                name: "clanker".to_string(),
+                description: "Clanker Code by Heiervang Technologies".to_string(),
+                agent_cli_path: "clanker".to_string(),
+                agent_cli_args: Vec::new(),
+                defaults: ProfileDefaults::default(),
+                agents: ProfileOverrides::default(),
+                stop_prompt: None,
+                theme: "#d4a017".to_string(),
+                env: default_env(),
+            },
+            Self {
                 name: "agy".to_string(),
                 description: "Antigravity CLI (agy) by Google".to_string(),
                 agent_cli_path: "agy".to_string(),
@@ -725,11 +736,28 @@ mod tests {
         // All agent profiles are seeded by default
         assert!(profiles.contains(&"claude".to_string()));
         assert!(profiles.contains(&"codex".to_string()));
+        assert!(profiles.contains(&"clanker".to_string()));
         assert!(profiles.contains(&"agy".to_string()));
         assert!(profiles.contains(&"gemini".to_string()));
         assert!(profiles.contains(&"opencode".to_string()));
         assert!(profiles.contains(&"pi".to_string()));
         assert!(profiles.contains(&"hermes".to_string()));
+    }
+
+    #[test]
+    fn clanker_default_profile_is_ranked_after_codex_and_uses_fork_binary() {
+        let profiles = Profile::default_profiles();
+        let codex = profiles
+            .iter()
+            .position(|profile| profile.name == "codex")
+            .unwrap();
+        let clanker = profiles
+            .iter()
+            .position(|profile| profile.name == "clanker")
+            .unwrap();
+        assert_eq!(clanker, codex + 1);
+        assert_eq!(profiles[clanker].agent_cli_path, "clanker");
+        assert!(profiles[clanker].description.contains("Heiervang"));
     }
 
     #[test]
@@ -759,6 +787,7 @@ mod tests {
         let profiles = manager.list_profiles().unwrap();
         assert!(profiles.contains(&"claude".to_string()));
         assert!(profiles.contains(&"codex".to_string()));
+        assert!(profiles.contains(&"clanker".to_string()));
         assert!(profiles.contains(&"agy".to_string()));
         assert!(profiles.contains(&"gemini".to_string()));
         assert!(profiles.contains(&"opencode".to_string()));

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,0 +1,147 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::io;
+use std::path::Path;
+use std::process::Command;
+
+pub(crate) const CLANKER_ID_ENV: &str = "CLANKER_ID";
+
+#[derive(Debug, Deserialize)]
+struct CharacterResolution {
+    #[serde(rename = "schemaVersion")]
+    schema_version: u64,
+    ok: bool,
+    input: String,
+    id: Option<String>,
+}
+
+/// Resolve an explicit character name through the configured target binary.
+///
+/// Unleash deliberately owns no character registry. The target Clanker Code
+/// executable is the authority for aliases, collisions, and canonical ids.
+pub(crate) fn resolve_clanker_id(
+    agent_cmd: &Path,
+    requested_name: &str,
+    profile_env: &HashMap<String, String>,
+) -> io::Result<String> {
+    let output = Command::new(agent_cmd)
+        .args([
+            "character",
+            "resolve",
+            requested_name,
+            "--json",
+            "--materialize-builtin",
+        ])
+        .envs(profile_env)
+        .output()
+        .map_err(|err| {
+            io::Error::new(
+                err.kind(),
+                format!(
+                    "failed to run character resolver from {}: {err}",
+                    agent_cmd.display()
+                ),
+            )
+        })?;
+
+    if !output.status.success() {
+        let detail = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let message = if detail.is_empty() {
+            format!("character resolver exited with {}", output.status)
+        } else {
+            format!("character resolver exited with {}: {detail}", output.status)
+        };
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, message));
+    }
+
+    let resolution: CharacterResolution =
+        serde_json::from_slice(&output.stdout).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("character resolver returned invalid JSON: {err}"),
+            )
+        })?;
+    if resolution.schema_version != 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "character resolver returned unsupported schemaVersion {}",
+                resolution.schema_version
+            ),
+        ));
+    }
+    if !resolution.ok {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "character resolver returned ok=false with a successful exit status",
+        ));
+    }
+    if resolution.input != requested_name {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "character resolver response did not echo the requested name",
+        ));
+    }
+
+    resolution
+        .id
+        .filter(|id| !id.trim().is_empty() && id.trim() == id)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "character resolver did not return a canonical id",
+            )
+        })
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn resolver_script(body: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("clanker");
+        std::fs::write(&script, format!("#!/bin/sh\n{body}\n")).unwrap();
+        let mut permissions = std::fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script, permissions).unwrap();
+        (dir, script)
+    }
+
+    #[test]
+    fn resolves_alias_to_canonical_id_through_target_binary() {
+        let (_dir, script) = resolver_script(
+            r#"test "$1" = character
+test "$2" = resolve
+test "$3" = Cleo
+test "$4" = --json
+test "$5" = --materialize-builtin
+printf '%s\n' '{"schemaVersion":1,"ok":true,"input":"Cleo","id":"chloe","displayName":"Chloe","manifestPath":"/tmp/character.json","matchKind":"explicit_alias"}'"#,
+        );
+
+        assert_eq!(
+            resolve_clanker_id(&script, "Cleo", &HashMap::new()).unwrap(),
+            "chloe"
+        );
+    }
+
+    #[test]
+    fn rejects_unresolved_or_malformed_identity() {
+        let (_dir, unresolved) = resolver_script("echo not-found >&2\nexit 1");
+        assert_eq!(
+            resolve_clanker_id(&unresolved, "missing", &HashMap::new())
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+
+        let (_dir, malformed) = resolver_script("printf '%s\\n' '{\"ok\":true}'");
+        assert_eq!(
+            resolve_clanker_id(&malformed, "chloe", &HashMap::new())
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+}

--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -98,7 +98,7 @@ pub fn inject_session(
     // Inject into target
     let (result, target_path) = match target_cli {
         "claude" | "claude-code" => inject_into_claude(&session, &hub_records)?,
-        "codex" => inject_into_codex(&session, &hub_records)?,
+        "codex" | "clanker" | "clanker-code" => inject_into_codex(&session, &hub_records)?,
         "gemini" | "gemini-cli" => inject_into_gemini(&session, &hub_records)?,
         "antigravity" | "antigravity-cli" | "agy" => {
             // agy does NOT share gemini's session storage. Storage details
@@ -164,6 +164,7 @@ fn normalize_target_cli(target: &str) -> &str {
     match target {
         "claude" | "claude-code" => "claude",
         "codex" => "codex",
+        "clanker" | "clanker-code" => "clanker",
         "gemini" | "gemini-cli" => "gemini",
         // agy is intentionally NOT mapped to gemini here. They don't share
         // storage layout (gemini = JSON chats, agy = protobuf .pb files at
@@ -529,6 +530,7 @@ fn resume_args_for(target: &str, session_id: &str) -> Vec<String> {
     let agent_type = match target {
         "claude" | "claude-code" => crate::agents::AgentType::Claude,
         "codex" => crate::agents::AgentType::Codex,
+        "clanker" | "clanker-code" => crate::agents::AgentType::Clanker,
         "gemini" | "gemini-cli" => crate::agents::AgentType::Gemini,
         "antigravity" | "antigravity-cli" | "agy" => crate::agents::AgentType::Antigravity,
         "hermes" | "hermes-agent" => crate::agents::AgentType::Hermes,
@@ -3058,5 +3060,15 @@ mod tests {
         // `~/.gemini/` prefix but nothing else.
         assert_eq!(normalize_target_cli("gemini"), "gemini");
         assert_eq!(normalize_target_cli("gemini-cli"), "gemini");
+    }
+
+    #[test]
+    fn normalize_target_cli_keeps_clanker_distinct_with_codex_transport() {
+        assert_eq!(normalize_target_cli("clanker"), "clanker");
+        assert_eq!(normalize_target_cli("clanker-code"), "clanker");
+        assert_eq!(
+            resume_args_for("clanker", "abc-123"),
+            vec!["resume", "abc-123"]
+        );
     }
 }

--- a/src/interchange/inject.rs
+++ b/src/interchange/inject.rs
@@ -98,7 +98,9 @@ pub fn inject_session(
     // Inject into target
     let (result, target_path) = match target_cli {
         "claude" | "claude-code" => inject_into_claude(&session, &hub_records)?,
-        "codex" | "clanker" | "clanker-code" => inject_into_codex(&session, &hub_records)?,
+        "codex" | "clanker" | "clanker-code" => {
+            inject_into_codex(&session, &hub_records, canonical_target)?
+        }
         "gemini" | "gemini-cli" => inject_into_gemini(&session, &hub_records)?,
         "antigravity" | "antigravity-cli" | "agy" => {
             // agy does NOT share gemini's session storage. Storage details
@@ -177,6 +179,13 @@ fn normalize_target_cli(target: &str) -> &str {
         "opencode" => "opencode",
         "pi" | "pi-coding-agent" => "pi",
         other => other,
+    }
+}
+
+fn codex_transport_display_name(target: &str) -> &str {
+    match target {
+        "clanker" => "Clanker",
+        _ => "Codex",
     }
 }
 
@@ -780,6 +789,7 @@ fn inject_into_claude(
 fn inject_into_codex(
     source: &SessionInfo,
     hub_records: &[HubRecord],
+    target_cli: &str,
 ) -> Result<(InjectionResult, String), ConvertError> {
     let codex_lines = codex::from_hub(hub_records)?;
 
@@ -861,9 +871,10 @@ fn inject_into_codex(
             session_id: session_id.clone(),
             resume_args: vec!["resume".into(), session_id],
             message: format!(
-                "Session '{}' from {} injected into Codex",
+                "Session '{}' from {} injected into {}",
                 source.name.as_deref().unwrap_or(&source.id),
                 source.cli,
+                codex_transport_display_name(target_cli),
             ),
         },
         target_path,
@@ -3066,6 +3077,8 @@ mod tests {
     fn normalize_target_cli_keeps_clanker_distinct_with_codex_transport() {
         assert_eq!(normalize_target_cli("clanker"), "clanker");
         assert_eq!(normalize_target_cli("clanker-code"), "clanker");
+        assert_eq!(codex_transport_display_name("clanker"), "Clanker");
+        assert_eq!(codex_transport_display_name("codex"), "Codex");
         assert_eq!(
             resume_args_for("clanker", "abc-123"),
             vec!["resume", "abc-123"]

--- a/src/interchange/mod.rs
+++ b/src/interchange/mod.rs
@@ -49,7 +49,7 @@ impl std::str::FromStr for CliFormat {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "claude" | "claude-code" => Ok(Self::ClaudeCode),
-            "codex" => Ok(Self::Codex),
+            "codex" | "clanker" | "clanker-code" => Ok(Self::Codex),
             "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" | "agy" => {
                 Ok(Self::GeminiCli)
             }
@@ -124,7 +124,7 @@ pub fn convert_command(
             let reader = BufReader::new(input_data.as_bytes());
             claude::to_hub(reader)?
         }
-        "codex" => {
+        "codex" | "clanker" | "clanker-code" => {
             let reader = BufReader::new(input_data.as_bytes());
             codex::to_hub(reader)?
         }
@@ -164,7 +164,7 @@ pub fn convert_command(
         }
         _ => {
             return Err(ConvertError::InvalidFormat(format!(
-                "Unsupported source format: {from}. Supported: claude, codex, gemini, antigravity, opencode, pi, hub"
+                "Unsupported source format: {from}. Supported: claude, codex, clanker, gemini, antigravity, opencode, pi, hub"
             )));
         }
     };
@@ -173,7 +173,7 @@ pub fn convert_command(
         // Round-trip verify: convert back and compare
         let back = match from {
             "claude" | "claude-code" => claude::from_hub(&hub_records)?,
-            "codex" => codex::from_hub(&hub_records)?,
+            "codex" | "clanker" | "clanker-code" => codex::from_hub(&hub_records)?,
             "pi" | "pi-coding-agent" => pi::from_hub(&hub_records)?,
             "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" | "agy" => {
                 let back_val = gemini::from_hub(&hub_records)?;
@@ -278,7 +278,7 @@ pub fn convert_command(
     } else {
         let values = match to {
             "claude" | "claude-code" => claude::from_hub(&hub_records)?,
-            "codex" => codex::from_hub(&hub_records)?,
+            "codex" | "clanker" | "clanker-code" => codex::from_hub(&hub_records)?,
             "pi" | "pi-coding-agent" => pi::from_hub(&hub_records)?,
             "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" | "agy" => {
                 let val = gemini::from_hub(&hub_records)?;
@@ -334,7 +334,7 @@ pub fn convert_command(
             }
             _ => {
                 return Err(ConvertError::InvalidFormat(format!(
-                    "Unsupported target format: {to}. Supported: claude, codex, gemini, antigravity, opencode, pi, hub, passthrough"
+                    "Unsupported target format: {to}. Supported: claude, codex, clanker, gemini, antigravity, opencode, pi, hub, passthrough"
                 )));
             }
         };
@@ -358,4 +358,18 @@ pub fn convert_command(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CliFormat;
+
+    #[test]
+    fn clanker_uses_the_codex_session_format() {
+        assert_eq!("clanker".parse::<CliFormat>().unwrap(), CliFormat::Codex);
+        assert_eq!(
+            "clanker-code".parse::<CliFormat>().unwrap(),
+            CliFormat::Codex
+        );
+    }
 }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -340,6 +340,20 @@ pub fn run_loop(config: LauncherConfig) -> io::Result<i32> {
 
 /// Run an agent with wrapper features
 pub fn run(auto_mode: bool, prompt: Option<String>, extra_args: Vec<String>) -> io::Result<()> {
+    run_with_env(auto_mode, prompt, extra_args, HashMap::new(), None)
+}
+
+/// Run the wrapper with launch-scoped environment overrides.
+///
+/// Overrides are applied after profile environment values and retained for
+/// every restart iteration without mutating the parent Unleash process.
+pub(crate) fn run_with_env(
+    auto_mode: bool,
+    prompt: Option<String>,
+    extra_args: Vec<String>,
+    child_env: HashMap<String, String>,
+    agent_type_override: Option<AgentType>,
+) -> io::Result<()> {
     // Meta-command short-circuit: --version / --help / doctor never need
     // hooks, plugins, permissions, or the restart loop. Exec the agent bare
     // with just profile env. Recovers the +100 ms / +54 MB claude pays for
@@ -394,10 +408,11 @@ pub fn run(auto_mode: bool, prompt: Option<String>, extra_args: Vec<String>) -> 
 
     // Find agent command
     let agent_cmd = find_agent_command()?;
-    let agent_type = detect_agent_type(&agent_cmd);
+    let agent_type = agent_type_override.or_else(|| detect_agent_type(&agent_cmd));
 
     // Load profile environment variables
-    let profile_env = load_profile_env()?;
+    let mut profile_env = load_profile_env()?;
+    profile_env.extend(child_env);
 
     // Check authentication on first run
     check_authentication();

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -97,7 +97,7 @@ pub(crate) fn exec_meta_command(
 }
 
 /// Returns true if `args` already encodes a resume/continue signal in any of
-/// the polyfill-emitted forms across the 7 supported agents. Used by the
+/// the polyfill-emitted forms across the 8 supported agents. Used by the
 /// restart loop to decide whether to inject its own `--continue` or leave the
 /// existing intent alone.
 ///
@@ -107,6 +107,7 @@ pub(crate) fn exec_meta_command(
 /// |------------|--------------------------|--------------------------|
 /// | Claude     | `--continue`, `-c`       | `--resume`, `-r`         |
 /// | Codex      | `resume` (subcommand)    | `resume` (subcommand)    |
+/// | Clanker    | `resume` (subcommand)    | `resume` (subcommand)    |
 /// | Gemini     | `--resume` (`latest`)    | `--resume`               |
 /// | OpenCode   | `--continue`             | `-s`                     |
 /// | Pi         | `--continue`             | `--session`              |
@@ -465,7 +466,7 @@ fn find_agent_command() -> io::Result<PathBuf> {
                         "AGENT_CMD is set to '{}' which resolves to the unleash binary itself.\n\
                          This would cause infinite recursion.\n\
                          Set agent_cli_path in your profile to the actual agent binary \
-                         (e.g. 'claude', 'codex', 'antigravity', 'opencode').",
+                         (e.g. 'claude', 'codex', 'clanker', 'antigravity', 'opencode').",
                         cmd
                     ),
                 ));
@@ -716,7 +717,9 @@ fn run_agent(
     }
 
     // Codex native notify hook: end-of-turn => reset opaque + idle sound.
-    if agent_type == Some(AgentType::Codex) && hyprland::is_focus_enabled() {
+    if matches!(agent_type, Some(AgentType::Codex | AgentType::Clanker))
+        && hyprland::is_focus_enabled()
+    {
         if let Ok(exe) = env::current_exe() {
             let exe = exe
                 .to_string_lossy()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ mod cli;
 pub mod config;
 mod hooks;
 mod hyprland;
+mod identity;
 #[cfg(feature = "tui")]
 mod input;
 pub mod interchange;
@@ -116,6 +117,19 @@ fn parse_wrapper_launch_args(
 fn detect_agent_type_from_cmd_path(cmd: &str) -> Option<AgentType> {
     let cmd_name = Path::new(cmd).file_name().and_then(|n| n.to_str())?;
     AgentType::from_str(cmd_name)
+}
+
+fn launch_agent_type(profile: &config::Profile) -> AgentType {
+    let target_name = Path::new(&profile.agent_cli_path)
+        .file_name()
+        .and_then(|name| name.to_str());
+    if profile.name.eq_ignore_ascii_case("clanker")
+        || target_name.is_some_and(|name| name.eq_ignore_ascii_case("clanker"))
+    {
+        return AgentType::Codex;
+    }
+
+    profile.agent_type().unwrap_or(AgentType::Claude)
 }
 
 /// Resolve the binary path/name for a target CLI used by the wrapper-reentry
@@ -294,7 +308,7 @@ fn run_agent_with_polyfill(
     }
 
     // Determine the agent type for polyfill resolution
-    let agent_type = profile.agent_type().unwrap_or(AgentType::Claude);
+    let agent_type = launch_agent_type(&profile);
     let agent_def = match &agent_type {
         AgentType::Custom(ref name) => {
             let app_config = manager.load_app_config().unwrap_or_default();
@@ -351,6 +365,21 @@ fn run_agent_with_polyfill(
             std::process::exit(exit_code);
         }
     }
+
+    // Resolve only explicit Codex/Clanker names. Bare launches remain fully
+    // delegated to Clanker Code's own continuation behavior. Keep this after
+    // the meta-command shortcut so informational commands stay side-effect free.
+    let resolved_clanker_id = if agent_type == AgentType::Codex {
+        polyfill_args
+            .name
+            .as_deref()
+            .map(|name| {
+                identity::resolve_clanker_id(Path::new(&profile.agent_cli_path), name, &profile.env)
+            })
+            .transpose()?
+    } else {
+        None
+    };
 
     let mut flags = polyfill_args.to_polyfill_flags(&profile.defaults);
     let mut ucf_active = None;
@@ -503,7 +532,12 @@ fn run_agent_with_polyfill(
         }
     }
 
-    let resolved = polyfill::resolve(&agent_def.polyfill, &flags, &profile.agent_cli_args);
+    let mut resolved = polyfill::resolve(&agent_def.polyfill, &flags, &profile.agent_cli_args);
+    if let Some(clanker_id) = resolved_clanker_id {
+        resolved
+            .env
+            .insert(identity::CLANKER_ID_ENV.to_string(), clanker_id);
+    }
 
     if polyfill_args.dry_run {
         let binary = &profile.agent_cli_path;
@@ -546,14 +580,9 @@ fn run_agent_with_polyfill(
     // Signal to launcher that polyfill handled yolo/permissions
     env::set_var("UNLEASH_POLYFILL_ACTIVE", "1");
 
-    // Set polyfill-resolved env vars
-    for (key, value) in &resolved.env {
-        env::set_var(key, value);
-    }
-
     // Headless prompt is handled by the polyfill (adds -p/exec/run to args)
     // Don't pass prompt separately to launcher since it would double-add for Claude
-    let res = launcher::run(auto, None, launch_args);
+    let res = launcher::run_with_env(auto, None, launch_args, resolved.env, Some(agent_type));
 
     if let Some((ucf_name, target_cli, session_id)) = ucf_active {
         sync_ucf_session(&ucf_name, &target_cli, &session_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,10 +127,32 @@ fn launch_agent_type(profile: &config::Profile) -> AgentType {
     if profile.name.eq_ignore_ascii_case("clanker")
         || target_name.is_some_and(|name| name.eq_ignore_ascii_case("clanker"))
     {
-        return AgentType::Codex;
+        return AgentType::Clanker;
     }
 
     profile.agent_type().unwrap_or(AgentType::Claude)
+}
+
+fn position_clanker_name_for_exec(
+    resolved: &mut polyfill::ResolvedInvocation,
+    requested_name: Option<&str>,
+) {
+    if resolved.subcommand_prefix.first().map(String::as_str) != Some("exec") {
+        return;
+    }
+    let Some(requested_name) = requested_name else {
+        return;
+    };
+    let Some(index) = resolved
+        .args
+        .windows(2)
+        .position(|pair| pair[0] == "--name" && pair[1] == requested_name)
+    else {
+        return;
+    };
+
+    let name_pair: Vec<String> = resolved.args.drain(index..index + 2).collect();
+    resolved.subcommand_prefix.splice(0..0, name_pair);
 }
 
 /// Resolve the binary path/name for a target CLI used by the wrapper-reentry
@@ -372,7 +394,7 @@ fn run_agent_with_polyfill(
     // Resolve only explicit Codex/Clanker names. Bare launches remain fully
     // delegated to Clanker Code's own continuation behavior. Keep this after
     // the meta-command shortcut so informational commands stay side-effect free.
-    let resolved_clanker_id = if agent_type == AgentType::Codex {
+    let resolved_clanker_id = if agent_type == AgentType::Clanker {
         polyfill_args
             .name
             .as_deref()
@@ -536,6 +558,9 @@ fn run_agent_with_polyfill(
     }
 
     let mut resolved = polyfill::resolve(&agent_def.polyfill, &flags, &profile.agent_cli_args);
+    if agent_type == AgentType::Clanker {
+        position_clanker_name_for_exec(&mut resolved, polyfill_args.name.as_deref());
+    }
     if let Some(clanker_id) = resolved_clanker_id {
         resolved
             .env

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod agents;
 #[cfg(feature = "tui")]
 mod ansi;
 mod auth;
+mod clanker;
 
 /// Crate-wide lock for tests that mutate process-global environment variables
 /// (`HOME`, `XDG_DATA_HOME`, `UNLEASH_*`, …). Module-local locks are NOT
@@ -146,6 +147,7 @@ fn resolve_target_binary(target_cli: &str) -> String {
     let canonical = match target_cli {
         "claude" | "claude-code" => Some(AgentType::Claude),
         "codex" => Some(AgentType::Codex),
+        "clanker" | "clanker-code" => Some(AgentType::Clanker),
         "antigravity" | "antigravity-cli" | "agy" => Some(AgentType::Antigravity),
         "gemini" | "gemini-cli" => Some(AgentType::Gemini),
         "opencode" => Some(AgentType::OpenCode),
@@ -327,6 +329,7 @@ fn run_agent_with_polyfill(
         AgentType::Unleash => unreachable!("Unleash is not a launchable agent"),
         AgentType::Claude => "claude",
         AgentType::Codex => "codex",
+        AgentType::Clanker => "clanker",
         AgentType::Antigravity => "agy",
         AgentType::Gemini => "gemini",
         AgentType::OpenCode => "opencode",
@@ -738,6 +741,7 @@ pub fn run() -> io::Result<()> {
             let target_cli = match first_arg {
                 "claude" | "claude-code" => "claude",
                 "codex" => "codex",
+                "clanker" | "clanker-code" => "clanker",
                 "antigravity" | "antigravity-cli" | "agy" => "agy",
                 "gemini" | "gemini-cli" => "gemini",
                 "opencode" => "opencode",
@@ -751,6 +755,7 @@ pub fn run() -> io::Result<()> {
                             AgentType::Unleash => "claude", // fall back; Unleash is not a crossload target
                             AgentType::Claude => "claude",
                             AgentType::Codex => "codex",
+                            AgentType::Clanker => "clanker",
                             AgentType::Antigravity => "agy",
                             AgentType::Gemini => "gemini",
                             AgentType::OpenCode => "opencode",
@@ -1173,7 +1178,7 @@ pub fn run() -> io::Result<()> {
                             io::Error::new(
                                 io::ErrorKind::InvalidInput,
                                 format!(
-                                    "Unknown agent: {}. Valid: claude, codex, gemini, opencode",
+                                    "Unknown agent: {}. Valid: claude, codex, clanker, antigravity, gemini, opencode, pi, hermes",
                                     name
                                 ),
                             )
@@ -1207,7 +1212,7 @@ pub fn run() -> io::Result<()> {
                             io::Error::new(
                                 io::ErrorKind::InvalidInput,
                                 format!(
-                                    "Unknown agent: {}. Valid: claude, codex, gemini, opencode",
+                                    "Unknown agent: {}. Valid: claude, codex, clanker, antigravity, gemini, opencode, pi, hermes",
                                     name
                                 ),
                             )
@@ -1242,7 +1247,7 @@ pub fn run() -> io::Result<()> {
                             io::Error::new(
                                 io::ErrorKind::InvalidInput,
                                 format!(
-                                    "Unknown agent: {}. Valid: claude, codex, gemini, opencode",
+                                    "Unknown agent: {}. Valid: claude, codex, clanker, antigravity, gemini, opencode, pi, hermes",
                                     name
                                 ),
                             )

--- a/src/pixel_art.rs
+++ b/src/pixel_art.rs
@@ -803,7 +803,7 @@ pub mod mascots {
     /// indexes into pre-rendered files; later it can composite body + head.
     pub fn full_art(agent: &str) -> &'static str {
         match agent {
-            "codex" => ART_CODEX,
+            "codex" | "clanker" | "clanker-code" => ART_CODEX,
             "gemini" | "gemini-cli" | "antigravity" | "antigravity-cli" | "agy" => ART_GEMINI,
             "opencode" => ART_OPENCODE,
             // "jules" => ART_JULES,

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -960,14 +960,15 @@ mod tests {
     }
 
     #[test]
-    fn test_codex_no_name_support() {
+    fn test_codex_session_name() {
         let config = AgentDefinition::codex().polyfill;
         let flags = PolyfillFlags {
             name: Some("test".into()),
             ..default_flags()
         };
         let inv = resolve(&config, &flags, &[]);
-        assert!(!inv.args.contains(&"--name".to_string()));
+        assert!(inv.args.contains(&"--name".to_string()));
+        assert!(inv.args.contains(&"test".to_string()));
     }
 
     // ── Add Dir ─────────────────────────────────────────────

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -967,6 +967,18 @@ mod tests {
             ..default_flags()
         };
         let inv = resolve(&config, &flags, &[]);
+        assert!(!inv.args.contains(&"--name".to_string()));
+        assert!(!inv.args.contains(&"test".to_string()));
+    }
+
+    #[test]
+    fn test_clanker_session_name() {
+        let config = AgentDefinition::clanker().polyfill;
+        let flags = PolyfillFlags {
+            name: Some("test".into()),
+            ..default_flags()
+        };
+        let inv = resolve(&config, &flags, &[]);
         assert!(inv.args.contains(&"--name".to_string()));
         assert!(inv.args.contains(&"test".to_string()));
     }

--- a/src/skillsync/mod.rs
+++ b/src/skillsync/mod.rs
@@ -102,7 +102,7 @@ impl std::str::FromStr for Harness {
         match s {
             "claude" | "claude-code" => Ok(Self::Claude),
             "opencode" => Ok(Self::OpenCode),
-            "codex" => Ok(Self::Codex),
+            "codex" | "clanker" | "clanker-code" => Ok(Self::Codex),
             "gemini" | "gemini-cli" => Ok(Self::Gemini),
             "agy" | "antigravity" | "antigravity-cli" => Ok(Self::Agy),
             "pi" | "pi-coding-agent" => Ok(Self::Pi),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -328,8 +328,10 @@ pub fn build_agent_cli_picker_entries(custom: &[AgentDefinition]) -> Vec<AgentCl
         .map(AgentCliPickerEntry::Agent)
         .collect();
     for def in custom {
-        if let AgentType::Custom(_) = &def.agent_type {
-            entries.push(AgentCliPickerEntry::Agent(def.agent_type.clone()));
+        if let AgentType::Custom(name) = &def.agent_type {
+            if AgentType::from_str(name).is_none() {
+                entries.push(AgentCliPickerEntry::Agent(def.agent_type.clone()));
+            }
         }
     }
     entries.push(AgentCliPickerEntry::AddCustom);
@@ -344,6 +346,7 @@ pub fn resolve_agent_binary_path(agent: &AgentType, custom: &[AgentDefinition]) 
         AgentType::Unleash => return String::new(), // not a launchable agent
         AgentType::Claude => AgentDefinition::claude().binary,
         AgentType::Codex => AgentDefinition::codex().binary,
+        AgentType::Clanker => AgentDefinition::clanker().binary,
         AgentType::Antigravity => AgentDefinition::antigravity().binary,
         AgentType::Gemini => AgentDefinition::gemini().binary,
         AgentType::OpenCode => AgentDefinition::opencode().binary,
@@ -1144,6 +1147,7 @@ impl App {
             if let Ok(mut mgr) = AgentManager::new() {
                 for agent_type in &[
                     AgentType::Codex,
+                    AgentType::Clanker,
                     AgentType::Antigravity,
                     AgentType::Gemini,
                     AgentType::OpenCode,
@@ -1715,6 +1719,23 @@ impl App {
                     let versions = vm.get_codex_version_list(installed.as_deref());
                     let conflicts = vm.detect_conflicts("codex");
                     let _ = tx.send((AgentType::Codex, versions, conflicts));
+                });
+            }
+            AgentType::Clanker => {
+                thread::spawn(move || {
+                    let versions = crate::clanker::latest_revision()
+                        .ok()
+                        .map(|revision| {
+                            let is_installed = crate::clanker::installed_revision().as_deref()
+                                == Some(revision.as_str());
+                            vec![VersionInfo {
+                                version: crate::clanker::revision_label(&revision).to_string(),
+                                is_installed,
+                            }]
+                        })
+                        .unwrap_or_default();
+                    let conflicts = VersionManager::new().detect_conflicts("clanker");
+                    let _ = tx.send((AgentType::Clanker, versions, conflicts));
                 });
             }
             AgentType::Antigravity => {
@@ -2883,6 +2904,7 @@ impl App {
                     AgentType::Unleash => "unleash",
                     AgentType::Claude => "claude",
                     AgentType::Codex => "codex",
+                    AgentType::Clanker => "clanker",
                     AgentType::Gemini => "gemini",
                     AgentType::Antigravity => "antigravity",
                     AgentType::OpenCode => "opencode",
@@ -3138,6 +3160,10 @@ impl App {
                     }),
                     AgentType::Claude => vm.install_version_streaming(&version_clone, log_tx),
                     AgentType::Codex => vm.install_codex_version_streaming(&version_clone, log_tx),
+                    AgentType::Clanker => {
+                        crate::version::install_latest_streaming(AgentType::Clanker, log_tx)
+                            .map(|(_, result)| result)
+                    }
                     AgentType::Gemini => {
                         vm.install_gemini_version_streaming(&version_clone, log_tx)
                     }
@@ -7474,12 +7500,15 @@ mod tests {
         // Unleash is now first in the picker
         assert_eq!(app.version_agent, AgentType::Unleash);
 
-        // Navigate down: Unleash -> Claude -> Codex -> Antigravity -> OpenCode -> Pi -> Hermes -> Gemini
+        // Navigate down: Unleash -> Claude -> Codex -> Clanker -> Antigravity -> OpenCode -> Pi -> Hermes -> Gemini
         let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
         assert_eq!(app.version_agent, AgentType::Claude);
 
         let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
         assert_eq!(app.version_agent, AgentType::Codex);
+
+        let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
+        assert_eq!(app.version_agent, AgentType::Clanker);
 
         let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
         assert_eq!(app.version_agent, AgentType::Antigravity);
@@ -7509,13 +7538,16 @@ mod tests {
         app.screen = Screen::VersionManagement;
         app.version_focus = VersionFocus::AgentPicker;
 
-        // Start at OpenCode (index 4 with Unleash first)
-        app.switch_to_agent_index(4);
+        // Start at OpenCode (index 5 with Unleash first)
+        app.switch_to_agent_index(5);
         assert_eq!(app.version_agent, AgentType::OpenCode);
 
-        // Navigate up: OpenCode -> Antigravity -> Codex -> Claude -> Unleash
+        // Navigate up: OpenCode -> Antigravity -> Clanker -> Codex -> Claude -> Unleash
         let _ = app.handle_version_input(NavAction::Up, key_for(NavAction::Up));
         assert_eq!(app.version_agent, AgentType::Antigravity);
+
+        let _ = app.handle_version_input(NavAction::Up, key_for(NavAction::Up));
+        assert_eq!(app.version_agent, AgentType::Clanker);
 
         let _ = app.handle_version_input(NavAction::Up, key_for(NavAction::Up));
         assert_eq!(app.version_agent, AgentType::Codex);
@@ -7712,7 +7744,12 @@ mod tests {
         assert!(app.version_list_receiver.is_some());
         assert_eq!(app.version_agent, AgentType::Codex);
 
-        // Switch again to Antigravity
+        // Switch again to Clanker
+        let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
+        assert!(app.version_list_receiver.is_some());
+        assert_eq!(app.version_agent, AgentType::Clanker);
+
+        // And then Antigravity
         let _ = app.handle_version_input(NavAction::Down, key_for(NavAction::Down));
         assert!(app.version_list_receiver.is_some());
         assert_eq!(app.version_agent, AgentType::Antigravity);
@@ -7769,20 +7806,22 @@ mod tests {
     #[test]
     fn test_all_agent_types_in_cycle() {
         let agents = AgentType::builtin();
-        assert_eq!(agents.len(), 7);
+        assert_eq!(agents.len(), 8);
         assert_eq!(agents[0], AgentType::Claude);
         assert_eq!(agents[1], AgentType::Codex);
-        assert_eq!(agents[2], AgentType::Antigravity);
-        assert_eq!(agents[3], AgentType::OpenCode);
-        assert_eq!(agents[4], AgentType::Pi);
-        assert_eq!(agents[5], AgentType::Hermes);
-        assert_eq!(agents[6], AgentType::Gemini);
+        assert_eq!(agents[2], AgentType::Clanker);
+        assert_eq!(agents[3], AgentType::Antigravity);
+        assert_eq!(agents[4], AgentType::OpenCode);
+        assert_eq!(agents[5], AgentType::Pi);
+        assert_eq!(agents[6], AgentType::Hermes);
+        assert_eq!(agents[7], AgentType::Gemini);
     }
 
     #[test]
     fn test_agent_display_names() {
         assert_eq!(AgentType::Claude.display_name(), "Claude Code");
         assert_eq!(AgentType::Codex.display_name(), "Codex");
+        assert_eq!(AgentType::Clanker.display_name(), "Clanker Code");
         assert_eq!(AgentType::Antigravity.display_name(), "Antigravity CLI");
         assert_eq!(AgentType::Gemini.display_name(), "Gemini CLI");
         assert_eq!(AgentType::OpenCode.display_name(), "OpenCode");
@@ -7884,8 +7923,8 @@ mod tests {
         app.screen = Screen::VersionManagement;
         app.version_focus = VersionFocus::AgentPicker;
 
-        // Navigate to Antigravity (index 3 with Unleash first)
-        app.switch_to_agent_index(3);
+        // Navigate to Antigravity (index 4 with Unleash first)
+        app.switch_to_agent_index(4);
         assert_eq!(app.version_agent, AgentType::Antigravity);
 
         // Press 'g' then 'g' to jump to top (Unleash is now index 0)
@@ -7949,18 +7988,19 @@ mod tests {
     #[test]
     fn test_picker_entries_default_order() {
         let entries = build_agent_cli_picker_entries(&[]);
-        assert_eq!(entries.len(), 8);
+        assert_eq!(entries.len(), 9);
         assert_eq!(entries[0], AgentCliPickerEntry::Agent(AgentType::Claude));
         assert_eq!(entries[1], AgentCliPickerEntry::Agent(AgentType::Codex));
+        assert_eq!(entries[2], AgentCliPickerEntry::Agent(AgentType::Clanker));
         assert_eq!(
-            entries[2],
+            entries[3],
             AgentCliPickerEntry::Agent(AgentType::Antigravity)
         );
-        assert_eq!(entries[3], AgentCliPickerEntry::Agent(AgentType::OpenCode));
-        assert_eq!(entries[4], AgentCliPickerEntry::Agent(AgentType::Pi));
-        assert_eq!(entries[5], AgentCliPickerEntry::Agent(AgentType::Hermes));
-        assert_eq!(entries[6], AgentCliPickerEntry::Agent(AgentType::Gemini));
-        assert_eq!(entries[7], AgentCliPickerEntry::AddCustom);
+        assert_eq!(entries[4], AgentCliPickerEntry::Agent(AgentType::OpenCode));
+        assert_eq!(entries[5], AgentCliPickerEntry::Agent(AgentType::Pi));
+        assert_eq!(entries[6], AgentCliPickerEntry::Agent(AgentType::Hermes));
+        assert_eq!(entries[7], AgentCliPickerEntry::Agent(AgentType::Gemini));
+        assert_eq!(entries[8], AgentCliPickerEntry::AddCustom);
     }
 
     /// Custom agents appear in the picker between built-ins and AddCustom.
@@ -7971,12 +8011,27 @@ mod tests {
         def.name = "aider".to_string();
         def.binary = "aider".to_string();
         let entries = build_agent_cli_picker_entries(&[def]);
-        assert_eq!(entries.len(), 9);
+        assert_eq!(entries.len(), 10);
         assert_eq!(
-            entries[7],
+            entries[8],
             AgentCliPickerEntry::Agent(AgentType::Custom("aider".to_string()))
         );
-        assert_eq!(entries[8], AgentCliPickerEntry::AddCustom);
+        assert_eq!(entries[9], AgentCliPickerEntry::AddCustom);
+    }
+
+    #[test]
+    fn test_picker_suppresses_legacy_custom_clanker_entry() {
+        let mut legacy = AgentDefinition::clanker();
+        legacy.agent_type = AgentType::Custom("clanker".to_string());
+        let entries = build_agent_cli_picker_entries(&[legacy]);
+        assert_eq!(entries.len(), 9);
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|entry| **entry == AgentCliPickerEntry::Agent(AgentType::Clanker))
+                .count(),
+            1
+        );
     }
 
     /// Right key advances and wraps; left key wraps backwards.
@@ -8001,9 +8056,9 @@ mod tests {
         app.handle_agent_cli_picker_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
         assert_eq!(app.agent_picker_index, 0);
 
-        // Left from 0 wraps to last (AddCustom = 7 with no custom agents)
+        // Left from 0 wraps to last (AddCustom = 8 with no custom agents)
         app.handle_agent_cli_picker_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
-        assert_eq!(app.agent_picker_index, 7);
+        assert_eq!(app.agent_picker_index, 8);
 
         // Right from last wraps back to 0
         app.handle_agent_cli_picker_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
@@ -8088,10 +8143,10 @@ mod tests {
         app.app_config.custom_agents.push(cfg);
 
         let entries = app.agent_cli_picker_entries();
-        // 7 builtins + 1 custom + AddCustom = 9
-        assert_eq!(entries.len(), 9);
+        // 8 builtins + 1 custom + AddCustom = 10
+        assert_eq!(entries.len(), 10);
         assert!(matches!(
-            &entries[7],
+            &entries[8],
             AgentCliPickerEntry::Agent(AgentType::Custom(n)) if n == "aider"
         ));
     }
@@ -8628,11 +8683,11 @@ yolo_flag = "--yes"
     #[test]
     fn test_picker_snapshot_cycle_right_to_gemini() {
         let (mut app, _temp) = picker_open_app("claude");
-        // Right six times: Claude -> Codex -> Antigravity -> OpenCode -> Pi -> Hermes -> Gemini
-        for _ in 0..6 {
+        // Right seven times: Claude -> Codex -> Clanker -> Antigravity -> OpenCode -> Pi -> Hermes -> Gemini
+        for _ in 0..7 {
             app.handle_agent_cli_picker_key(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
         }
-        assert_eq!(app.agent_picker_index, 6);
+        assert_eq!(app.agent_picker_index, 7);
 
         let buf = render_region_to_buffer(80, 8, |frame, area| {
             app.render_profile_edit(frame, area);

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -583,6 +583,9 @@ fn get_installed_version(agent_type: AgentType) -> Option<String> {
     if let AgentType::Custom(_) = &agent_type {
         return None; // custom agents don't support version detection yet
     }
+    if agent_type == AgentType::Clanker {
+        return crate::clanker::installed_product_version();
+    }
     let def = AgentDefinition::from_type(agent_type.clone());
     let output = Command::new(&def.binary).arg("--version").output().ok()?;
     if !output.status.success() {

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -550,6 +550,16 @@ fn check_or_update_self(check_only: bool) -> io::Result<()> {
 /// Check a single agent's installed vs latest version.
 fn check_agent(agent_type: AgentType) -> io::Result<CheckResult> {
     let installed = get_installed_version(agent_type.clone());
+    if agent_type == AgentType::Clanker {
+        let revision = crate::clanker::latest_revision()?;
+        return Ok(CheckResult {
+            agent_type,
+            installed: installed.clone(),
+            latest: Some(crate::clanker::revision_label(&revision).to_string()),
+            update_available: installed.is_none() || crate::clanker::update_available(&revision),
+        });
+    }
+
     let latest = get_latest_version(agent_type.clone())?;
 
     let update_available = match (&installed, &latest) {
@@ -617,6 +627,10 @@ fn get_latest_version(agent_type: AgentType) -> io::Result<Option<String>> {
     if let AgentType::Custom(_) = &agent_type {
         return Ok(None); // custom agents don't support version detection yet
     }
+    if agent_type == AgentType::Clanker {
+        return crate::clanker::latest_revision()
+            .map(|revision| Some(crate::clanker::revision_label(&revision).to_string()));
+    }
     let def = AgentDefinition::from_type(agent_type.clone());
 
     // Prefer npm registry for agents that have an npm package.
@@ -659,6 +673,7 @@ fn latest_embedded_version(agent_type: &AgentType) -> Option<String> {
     let key = match agent_type {
         AgentType::Claude => "claude",
         AgentType::Codex => "codex",
+        AgentType::Clanker => return None,
         AgentType::Antigravity => "antigravity",
         AgentType::Gemini => "gemini",
         AgentType::OpenCode => "opencode",
@@ -1112,6 +1127,7 @@ fn update_agent(
         )),
         AgentType::Claude => update_claude(tx, index),
         AgentType::Codex => update_codex(tx, index, latest_version),
+        AgentType::Clanker => update_clanker(tx, index),
         AgentType::Antigravity => update_antigravity(tx, index, latest_version),
         AgentType::Gemini => update_gemini(tx, index, latest_version),
         AgentType::OpenCode => update_opencode(tx, index),
@@ -1204,6 +1220,25 @@ fn update_codex(
         .or(latest_version)
         .unwrap_or_else(|| "latest".into());
     Ok(version)
+}
+
+/// Update Clanker Code from the fork-owned release branch.
+fn update_clanker(tx: &mpsc::Sender<(usize, LineState)>, index: usize) -> io::Result<String> {
+    let _ = tx.send((
+        index,
+        LineState::Building {
+            version: String::new(),
+            phase: "building fork release branch...".into(),
+        },
+    ));
+
+    let mut manager = crate::agents::AgentManager::new()?;
+    manager.update_agent(AgentType::Clanker)?;
+
+    Ok(crate::clanker::installed_revision()
+        .map(|revision| crate::clanker::revision_label(&revision).to_string())
+        .or_else(|| get_installed_version(AgentType::Clanker))
+        .unwrap_or_else(|| "latest".into()))
 }
 
 /// Ensure npm is available, offering to install Node.js if missing.
@@ -1802,7 +1837,8 @@ Version                       : 1.1.0_4523441756438528-1\n";
     }
 
     #[test]
-    fn latest_embedded_version_returns_none_for_custom_and_unleash() {
+    fn latest_embedded_version_returns_none_for_clanker_custom_and_unleash() {
+        assert_eq!(latest_embedded_version(&AgentType::Clanker), None);
         assert_eq!(latest_embedded_version(&AgentType::Unleash), None);
         assert_eq!(
             latest_embedded_version(&AgentType::Custom("foo".into())),

--- a/src/version.rs
+++ b/src/version.rs
@@ -119,6 +119,7 @@ pub fn save_embedded_versions(map: &HashMap<crate::agents::AgentType, Vec<Versio
             crate::agents::AgentType::Unleash => continue, // unleash versions not stored here
             crate::agents::AgentType::Claude => "claude",
             crate::agents::AgentType::Codex => "codex",
+            crate::agents::AgentType::Clanker => continue,
             crate::agents::AgentType::Antigravity => "antigravity",
             crate::agents::AgentType::Gemini => "gemini",
             crate::agents::AgentType::OpenCode => "opencode",
@@ -2412,6 +2413,37 @@ pub fn install_latest_streaming(
                 .ok_or_else(|| io::Error::other("no Codex version available"))?;
             let r = vm.install_codex_version_streaming(&v, log_tx)?;
             Ok((v, r))
+        }
+        AgentType::Clanker => {
+            let _ = log_tx
+                .send("Building Clanker Code from the fork-owned release branch...".to_string());
+            let mut manager = crate::agents::AgentManager::new()?;
+            match manager.update_agent(AgentType::Clanker) {
+                Ok(message) => {
+                    let revision = crate::clanker::installed_revision()
+                        .unwrap_or_else(|| "latest".to_string());
+                    let version = crate::clanker::revision_label(&revision).to_string();
+                    let _ = log_tx.send(message.clone());
+                    Ok((
+                        version,
+                        InstallResult {
+                            success: true,
+                            stdout: message,
+                            stderr: String::new(),
+                            error: None,
+                        },
+                    ))
+                }
+                Err(err) => Ok((
+                    "latest".to_string(),
+                    InstallResult {
+                        success: false,
+                        stdout: String::new(),
+                        stderr: err.to_string(),
+                        error: Some(err.to_string()),
+                    },
+                )),
+            }
         }
         AgentType::Gemini => {
             let versions = vm.get_gemini_version_list(None);

--- a/tests/character_identity_transport.rs
+++ b/tests/character_identity_transport.rs
@@ -1,0 +1,528 @@
+#![cfg(unix)]
+
+use serde_json::json;
+use std::collections::HashMap;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use unleash::config::AppConfig;
+use unleash::config::CustomAgentConfig;
+use unleash::config::Profile;
+use unleash::config::ProfileManager;
+
+struct Harness {
+    _root: tempfile::TempDir,
+    home: PathBuf,
+    config_base: PathBuf,
+    data_home: PathBuf,
+    cache_home: PathBuf,
+    codex_home: PathBuf,
+    profile_codex_home: PathBuf,
+    capture: PathBuf,
+}
+
+impl Harness {
+    fn new() -> Self {
+        Self::with_profile("codex", "codex")
+    }
+
+    fn with_profile(profile_name: &str, binary_name: &str) -> Self {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let config_base = root.path().join("config");
+        let data_home = root.path().join("data");
+        let cache_home = root.path().join("cache");
+        let codex_home = root.path().join("ambient-codex-home");
+        let profile_codex_home = root.path().join("profile-codex-home");
+        let capture = root.path().join("capture");
+        for path in [
+            &home,
+            &config_base,
+            &data_home,
+            &cache_home,
+            &codex_home,
+            &profile_codex_home,
+            &capture,
+        ] {
+            fs::create_dir_all(path).unwrap();
+        }
+
+        let target = root.path().join("bin").join(binary_name);
+        fs::create_dir_all(target.parent().unwrap()).unwrap();
+        fs::write(
+            &target,
+            r#"#!/bin/sh
+set -eu
+capture=${IDENTITY_CAPTURE_DIR:?}
+
+if [ "${1-}" = character ]; then
+  printf '%s\n' "$*" >> "$capture/resolver.calls"
+  printf '%s' "${CODEX_HOME-unset}" > "$capture/resolver.codex_home"
+  case "${RESOLVER_MODE-ok}:${3-}" in
+    ok:Cleo)
+      printf '%s\n' '{"schemaVersion":1,"ok":true,"input":"Cleo","id":"chloe","displayName":"Chloe","manifestPath":"/tmp/fixture/character.json","matchKind":"explicit_alias"}'
+      ;;
+    ok:Rusty)
+      printf '%s\n' '{"schemaVersion":1,"ok":true,"input":"Rusty","id":"clanker","displayName":"Rusty Clanker","manifestPath":"/tmp/fixture/character.json","matchKind":"explicit_alias"}'
+      ;;
+    malformed:*)
+      printf '%s\n' '{"schemaVersion":1,"ok":true}'
+      ;;
+    mismatch:*)
+      printf '%s\n' '{"schemaVersion":1,"ok":true,"input":"Rusty","id":"chloe","displayName":"Chloe","manifestPath":"/tmp/fixture/character.json","matchKind":"explicit_alias"}'
+      ;;
+    *)
+      printf '%s\n' 'not found' >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+iteration_file="$capture/iteration"
+iteration=0
+if [ -f "$iteration_file" ]; then
+  iteration=$(cat "$iteration_file")
+fi
+iteration=$((iteration + 1))
+printf '%s' "$iteration" > "$iteration_file"
+: > "$capture/argv.$iteration"
+for arg in "$@"; do
+  printf '%s\n' "$arg" >> "$capture/argv.$iteration"
+done
+printf '%s' "${CLANKER_ID-unset}" > "$capture/clanker_id.$iteration"
+printf '%s' "$PWD" > "$capture/cwd.$iteration"
+printf '%s' "${TMUX-unset}" > "$capture/tmux.$iteration"
+
+if [ "${TRIGGER_ONE_RESTART-0}" = 1 ] && [ "$iteration" = 1 ]; then
+  mkdir -p "${XDG_CACHE_HOME:?}/unleash/process-restart"
+  : > "${XDG_CACHE_HOME}/unleash/process-restart/restart-trigger-${AGENT_WRAPPER_PID:?}"
+fi
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&target).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&target, permissions).unwrap();
+
+        let manager = ProfileManager::with_config_dir(config_base.join("unleash")).unwrap();
+        let mut profile = Profile::new(profile_name);
+        profile.agent_cli_path = target.to_string_lossy().into_owned();
+        profile.env = HashMap::from([
+            ("AU_HYPRLAND_FOCUS".to_string(), "0".to_string()),
+            (
+                "CODEX_HOME".to_string(),
+                profile_codex_home.to_string_lossy().into_owned(),
+            ),
+            (
+                "IDENTITY_CAPTURE_DIR".to_string(),
+                capture.to_string_lossy().into_owned(),
+            ),
+        ]);
+        manager.save_profile(&profile).unwrap();
+        let custom_agents = if profile_name == "clanker" {
+            let mut polyfill = unleash::agents::AgentDefinition::codex().polyfill;
+            polyfill.name_flag = None;
+            vec![CustomAgentConfig {
+                name: "clanker".to_string(),
+                binary: "clanker".to_string(),
+                description: "Clanker Code fixture".to_string(),
+                polyfill,
+                github_repo: None,
+                npm_package: None,
+                asset_template: None,
+                enabled: true,
+            }]
+        } else {
+            Vec::new()
+        };
+        manager
+            .save_app_config(&AppConfig {
+                current_profile: profile_name.to_string(),
+                custom_agents,
+                ..AppConfig::default()
+            })
+            .unwrap();
+
+        Self {
+            _root: root,
+            home,
+            config_base,
+            data_home,
+            cache_home,
+            codex_home,
+            profile_codex_home,
+            capture,
+        }
+    }
+
+    fn command(&self, cwd: &Path) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_unleash"));
+        command
+            .current_dir(cwd)
+            .env("HOME", &self.home)
+            .env("XDG_CONFIG_HOME", &self.config_base)
+            .env("XDG_DATA_HOME", &self.data_home)
+            .env("XDG_CACHE_HOME", &self.cache_home)
+            .env("CODEX_HOME", &self.codex_home)
+            .env("AU_HYPRLAND_FOCUS", "0")
+            .env_remove("AGENT_CMD")
+            .env_remove("AGENT_UNLEASH")
+            .env_remove("UNLEASH_POLYFILL_ACTIVE");
+        command
+    }
+
+    fn argv(&self, iteration: usize) -> Vec<String> {
+        fs::read_to_string(self.capture.join(format!("argv.{iteration}")))
+            .unwrap()
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn captured(&self, name: &str, iteration: usize) -> String {
+        fs::read_to_string(self.capture.join(format!("{name}.{iteration}"))).unwrap()
+    }
+}
+
+fn assert_name_pair(args: &[String], expected: &str) {
+    assert!(
+        args.windows(2).any(|pair| pair == ["--name", expected]),
+        "missing --name {expected:?} in {args:?}"
+    );
+}
+
+#[test]
+fn explicit_alias_transports_original_argv_and_canonical_env_across_workspaces_and_tmux() {
+    for (requested, canonical, tmux) in [
+        ("Cleo", "chloe", None),
+        ("Rusty", "clanker", Some("fixture")),
+    ] {
+        let harness = Harness::new();
+        let workspace = harness.home.join(format!("workspace-{canonical}"));
+        fs::create_dir_all(&workspace).unwrap();
+        let mut command = harness.command(&workspace);
+        command
+            .args(["codex", "--name", requested])
+            .env("CLANKER_ID", "stale-parent-value");
+        match tmux {
+            Some(value) => {
+                command.env("TMUX", value);
+            }
+            None => {
+                command.env_remove("TMUX");
+            }
+        }
+
+        let output = command.output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_name_pair(&harness.argv(1), requested);
+        assert_eq!(
+            fs::read_to_string(harness.capture.join("resolver.calls"))
+                .unwrap()
+                .trim(),
+            format!("character resolve {requested} --json --materialize-builtin")
+        );
+        assert_eq!(harness.captured("clanker_id", 1), canonical);
+        assert_eq!(harness.captured("cwd", 1), workspace.to_string_lossy());
+        assert_eq!(harness.captured("tmux", 1), tmux.unwrap_or("unset"));
+        assert!(!harness.config_base.join("unleash/characters").exists());
+    }
+}
+
+#[test]
+fn bare_launch_never_resolves_and_preserves_inherited_identity_behavior() {
+    let harness = Harness::new();
+    let workspace = harness.home.join("bare-workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    let output = harness
+        .command(&workspace)
+        .arg("codex")
+        .env("CLANKER_ID", "inherited")
+        .env_remove("TMUX")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!harness.capture.join("resolver.calls").exists());
+    assert!(!harness.argv(1).iter().any(|arg| arg == "--name"));
+    assert_eq!(harness.captured("clanker_id", 1), "inherited");
+}
+
+#[test]
+fn live_clanker_profile_uses_codex_identity_and_restart_semantics() {
+    let harness = Harness::with_profile("clanker", "clanker");
+    let output = harness
+        .command(&harness.home)
+        .args(["clanker", "--name", "Cleo"])
+        .env("TRIGGER_ONE_RESTART", "1")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    for iteration in [1, 2] {
+        assert_name_pair(&harness.argv(iteration), "Cleo");
+        assert_eq!(harness.captured("clanker_id", iteration), "chloe");
+    }
+    assert_eq!(&harness.argv(2)[..2], ["resume", "--last"]);
+}
+
+#[test]
+fn profile_environment_wins_for_character_resolution_context() {
+    let harness = Harness::new();
+    let output = harness
+        .command(&harness.home)
+        .args(["codex", "--name", "Cleo"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_ne!(harness.codex_home, harness.profile_codex_home);
+    assert_eq!(
+        fs::read_to_string(harness.capture.join("resolver.codex_home")).unwrap(),
+        harness.profile_codex_home.to_string_lossy()
+    );
+}
+
+#[test]
+fn malformed_mismatched_or_unresolved_identity_fails_before_child_launch() {
+    for mode in ["malformed", "mismatch", "missing"] {
+        let harness = Harness::new();
+        let output = harness
+            .command(&harness.home)
+            .args(["codex", "--name", "Cleo"])
+            .env("RESOLVER_MODE", mode)
+            .output()
+            .unwrap();
+
+        assert!(!output.status.success());
+        assert!(!harness.capture.join("argv.1").exists());
+    }
+}
+
+#[test]
+fn named_meta_commands_skip_resolution_and_preserve_meta_behavior() {
+    for meta in ["--help", "--version", "doctor"] {
+        let harness = Harness::new();
+        let output = harness
+            .command(&harness.home)
+            .args(["codex", "--name", "Cleo", meta])
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "{meta}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!harness.capture.join("resolver.calls").exists());
+    }
+}
+
+#[test]
+fn dry_run_resolves_only_explicit_names_and_prints_verified_transport() {
+    let named = Harness::new();
+    let output = named
+        .command(&named.home)
+        .args(["codex", "--name", "Cleo", "--dry-run"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(named.capture.join("resolver.calls").exists());
+    assert!(!named.capture.join("argv.1").exists());
+    assert!(stdout.contains("--name Cleo"), "{stdout}");
+    assert!(stdout.contains("CLANKER_ID=chloe"), "{stdout}");
+
+    let bare = Harness::new();
+    let output = bare
+        .command(&bare.home)
+        .args(["codex", "--dry-run"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!bare.capture.join("resolver.calls").exists());
+    assert!(!bare.capture.join("argv.1").exists());
+    assert!(!stdout.contains("CLANKER_ID"), "{stdout}");
+}
+
+#[test]
+fn restart_retains_verified_identity_and_original_name() {
+    let harness = Harness::new();
+    let output = harness
+        .command(&harness.home)
+        .args(["codex", "--name", "Cleo"])
+        .env("TRIGGER_ONE_RESTART", "1")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    for iteration in [1, 2] {
+        assert_name_pair(&harness.argv(iteration), "Cleo");
+        assert_eq!(harness.captured("clanker_id", iteration), "chloe");
+    }
+    assert_eq!(&harness.argv(2)[..2], ["resume", "--last"]);
+}
+
+#[test]
+fn explicit_name_coexists_with_resume_and_fork_subcommands() {
+    let resume = Harness::new();
+    let output = resume
+        .command(&resume.home)
+        .args(["codex", "--name", "Cleo", "--resume", "thread-1"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let args = resume.argv(1);
+    assert_eq!(&args[..2], ["resume", "thread-1"]);
+    assert_name_pair(&args, "Cleo");
+    assert_eq!(resume.captured("clanker_id", 1), "chloe");
+
+    let fork = Harness::new();
+    let output = fork
+        .command(&fork.home)
+        .args(["codex", "--name", "Cleo", "--fork"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let args = fork.argv(1);
+    assert_eq!(args.first().map(String::as_str), Some("fork"));
+    assert_name_pair(&args, "Cleo");
+    assert_eq!(fork.captured("clanker_id", 1), "chloe");
+}
+
+fn write_ucf_lineage(harness: &Harness, name: &str) -> (PathBuf, serde_json::Value) {
+    let session_dir = harness.data_home.join("unleash/sessions");
+    fs::create_dir_all(&session_dir).unwrap();
+    let path = session_dir.join(format!("{name}.ucf.jsonl"));
+    let header = json!({
+        "type": "session",
+        "ucf_version": "1.0.0",
+        "session_id": format!("{name}-session"),
+        "created_at": "2026-07-22T00:00:00Z",
+        "updated_at": "2026-07-22T00:01:00Z",
+        "source_cli": "foreign-fixture",
+        "source_version": "1.0.0",
+        "title": "Lineage fixture",
+        "parent_session_id": "parent-session",
+        "extensions": {"foreign": {"opaque": [1, 2, 3]}}
+    });
+    let message = json!({
+        "type": "message",
+        "id": "message-1",
+        "timestamp": "2026-07-22T00:01:00Z",
+        "completed_at": "2026-07-22T00:01:01Z",
+        "role": "user",
+        "content": [{"type": "text", "text": "lineage"}],
+        "metadata": {},
+        "extensions": {"foreign": {"message": true}}
+    });
+    fs::write(
+        &path,
+        format!(
+            "{}\n{}\n",
+            serde_json::to_string(&header).unwrap(),
+            serde_json::to_string(&message).unwrap()
+        ),
+    )
+    .unwrap();
+    (path, header)
+}
+
+#[test]
+fn ucf_resume_keeps_lineage_unchanged_alongside_name_and_identity_env() {
+    let harness = Harness::new();
+    let (path, expected_header) = write_ucf_lineage(&harness, "lineage");
+
+    let output = harness
+        .command(&harness.home)
+        .args(["codex", "--name", "Cleo", "--ucf", "lineage"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let args = harness.argv(1);
+    assert_name_pair(&args, "Cleo");
+    assert!(
+        args.iter().any(|arg| arg == "resume"),
+        "missing resume argument in {args:?}"
+    );
+    assert_eq!(harness.captured("clanker_id", 1), "chloe");
+    let actual_header: serde_json::Value =
+        serde_json::from_str(fs::read_to_string(path).unwrap().lines().next().unwrap()).unwrap();
+    assert_eq!(actual_header, expected_header);
+}
+
+#[test]
+fn crossload_keeps_source_ucf_bytes_unchanged_alongside_name_and_identity_env() {
+    let harness = Harness::new();
+    let (path, _) = write_ucf_lineage(&harness, "crossload-lineage");
+    let before = fs::read(&path).unwrap();
+
+    let output = harness
+        .command(&harness.home)
+        .args([
+            "codex",
+            "--name",
+            "Cleo",
+            "--crossload",
+            "ucf:crossload-lineage",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let args = harness.argv(1);
+    assert_name_pair(&args, "Cleo");
+    assert!(args.iter().any(|arg| arg == "resume"));
+    assert_eq!(harness.captured("clanker_id", 1), "chloe");
+    assert_eq!(fs::read(path).unwrap(), before);
+}

--- a/tests/character_identity_transport.rs
+++ b/tests/character_identity_transport.rs
@@ -8,7 +8,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use unleash::config::AppConfig;
-use unleash::config::CustomAgentConfig;
 use unleash::config::Profile;
 use unleash::config::ProfileManager;
 
@@ -25,7 +24,7 @@ struct Harness {
 
 impl Harness {
     fn new() -> Self {
-        Self::with_profile("codex", "codex")
+        Self::with_profile("clanker", "clanker")
     }
 
     fn with_profile(profile_name: &str, binary_name: &str) -> Self {
@@ -122,26 +121,9 @@ fi
             ),
         ]);
         manager.save_profile(&profile).unwrap();
-        let custom_agents = if profile_name == "clanker" {
-            let mut polyfill = unleash::agents::AgentDefinition::codex().polyfill;
-            polyfill.name_flag = None;
-            vec![CustomAgentConfig {
-                name: "clanker".to_string(),
-                binary: "clanker".to_string(),
-                description: "Clanker Code fixture".to_string(),
-                polyfill,
-                github_repo: None,
-                npm_package: None,
-                asset_template: None,
-                enabled: true,
-            }]
-        } else {
-            Vec::new()
-        };
         manager
             .save_app_config(&AppConfig {
                 current_profile: profile_name.to_string(),
-                custom_agents,
                 ..AppConfig::default()
             })
             .unwrap();
@@ -205,7 +187,7 @@ fn explicit_alias_transports_original_argv_and_canonical_env_across_workspaces_a
         fs::create_dir_all(&workspace).unwrap();
         let mut command = harness.command(&workspace);
         command
-            .args(["codex", "--name", requested])
+            .args(["clanker", "--name", requested])
             .env("CLANKER_ID", "stale-parent-value");
         match tmux {
             Some(value) => {
@@ -244,7 +226,7 @@ fn bare_launch_never_resolves_and_preserves_inherited_identity_behavior() {
 
     let output = harness
         .command(&workspace)
-        .arg("codex")
+        .arg("clanker")
         .env("CLANKER_ID", "inherited")
         .env_remove("TMUX")
         .output()
@@ -283,11 +265,34 @@ fn live_clanker_profile_uses_codex_identity_and_restart_semantics() {
 }
 
 #[test]
+fn named_headless_launch_places_name_before_exec_subcommand() {
+    let harness = Harness::new();
+    let output = harness
+        .command(&harness.home)
+        .args(["clanker", "--name", "Cleo", "-p", "hello"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let args = harness.argv(1);
+    assert_eq!(&args[..3], ["--name", "Cleo", "exec"]);
+    assert_eq!(
+        args.iter().filter(|arg| arg.as_str() == "--name").count(),
+        1
+    );
+    assert_eq!(harness.captured("clanker_id", 1), "chloe");
+}
+
+#[test]
 fn profile_environment_wins_for_character_resolution_context() {
     let harness = Harness::new();
     let output = harness
         .command(&harness.home)
-        .args(["codex", "--name", "Cleo"])
+        .args(["clanker", "--name", "Cleo"])
         .output()
         .unwrap();
 
@@ -309,7 +314,7 @@ fn malformed_mismatched_or_unresolved_identity_fails_before_child_launch() {
         let harness = Harness::new();
         let output = harness
             .command(&harness.home)
-            .args(["codex", "--name", "Cleo"])
+            .args(["clanker", "--name", "Cleo"])
             .env("RESOLVER_MODE", mode)
             .output()
             .unwrap();
@@ -325,7 +330,7 @@ fn named_meta_commands_skip_resolution_and_preserve_meta_behavior() {
         let harness = Harness::new();
         let output = harness
             .command(&harness.home)
-            .args(["codex", "--name", "Cleo", meta])
+            .args(["clanker", "--name", "Cleo", meta])
             .output()
             .unwrap();
 
@@ -343,7 +348,7 @@ fn dry_run_resolves_only_explicit_names_and_prints_verified_transport() {
     let named = Harness::new();
     let output = named
         .command(&named.home)
-        .args(["codex", "--name", "Cleo", "--dry-run"])
+        .args(["clanker", "--name", "Cleo", "--dry-run"])
         .output()
         .unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -360,7 +365,7 @@ fn dry_run_resolves_only_explicit_names_and_prints_verified_transport() {
     let bare = Harness::new();
     let output = bare
         .command(&bare.home)
-        .args(["codex", "--dry-run"])
+        .args(["clanker", "--dry-run"])
         .output()
         .unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -379,7 +384,7 @@ fn restart_retains_verified_identity_and_original_name() {
     let harness = Harness::new();
     let output = harness
         .command(&harness.home)
-        .args(["codex", "--name", "Cleo"])
+        .args(["clanker", "--name", "Cleo"])
         .env("TRIGGER_ONE_RESTART", "1")
         .output()
         .unwrap();
@@ -401,7 +406,7 @@ fn explicit_name_coexists_with_resume_and_fork_subcommands() {
     let resume = Harness::new();
     let output = resume
         .command(&resume.home)
-        .args(["codex", "--name", "Cleo", "--resume", "thread-1"])
+        .args(["clanker", "--name", "Cleo", "--resume", "thread-1"])
         .output()
         .unwrap();
     assert!(
@@ -417,7 +422,7 @@ fn explicit_name_coexists_with_resume_and_fork_subcommands() {
     let fork = Harness::new();
     let output = fork
         .command(&fork.home)
-        .args(["codex", "--name", "Cleo", "--fork"])
+        .args(["clanker", "--name", "Cleo", "--fork"])
         .output()
         .unwrap();
     assert!(
@@ -476,7 +481,7 @@ fn ucf_resume_keeps_lineage_unchanged_alongside_name_and_identity_env() {
 
     let output = harness
         .command(&harness.home)
-        .args(["codex", "--name", "Cleo", "--ucf", "lineage"])
+        .args(["clanker", "--name", "Cleo", "--ucf", "lineage"])
         .output()
         .unwrap();
 
@@ -506,7 +511,7 @@ fn crossload_keeps_source_ucf_bytes_unchanged_alongside_name_and_identity_env() 
     let output = harness
         .command(&harness.home)
         .args([
-            "codex",
+            "clanker",
             "--name",
             "Cleo",
             "--crossload",


### PR DESCRIPTION
## Summary

- add Clanker Code as a first-class built-in agent, profile, launcher target, session-format alias, SkillSync target, TUI entry, installer, and updater
- build the fork-owned `clanker` branch from source and atomically install the resulting binary with an exact revision/product-version receipt
- resolve explicit Clanker character names through the configured target and export the verified canonical identity as launch-scoped `CLANKER_ID`
- preserve the original `--name` spelling in argv, including valid root-level ordering before the `exec` subcommand for named headless runs
- keep bare launches and informational commands resolver-free

## Correctness contracts

- character resolution requires schema version 1, `ok: true`, a byte-exact input echo, and a non-empty canonical id
- a revision receipt is authoritative only while Unleash's owned `~/.local/bin/clanker` exists and reports the recorded product version
- update status compares full Git revisions; abbreviated SHAs are presentation-only and product SemVer is never compared to a Git SHA
- Clanker reuses the physical Codex-format session store without inventing a second discovery scan or a distinct source label

## Known constraints

- updates compile the large private fork workspace and require authenticated Git access plus Rust/Cargo
- update authority is the current head of the private `heiervang-technologies/clanker-code` `clanker` branch; there is no signed release artifact or historical version picker yet
- the real update command was not executed during review because it would replace the Clanker binary running this work; update discovery and the complete install/receipt logic are covered without mutating that binary

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo check --no-default-features`
- `cargo test --all-targets`
- character identity black-box suite, including named headless grammar
- receipt authority and revision-status regression tests
- real installed-Clanker dry run: `Cleo` resolves to `CLANKER_ID=chloe` and emits `clanker --name Cleo exec ...`
- `git diff --check`
