### PR TITLE
fix(gateway): unbreak the clippy gate on main (`get(0)` → `first()`)

### DIFF
--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -1433,7 +1433,7 @@ mod tests {
                 }
                 let parsed: Value = serde_json::from_str(data).unwrap();
                 if let Some(choices) = parsed.get("choices").and_then(Value::as_array) {
-                    if let Some(choice) = choices.get(0) {
+                    if let Some(choice) = choices.first() {
                         if let Some(content) = choice
                             .get("delta")
                             .and_then(|d| d.get("content"))


### PR DESCRIPTION
## The break

`origin/main` currently fails the lint gate. Reproduced with the exact command
`.github/workflows/lint.yml:89` runs:

```
$ cargo clippy --all-targets --no-deps -- -D warnings
error: accessing first element with `choices.get(0)`
    --> src/gateway/api.rs:1436:43
error: could not compile `unleash` (lib test) due to 1 previous error
```

Clean after this one-line change.

## Why it slipped

The call is inside a `#[cfg(test)]` block, so a plain `cargo clippy` never
compiles it. Only `--all-targets` — which CI uses and the workflow header
explicitly says it widened to in #248 — reaches it. So the gate is doing its
job; it just isn't what most people run locally.

## Why it is worth fixing ahead of anything else

While it stands, **every** PR against `main` gets a red lint job for a reason
that has nothing to do with the change under review. That is the failure mode
where a real finding gets read as "the usual red" — the check stops carrying
information in either direction.

Found while opening #439 (unrelated: Pi's npm package is deprecated); that
branch cannot show a green lint until this lands.