### PR TITLE
fix(gateway): use `first()` instead of `get(0)` to unbreak clippy on main

### DIFF
--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -1433,7 +1433,7 @@ mod tests {
                 }
                 let parsed: Value = serde_json::from_str(data).unwrap();
                 if let Some(choices) = parsed.get("choices").and_then(Value::as_array) {
-                    if let Some(choice) = choices.get(0) {
+                    if let Some(choice) = choices.first() {
                         if let Some(content) = choice
                             .get("delta")
                             .and_then(|d| d.get("content"))


### PR DESCRIPTION
## Main's lint has been red since 2026-07-27

CI runs `cargo clippy --all-targets --no-deps -- -D warnings`, which makes `clippy::get_first` an **error**:

```
error: accessing first element with `choices.get(0)`
    --> src/gateway/api.rs:1436:43
     = note: `-D clippy::get-first` implied by `-D warnings`
```

Every branch cut from main now fails CI on first push, with nothing in its own diff to fix. Found while pushing #437, which failed on this rather than on its own changes.

## Timeline (observed)

| When | What |
|---|---|
| 2026-07-26 09:51 | `Lint Rust` on `agent/openai-agent-gateway` (#433) — **success** |
| 2026-07-27 11:42 | #433 merged; `Lint Rust` on the main push — **failure** |
| 2026-07-27 11:46 | dependabot PR #436, rebased onto new main — **failure** |
| since | no further pushes to main; HEAD still red |

I am **not** claiming to know why the PR run was green and the merge-commit run was not. The tested commit and the merged result differ in ways this history does not record, and I have not established which difference mattered.

## The change

One line. `choices.first()` is exactly `choices.get(0)`; no behaviour change.

Verified locally with the same invocation CI uses — `cargo clippy --all-targets --no-deps -- -D warnings` exits clean. `cargo fmt --check` clean.

## Correction to an earlier version of this description

An earlier draft asserted that "the clippy job only runs on pull requests and never gated that merge." **That is false** — `.github/workflows/lint.yml` triggers on `push: branches: [main]` as well as `pull_request`, and it did run on the merge commit, and it did fail.

So the gate is not missing. It fired correctly and the failure simply went unactioned for ~12 days. The gap is that nothing surfaces a red `main` to anyone; a post-merge push run reports, but by construction cannot block. Whether that warrants a notification, a required up-to-date-with-base rule, or nothing at all is a maintainer call, and I am not proposing a specific fix here.