### PR TITLE
fix(skillsync): escape backslashes when rendering gemini/agy TOML commands

### DIFF
--- a/src/skillsync/cross_harness_tests.rs
+++ b/src/skillsync/cross_harness_tests.rs
@@ -289,4 +289,54 @@ Body text.
         .expect("manifest");
         assert!(!manifest.contains("minimal-skill"));
     }
+
+    fn skill_with_body(body: &str) -> Skill {
+        Skill {
+            name: "escape-probe".to_string(),
+            description: "probe".to_string(),
+            body: body.to_string(),
+            path: PathBuf::from("/nonexistent/escape-probe"),
+        }
+    }
+
+    /// A markdown table escapes pipes as `\|`. That is not a legal TOML escape,
+    /// so an unescaped body made the rendered command unparseable — and because
+    /// `skills list` parses every command, one bad body took the whole
+    /// subcommand down.
+    #[test]
+    fn gemini_render_escapes_backslashes_in_markdown_tables() {
+        let rendered = skillsync::render_gemini_command(&skill_with_body(
+            "| You have\u{2026} | Use |\n|---|---|\n| Text from another command | `cmd \\| show-me -` |\n",
+        ));
+
+        let parsed: toml::Value =
+            toml::from_str(&rendered).expect("rendered command is valid TOML");
+        let prompt = parsed["prompt"].as_str().expect("prompt is a string");
+        // the body must survive the round trip byte-for-byte
+        assert!(prompt.contains("`cmd \\| show-me -`"));
+    }
+
+    #[test]
+    fn gemini_render_survives_other_backslash_sequences() {
+        // \n and \t are legal TOML escapes and would silently corrupt the body;
+        // \d and a trailing lone backslash are illegal and would fail the parse.
+        let body = "regex: \\d+\\s*\\n literal\ntrailing backslash: \\";
+        let rendered = skillsync::render_gemini_command(&skill_with_body(body));
+
+        let parsed: toml::Value =
+            toml::from_str(&rendered).expect("rendered command is valid TOML");
+        let prompt = parsed["prompt"].as_str().expect("prompt is a string");
+        assert!(prompt.contains(body));
+    }
+
+    #[test]
+    fn gemini_render_still_escapes_triple_quotes() {
+        let rendered =
+            skillsync::render_gemini_command(&skill_with_body("fence: \"\"\" and \\ backslash"));
+
+        let parsed: toml::Value =
+            toml::from_str(&rendered).expect("rendered command is valid TOML");
+        let prompt = parsed["prompt"].as_str().expect("prompt is a string");
+        assert!(prompt.contains("fence: \"\"\" and \\ backslash"));
+    }
 }

--- a/src/skillsync/mod.rs
+++ b/src/skillsync/mod.rs
@@ -496,8 +496,22 @@ Use the provided user arguments (if any) to parameterize this run (e.g. specifyi
 \"\"\"\n",
         name = skill.name,
         description = escape_toml_basic_string(&skill.description),
-        body = skill.body.trim_start().replace("\"\"\"", "\\\"\\\"\\\"")
+        body = escape_toml_multiline_body(skill.body.trim_start())
     )
+}
+
+/// Escape a skill body for embedding in a TOML *multi-line basic* string (`"""`).
+///
+/// Basic strings process escape sequences, so a lone backslash in the body is
+/// interpreted as the start of one. Markdown tables routinely escape pipes as
+/// `\|`, which is not a legal TOML escape and makes the whole file unparseable —
+/// and since `skills list` parses every rendered command, one bad body took the
+/// entire command down.
+///
+/// Backslashes must be doubled *before* `"""` is escaped, or the backslashes this
+/// function inserts would themselves be doubled.
+fn escape_toml_multiline_body(body: &str) -> String {
+    body.replace('\\', "\\\\").replace("\"\"\"", "\\\"\\\"\\\"")
 }
 
 pub fn render_context_reference(skill: &Skill) -> String {


### PR DESCRIPTION
Fixes defect 4 of heiervang-technologies/hai-os#400 — `unleash skills list` currently **fails outright** on this box.

## The bug

`render_gemini_command` interpolates the skill body into a TOML multi-line basic string (`"""`), which processes escape sequences. Only `"""` was escaped, never backslashes — so a lone `\` in a body starts an escape sequence the parser then rejects.

Markdown tables routinely escape pipes as `\|`, and `\|` is not a legal TOML escape:

```
TOML parse error at line 43 column 50
43 | | Text from another command | `cmd \| show-me -` |
```

Because `skills list` parses *every* rendered command, one bad body takes the whole subcommand down. Validated across the three renders on this box: `brother-vc500w.toml` OK, `port-convo.toml` OK, `show-me.toml` FAILS. Confirmed by two independent parsers on the same character — unleash's own Rust `toml` (col 50) and Python `tomllib` (col 51).

The `description` field already escaped backslashes via `escape_toml_basic_string`. The body path simply did not — this restores consistency.

## The fix

`escape_toml_multiline_body` doubles backslashes **before** escaping `"""`. Order matters: reversed, the backslashes the `"""` escape itself inserts would be doubled in turn.

## Also fixes silent corruption

`\n` and `\t` in a body are *legal* TOML escapes, so they parsed cleanly while quietly rewriting the skill text — a real newline where the author wrote a literal `\n`. That class of corruption produced no error at all, so nothing would have surfaced it.

## Tests

Three regression tests, **each verified to fail without the fix** (reverted the one-line change and confirmed all three fail with the in-the-wild error, then restored):

- markdown table containing `\|`
- other backslash sequences — legal `\n` alongside illegal `\d` and a trailing lone backslash
- `"""` combined with a backslash, guarding the ordering requirement

Each asserts the body survives the round trip byte-for-byte, not merely that the file parses.

`cargo test --lib skillsync` 11/11 green, `cargo fmt --check` clean, clippy clean.

## Note on the other defects in hai-os#400

This PR addresses **only** defect 4. Defect 1 (`skills diff` never detects drift) and defect 2 (duplicate + stale blocks with corrupted markers) are untouched — for defect 2 in particular the *structure* is observed but the *mechanism* is not, so I have deliberately not guessed at a write-path fix.