### PR TITLE
fix(pi): move to `@earendil-works/pi-coding-agent`, migrating off the deprecated scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ unleash manages versions for all eight built-in agent CLIs:
 - **Antigravity CLI** (`agy`): AUR helper (`yay`/`paru`) on Arch; download from antigravity.google elsewhere
 - **Gemini CLI**: npm install
 - **OpenCode**: Built-in `opencode upgrade` command
-- **Pi**: npm install (`@mariozechner/pi-coding-agent`)
+- **Pi**: npm install (`@earendil-works/pi-coding-agent`; updating migrates off the deprecated `@mariozechner/pi-coding-agent`)
 - **Hermes Agent**: Official curl install script (always installs latest)
 
 Version filtering:

--- a/src/agents/definition.rs
+++ b/src/agents/definition.rs
@@ -5,6 +5,16 @@ use super::{
     SandboxStrategy, SessionStrategy,
 };
 
+/// npm package providing the `pi` binary.
+pub const PI_NPM_PACKAGE: &str = "@earendil-works/pi-coding-agent";
+
+/// Former name of [`PI_NPM_PACKAGE`], deprecated upstream in favour of the
+/// `@earendil-works` scope. Kept so the updater can *remove* it rather than
+/// leave two packages fighting over the same `pi` bin — both declare it, so a
+/// plain install of the new package on top of the old one can leave the stale
+/// binary in place while we report the new version.
+pub const PI_NPM_PACKAGE_DEPRECATED: &str = "@mariozechner/pi-coding-agent";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentDefinition {
     /// Agent type
@@ -308,7 +318,7 @@ impl AgentDefinition {
                 interactive_prompt_flag: None,
             },
             github_repo: None,
-            npm_package: Some("@mariozechner/pi-coding-agent".to_string()),
+            npm_package: Some(PI_NPM_PACKAGE.to_string()),
             enabled: true,
         }
     }

--- a/src/agents/manager.rs
+++ b/src/agents/manager.rs
@@ -484,7 +484,11 @@ impl AgentManager {
             AgentType::Antigravity => self.update_antigravity(),
             AgentType::Gemini => self.update_npm_agent("@google/gemini-cli", "Gemini CLI"),
             AgentType::OpenCode => self.update_opencode(),
-            AgentType::Pi => self.update_npm_agent("@mariozechner/pi-coding-agent", "Pi"),
+            AgentType::Pi => self.update_npm_agent_replacing(
+                super::PI_NPM_PACKAGE,
+                &[super::PI_NPM_PACKAGE_DEPRECATED],
+                "Pi",
+            ),
             AgentType::Hermes => self.update_hermes(),
             AgentType::Custom(name) => self.update_custom(&name),
         }
@@ -970,12 +974,59 @@ impl AgentManager {
 
     /// Update an npm-based agent to latest version
     fn update_npm_agent(&self, package: &str, name: &str) -> io::Result<String> {
+        self.update_npm_agent_replacing(package, &[], name)
+    }
+
+    /// Update an npm-installed agent, first removing any `superseded` packages
+    /// that provide the same binary.
+    ///
+    /// The uninstall is what makes a scope migration actually take effect. When
+    /// an agent is renamed upstream, the old and new packages both declare the
+    /// same `bin`, so installing the new one while the old is still present can
+    /// leave the *old* binary linked — and then we report "updated
+    /// successfully" while the user keeps running the abandoned build. That is
+    /// worse than not migrating at all, because the version we display is right
+    /// and the binary it describes is wrong.
+    ///
+    /// A superseded package that is not installed is not an error: `npm
+    /// uninstall -g` on an absent package is a no-op, so this stays idempotent
+    /// and costs one npm call on machines that never had the old name.
+    fn update_npm_agent_replacing(
+        &self,
+        package: &str,
+        superseded: &[&str],
+        name: &str,
+    ) -> io::Result<String> {
+        let mut removed = Vec::new();
+        for old in superseded {
+            if *old == package {
+                continue;
+            }
+            let uninstall = crate::version::VersionManager::npm_global_command()
+                .args(["uninstall", "-g", old])
+                .output()?;
+            // Best-effort: a failure here is not fatal, because the install
+            // below may still produce a working binary. Do not surface it as
+            // the update's outcome.
+            if uninstall.status.success() {
+                removed.push(*old);
+            }
+        }
+
         let output = crate::version::VersionManager::npm_global_command()
             .args(["install", "-g", &format!("{}@latest", package)])
             .output()?;
 
         if output.status.success() {
-            Ok(format!("{} updated successfully", name))
+            if removed.is_empty() {
+                Ok(format!("{} updated successfully", name))
+            } else {
+                Ok(format!(
+                    "{} updated successfully (migrated off {})",
+                    name,
+                    removed.join(", ")
+                ))
+            }
         } else {
             Err(io::Error::other(format!(
                 "Failed to update {}: {}",

--- a/src/agents/tests.rs
+++ b/src/agents/tests.rs
@@ -508,14 +508,30 @@ fn no_non_anthropic_agent_uses_anthropic_npm_scope() {
 }
 
 #[test]
-fn pi_npm_package_is_mariozechner() {
+fn pi_npm_package_is_earendil_works() {
     let pi = AgentDefinition::pi();
     assert_eq!(
         pi.npm_package.as_deref(),
-        Some("@mariozechner/pi-coding-agent")
+        Some("@earendil-works/pi-coding-agent")
     );
     assert_eq!(pi.binary, "pi");
     assert_eq!(pi.agent_type, AgentType::Pi);
+}
+
+/// The point of the migration is that we no longer resolve Pi against the
+/// deprecated scope. Asserting the active package name alone would still pass
+/// if someone re-pointed the constant back, so pin the relationship: the two
+/// names must differ, and the live one must not be the deprecated one.
+#[test]
+fn pi_npm_package_is_not_the_deprecated_scope() {
+    use crate::agents::{PI_NPM_PACKAGE, PI_NPM_PACKAGE_DEPRECATED};
+
+    assert_eq!(PI_NPM_PACKAGE_DEPRECATED, "@mariozechner/pi-coding-agent");
+    assert_ne!(PI_NPM_PACKAGE, PI_NPM_PACKAGE_DEPRECATED);
+    assert_eq!(
+        AgentDefinition::pi().npm_package.as_deref(),
+        Some(PI_NPM_PACKAGE)
+    );
 }
 
 #[test]

--- a/src/version/pi.rs
+++ b/src/version/pi.rs
@@ -9,7 +9,7 @@ impl VersionManager {
     // ── Pi version management ───────────────────────
 
     pub fn get_pi_available_versions(&self) -> io::Result<Vec<String>> {
-        let res = Self::query_npm_registry_versions("@mariozechner/pi-coding-agent", 20);
+        let res = Self::query_npm_registry_versions(crate::agents::PI_NPM_PACKAGE, 20);
         match res {
             Ok(versions) if !versions.is_empty() => Ok(versions),
             _ => {
@@ -58,16 +58,23 @@ impl VersionManager {
 
         let use_sudo = Self::npm_global_needs_sudo();
         let _ = log_tx.send(format!(
-            "Running: {}npm install -g @mariozechner/pi-coding-agent@{}",
+            "Running: {}npm install -g {}@{}",
             if use_sudo { "sudo " } else { "" },
+            crate::agents::PI_NPM_PACKAGE,
             version
         ));
+        // `--force` is what handles the bin collision on this path: Pi moved
+        // scope upstream, and the deprecated package declares the same `pi`
+        // bin, so without it npm can refuse or silently keep the old link.
+        // The updater in AgentManager uninstalls the old package outright;
+        // here we only ever install one explicit version, so forcing the link
+        // is enough.
         let (ok, stdout, stderr) = Self::run_streaming(
             Self::npm_global_command().args([
                 "install",
                 "-g",
                 "--force",
-                &format!("@mariozechner/pi-coding-agent@{}", version),
+                &format!("{}@{}", crate::agents::PI_NPM_PACKAGE, version),
             ]),
             &log_tx,
         )?;


### PR DESCRIPTION
Closes #439.

## What

Pi's npm package was renamed upstream. Measured against the registry today:

| | `@mariozechner/pi-coding-agent` | `@earendil-works/pi-coding-agent` |
|---|---|---|
| latest | 0.73.1 | **0.84.1** |
| last published | 2026-05-07 | 2026-08-07 |
| deprecated | yes | no |

`unleash`'s own update path was walking users onto a three-month-stale
abandoned build and reporting success, and the version picker could only ever
offer versions of the dead package.

## Why this is more than a find-and-replace

Both packages declare the same `pi` bin. Installing the new one while the old
is still present can leave the **old** binary linked — so we would report
0.84.x while the user runs 0.73.1. That is worse than not migrating at all:
the version we display would be right and the binary it describes wrong, which
is precisely the quiet failure this PR exists to remove.

`update_npm_agent_replacing()` therefore uninstalls the superseded package
before installing. `npm uninstall -g` on an absent package is a no-op, so it
is idempotent and costs one npm call on machines that never had the old name.
`update_npm_agent()` is kept as a thin wrapper with an empty list, so no other
agent's behaviour changes.

`install_pi_version_streaming` already passed `--force`, so the version-picker
path was never exposed to the collision — it only needed the new name. Noted in
a comment there so the asymmetry does not read as an oversight later.

## Tests

The existing test was called `pi_npm_package_is_mariozechner`. The name
asserts the vendor, so editing only its expected value would have left a test
whose *name* claimed the opposite of what it checked. Renamed, plus a second
test that pins the *relationship* — the live package must differ from the
deprecated one — so quietly re-pointing the constant back fails rather than
passes.

- Full suite: **815 passed, 0 failed** (`cargo test --all-targets`).
- Red-proofed: with `PI_NPM_PACKAGE` flipped back to the deprecated value both
  new tests **FAIL**. They can tell the two states apart rather than passing
  unconditionally.

## CI note

The lint job will be red on this branch until #438 lands — `origin/main`
currently fails `cargo clippy --all-targets -- -D warnings` on an unrelated
`get(0)` in `src/gateway/api.rs`. That break is not from this change; #438 is
the one-line fix.

## Not done here

Only the coding-agent package is migrated. `@mariozechner/pi-tui` and
`@mariozechner/pi-ai` carry the same deprecation notice, but unleash does not
reference them directly — they arrive as transitive deps — so there is nothing
to change on our side and I have not touched them.