### PR TITLE
fix: install the Code Mode host alongside Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ harness. See the [OpenAI-compatible gateway guide](docs/openai-gateway.md).
 unleash manages versions for all eight built-in agent CLIs:
 
 - **Claude Code**: Native binary (GCS) or npm install
-- **Codex**: Prebuilt binary from GitHub releases, cargo build fallback
+- **Codex**: Version-matched CLI and Code Mode host binaries from GitHub releases, cargo build fallback
 - **Clanker Code**: Fork-owned `clanker` branch source build with atomic install and revision receipt
 - **Antigravity CLI** (`agy`): AUR helper (`yay`/`paru`) on Arch; download from antigravity.google elsewhere
 - **Gemini CLI**: npm install

--- a/src/agents/manager.rs
+++ b/src/agents/manager.rs
@@ -744,6 +744,7 @@ impl AgentManager {
             .ok_or_else(|| io::Error::other("Unsupported platform for prebuilt binary"))?;
 
         let asset_name = format!("codex-{}.tar.gz", triple);
+        let code_mode_host_asset_name = format!("codex-code-mode-host-{}.tar.gz", triple);
 
         // Get latest release tag
         let tag_output = Command::new("curl")
@@ -765,62 +766,73 @@ impl AgentManager {
 
         let version = tag.trim_start_matches("rust-v").trim_start_matches('v');
 
-        // Check if asset exists in this release
-        let has_asset = json
-            .get("assets")
-            .and_then(|a| a.as_array())
-            .map(|assets| {
-                assets
-                    .iter()
-                    .any(|a| a.get("name").and_then(|n| n.as_str()) == Some(&asset_name))
-            })
-            .unwrap_or(false);
+        // Check that both runtime binaries exist in this release. New Codex
+        // models can require Code Mode, and the main CLI fails closed when its
+        // version-matched `codex-code-mode-host` companion is absent.
+        let has_asset = |name: &str| {
+            json.get("assets")
+                .and_then(|a| a.as_array())
+                .map(|assets| {
+                    assets
+                        .iter()
+                        .any(|a| a.get("name").and_then(|n| n.as_str()) == Some(name))
+                })
+                .unwrap_or(false)
+        };
 
-        if !has_asset {
+        if !has_asset(&asset_name) {
             return Err(io::Error::other(format!(
                 "No prebuilt binary '{}' found in release {}",
                 asset_name, tag
             )));
         }
-
-        let download_url = format!(
-            "https://github.com/openai/codex/releases/download/{}/{}",
-            tag, asset_name
-        );
+        if !has_asset(&code_mode_host_asset_name) {
+            return Err(io::Error::other(format!(
+                "No Code Mode host '{}' found in release {}",
+                code_mode_host_asset_name, tag
+            )));
+        }
 
         // Download to temp file
         let tmp_dir = dirs::cache_dir()
             .unwrap_or_else(|| PathBuf::from("/tmp"))
             .join("unleash/codex-download");
         fs::create_dir_all(&tmp_dir)?;
-        let tmp_archive = tmp_dir.join(&asset_name);
+        for archive_name in [&asset_name, &code_mode_host_asset_name] {
+            let download_url = format!(
+                "https://github.com/openai/codex/releases/download/{}/{}",
+                tag, archive_name
+            );
+            let tmp_archive = tmp_dir.join(archive_name);
+            let dl_output = Command::new("curl")
+                .args(["-fsSL", "-o", &tmp_archive.to_string_lossy(), &download_url])
+                .output()?;
 
-        let dl_output = Command::new("curl")
-            .args(["-fsSL", "-o", &tmp_archive.to_string_lossy(), &download_url])
-            .output()?;
+            if !dl_output.status.success() {
+                return Err(io::Error::other(format!(
+                    "Download failed for {}: {}",
+                    archive_name,
+                    String::from_utf8_lossy(&dl_output.stderr)
+                )));
+            }
 
-        if !dl_output.status.success() {
-            return Err(io::Error::other(format!(
-                "Download failed: {}",
-                String::from_utf8_lossy(&dl_output.stderr)
-            )));
-        }
+            // Both archives contain one target-suffixed binary at the root.
+            let extract_output = Command::new("tar")
+                .args([
+                    "xzf",
+                    &tmp_archive.to_string_lossy(),
+                    "-C",
+                    &tmp_dir.to_string_lossy(),
+                ])
+                .output()?;
 
-        // Extract — codex binary is at the root of the tar.gz
-        let extract_output = Command::new("tar")
-            .args([
-                "xzf",
-                &tmp_archive.to_string_lossy(),
-                "-C",
-                &tmp_dir.to_string_lossy(),
-            ])
-            .output()?;
-
-        if !extract_output.status.success() {
-            return Err(io::Error::other(format!(
-                "Extraction failed: {}",
-                String::from_utf8_lossy(&extract_output.stderr)
-            )));
+            if !extract_output.status.success() {
+                return Err(io::Error::other(format!(
+                    "Extraction failed for {}: {}",
+                    archive_name,
+                    String::from_utf8_lossy(&extract_output.stderr)
+                )));
+            }
         }
 
         // Find the codex binary — named codex-<triple> inside the archive
@@ -836,15 +848,27 @@ impl AgentManager {
                 triple
             )));
         };
+        let extracted_code_mode_host = tmp_dir.join(format!("codex-code-mode-host-{}", triple));
+        if !extracted_code_mode_host.exists() {
+            return Err(io::Error::other(format!(
+                "Extracted archive does not contain 'codex-code-mode-host-{}' binary",
+                triple
+            )));
+        }
+        let code_mode_host_install_path = install_path.with_file_name("codex-code-mode-host");
 
-        // Install atomically (chmod +x happens on the staged temp before the
-        // rename, so a running `codex` is never overwritten in place).
+        // Install the companion first and the CLI last. A new CLI is therefore
+        // never exposed without the matching host it may require.
+        atomic_install_binary(&extracted_code_mode_host, &code_mode_host_install_path)?;
         atomic_install_binary(binary_path, install_path)?;
 
         // Cleanup
         let _ = fs::remove_dir_all(&tmp_dir);
 
-        Ok(format!("Codex {} installed from prebuilt binary", version))
+        Ok(format!(
+            "Codex {} and Code Mode host installed from prebuilt binaries",
+            version
+        ))
     }
 
     /// Detect the platform triple for prebuilt binary downloads
@@ -931,12 +955,22 @@ impl AgentManager {
 
         progress.push("Building codex from source (this may take a while)...".to_string());
         let output = Command::new("cargo")
-            .args(["build", "--release", "-p", "codex-cli"])
+            .args([
+                "build",
+                "--release",
+                "-p",
+                "codex-cli",
+                "-p",
+                "codex-code-mode-host",
+            ])
             .current_dir(&codex_rs_dir)
             .output()?;
 
         if output.status.success() {
             let binary_path = codex_rs_dir.join("target/release/codex");
+            let code_mode_host_path = codex_rs_dir.join("target/release/codex-code-mode-host");
+            let code_mode_host_install_path = install_path.with_file_name("codex-code-mode-host");
+            atomic_install_binary(&code_mode_host_path, &code_mode_host_install_path)?;
             atomic_install_binary(&binary_path, install_path)?;
 
             progress.push(format!(

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -415,8 +415,12 @@ pub(crate) fn run_with_env(
     let mut profile_env = load_profile_env()?;
     profile_env.extend(child_env);
 
-    // Check authentication on first run
-    check_authentication();
+    // Claude auth is Claude-specific. Running this check for Codex (or any
+    // other agent) produces a misleading warning even when that agent's own
+    // authentication is healthy.
+    if should_check_claude_authentication(agent_type.as_ref()) {
+        check_authentication();
+    }
 
     // Hyprland integration: set window rules and notify on start (only if plugin enabled)
     if hyprland::is_focus_enabled() {
@@ -769,6 +773,10 @@ fn run_agent(
 }
 
 /// Check if authentication is configured
+fn should_check_claude_authentication(agent_type: Option<&AgentType>) -> bool {
+    matches!(agent_type, Some(AgentType::Claude))
+}
+
 fn check_authentication() {
     // Check OAuth token
     if env::var("CLAUDE_CODE_OAUTH_TOKEN").is_ok() {
@@ -900,6 +908,27 @@ mod tests {
         // Substrings must not match — only exact arg equality.
         assert!(!is_meta_command(&s(&["--version-check"])));
         assert!(!is_meta_command(&s(&["--help-mcp"])));
+    }
+
+    #[test]
+    fn claude_auth_check_is_not_run_for_other_agents() {
+        assert!(should_check_claude_authentication(Some(&AgentType::Claude)));
+        for agent in [
+            AgentType::Codex,
+            AgentType::Clanker,
+            AgentType::Gemini,
+            AgentType::Antigravity,
+            AgentType::OpenCode,
+            AgentType::Pi,
+            AgentType::Hermes,
+        ] {
+            assert!(
+                !should_check_claude_authentication(Some(&agent)),
+                "{} launch must not run Claude authentication checks",
+                agent.display_name()
+            );
+        }
+        assert!(!should_check_claude_authentication(None));
     }
 
     // Coverage for args_already_signal_resume — one assertion per agent's

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -435,7 +435,12 @@ fn print_summary(check_results: &[CheckResult], outcomes: &[UpdateOutcome]) -> u
 /// trap-on-EXIT for guaranteed cleanup, and explicit `|| exit 1` on each
 /// fallible step so the caller gets a non-zero exit (and the real stderr)
 /// when something breaks.
-fn self_update_script(version: &str, platform: &str) -> String {
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn self_update_script(release_tag: &str, platform: &str) -> String {
+    let release_tag = shell_quote(release_tag);
     format!(
         "tmp=$(mktemp -d -t unleash-update.XXXXXXXX) || exit 1\n\
          trap 'rm -rf \"$tmp\"' EXIT\n\
@@ -470,9 +475,9 @@ fn self_update_script(version: &str, platform: &str) -> String {
          gh repo clone heiervang-technologies/unleash source -- -b {} || exit 1\n\
          expected=$(git -C source rev-list -n 1 {}) || exit 1\n\
          actual=$(git -C source rev-parse HEAD) || exit 1\n\
-         if [ \"$expected\" != \"$actual\" ]; then echo \"Cloned source does not match {}\" >&2; exit 1; fi\n\
+         if [ \"$expected\" != \"$actual\" ]; then echo \"Cloned source does not match release tag\" >&2; exit 1; fi\n\
          bash source/scripts/install.sh --no-build",
-        version,
+        release_tag,
         platform,
         platform,
         platform,
@@ -485,9 +490,8 @@ fn self_update_script(version: &str, platform: &str) -> String {
         platform,
         platform,
         platform,
-        version,
-        version,
-        version
+        release_tag,
+        release_tag
     )
 }
 
@@ -497,14 +501,19 @@ fn check_or_update_self(check_only: bool) -> io::Result<()> {
 
     // Check latest release from GitHub
     eprintln!("Checking unleash...");
-    let latest = get_latest_github_version("heiervang-technologies/unleash")?;
+    // Keep GitHub's exact tag for release download and source checkout. The
+    // repository currently uses `v`-prefixed tags, and reconstructing a tag
+    // from normalized semver caused `gh release download 0.1.98` to fail even
+    // though release `v0.1.98` existed.
+    let latest = get_latest_github_release_tag("heiervang-technologies/unleash")?;
 
     match latest {
         Some(ref ver) if version_less_than(current, ver) => {
+            let display_version = sanitize_version(ver);
             if check_only {
                 println!(
                     "  unleash          {} -> {} (update available)",
-                    current, ver
+                    current, display_version
                 );
             } else {
                 let arch = std::env::consts::ARCH;
@@ -521,13 +530,19 @@ fn check_or_update_self(check_only: bool) -> io::Result<()> {
                     }
                 };
 
-                println!("  unleash          updating {} -> {}...", current, ver);
+                println!(
+                    "  unleash          updating {} -> {}...",
+                    current, display_version
+                );
                 let output = Command::new("bash")
                     .arg("-c")
                     .arg(self_update_script(ver, platform))
                     .output()?;
                 if output.status.success() {
-                    println!("  unleash          {} -> {} (updated)", current, ver);
+                    println!(
+                        "  unleash          {} -> {} (updated)",
+                        current, display_version
+                    );
                 } else {
                     eprintln!(
                         "  unleash          update failed: {}",
@@ -728,7 +743,10 @@ fn get_latest_npm_version(package: &str) -> io::Result<Option<String>> {
     Ok(None)
 }
 
-fn get_latest_github_version(repo: &str) -> io::Result<Option<String>> {
+/// Return GitHub's exact latest-release tag. Callers that address release or
+/// git objects must use this value unchanged; normalizing it can make an
+/// existing release impossible to find.
+fn get_latest_github_release_tag(repo: &str) -> io::Result<Option<String>> {
     let url = format!("https://api.github.com/repos/{}/releases/latest", repo);
 
     // Try with auth first (needed for private repos), then fall back to
@@ -742,6 +760,13 @@ fn get_latest_github_version(repo: &str) -> io::Result<Option<String>> {
         }
     }
     fetch_github_release_tag(&url, None)
+}
+
+/// Return a normalized version suitable for display and version comparison.
+/// Agent update paths do not address GitHub release objects directly, so they
+/// should not leak repository-specific tag prefixes into their version labels.
+fn get_latest_github_version(repo: &str) -> io::Result<Option<String>> {
+    Ok(get_latest_github_release_tag(repo)?.map(|tag| sanitize_version(&tag)))
 }
 
 fn get_latest_antigravity_aur_version() -> io::Result<Option<String>> {
@@ -815,7 +840,8 @@ fn parse_release_tag(body: &[u8]) -> Option<String> {
     let json: serde_json::Value = serde_json::from_slice(body).ok()?;
     json.get("tag_name")
         .and_then(|t| t.as_str())
-        .map(sanitize_version)
+        .filter(|tag| !tag.is_empty())
+        .map(str::to_string)
 }
 
 /// Get a GitHub token for API auth (needed for private repos).
@@ -1755,7 +1781,9 @@ mod tests {
     #[test]
     fn parse_release_tag_extracts_tag_from_success_response() {
         let body = br#"{"tag_name":"v2026.5.7","name":"Release"}"#;
-        assert_eq!(parse_release_tag(body), Some("2026.5.7".to_string()));
+        let tag = parse_release_tag(body).expect("release tag");
+        assert_eq!(tag, "v2026.5.7");
+        assert_eq!(sanitize_version(&tag), "2026.5.7");
     }
 
     #[test]
@@ -1945,10 +1973,58 @@ Version                       : 1.1.0_4523441756438528-1\n";
     fn self_update_script_verifies_cloned_source_tag() {
         let script = self_update_script("v0.1.82", "linux");
         assert!(
-            script.contains("git -C source rev-list -n 1 v0.1.82")
+            script.contains("git -C source rev-list -n 1 'v0.1.82'")
                 && script.contains("git -C source rev-parse HEAD")
-                && script.contains("Cloned source does not match v0.1.82"),
+                && script.contains("Cloned source does not match release tag"),
             "self-update must verify cloned source before running install.sh: {script}"
+        );
+    }
+
+    #[test]
+    fn self_update_script_preserves_exact_github_tag() {
+        let body = br#"{"tag_name":"v0.1.98","name":"Release"}"#;
+        let tag = parse_release_tag(body).expect("release tag");
+        let script = self_update_script(&tag, "linux-x86_64");
+        assert!(
+            script.contains("gh release download 'v0.1.98' ")
+                && script.contains("source -- -b 'v0.1.98'")
+                && script.contains("git -C source rev-list -n 1 'v0.1.98'"),
+            "self-update must use GitHub's exact release tag: {script}"
+        );
+    }
+
+    #[test]
+    fn self_update_script_shell_quotes_release_tag() {
+        let script = self_update_script("v1.2.3'; touch /tmp/pwned; '", "linux-x86_64");
+        assert!(
+            script.contains("'v1.2.3'\"'\"'; touch /tmp/pwned; '\"'\"''"),
+            "release tag must remain one inert shell argument: {script}"
+        );
+    }
+
+    #[test]
+    fn self_update_script_is_valid_bash_syntax() {
+        use std::io::Write as _;
+        use std::process::Stdio;
+
+        let script = self_update_script("v0.1.98", "linux-x86_64");
+        let mut child = Command::new("bash")
+            .arg("-n")
+            .stdin(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("bash must be available for the bash-based self-updater");
+        child
+            .stdin
+            .as_mut()
+            .expect("bash stdin")
+            .write_all(script.as_bytes())
+            .expect("write update script");
+        let output = child.wait_with_output().expect("wait for bash -n");
+        assert!(
+            output.status.success(),
+            "generated self-update script must parse as bash: {}",
+            String::from_utf8_lossy(&output.stderr)
         );
     }
 }

--- a/src/version/codex.rs
+++ b/src/version/codex.rs
@@ -77,6 +77,7 @@ impl VersionManager {
     pub fn install_codex_version(&self, version: &str) -> io::Result<InstallResult> {
         let tag = format!("rust-v{}", version);
         let asset_name = Self::codex_asset_name();
+        let code_mode_host_asset_name = Self::codex_code_mode_host_asset_name();
 
         let install_dir = dirs::home_dir()
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Home dir not found"))?
@@ -98,6 +99,8 @@ impl VersionManager {
                 "openai/codex",
                 "--pattern",
                 &format!("{}.tar.gz", asset_name),
+                "--pattern",
+                &format!("{}.tar.gz", code_mode_host_asset_name),
                 "--dir",
                 tmp_dir.to_str().unwrap_or("/tmp"),
             ])
@@ -132,6 +135,27 @@ impl VersionManager {
             });
         }
 
+        // Code Mode was introduced as a version-matched companion binary.
+        // Older releases may not publish it, so install it when present while
+        // retaining the ability to select historical Codex versions.
+        let code_mode_host_archive = tmp_dir.join(format!("{}.tar.gz", code_mode_host_asset_name));
+        let extracted_code_mode_host = tmp_dir.join(&code_mode_host_asset_name);
+        if code_mode_host_archive.exists() {
+            let extract_host = Command::new("tar")
+                .args(["xzf", &format!("{}.tar.gz", code_mode_host_asset_name)])
+                .current_dir(&tmp_dir)
+                .output()?;
+            if !extract_host.status.success() {
+                let _ = fs::remove_dir_all(&tmp_dir);
+                return Ok(InstallResult {
+                    success: false,
+                    stdout: String::from_utf8_lossy(&extract_host.stdout).to_string(),
+                    stderr: String::from_utf8_lossy(&extract_host.stderr).to_string(),
+                    error: Some("Failed to extract Codex Code Mode host tarball".to_string()),
+                });
+            }
+        }
+
         // Install the binary
         let extracted_binary = tmp_dir.join(&asset_name);
         let install_path = install_dir.join("codex");
@@ -146,6 +170,24 @@ impl VersionManager {
             });
         }
 
+        if code_mode_host_archive.exists() {
+            if !extracted_code_mode_host.exists() {
+                let _ = fs::remove_dir_all(&tmp_dir);
+                return Ok(InstallResult {
+                    success: false,
+                    stdout: String::new(),
+                    stderr: format!(
+                        "Expected binary {} not found in archive",
+                        code_mode_host_asset_name
+                    ),
+                    error: Some("Code Mode host not found after extraction".to_string()),
+                });
+            }
+            crate::agents::atomic_install_binary(
+                &extracted_code_mode_host,
+                &install_dir.join("codex-code-mode-host"),
+            )?;
+        }
         crate::agents::atomic_install_binary(&extracted_binary, &install_path)?;
 
         let _ = fs::remove_dir_all(&tmp_dir);
@@ -165,6 +207,7 @@ impl VersionManager {
     ) -> io::Result<InstallResult> {
         let tag = format!("rust-v{}", version);
         let asset_name = Self::codex_asset_name();
+        let code_mode_host_asset_name = Self::codex_code_mode_host_asset_name();
 
         let install_dir = dirs::home_dir()
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Home dir not found"))?
@@ -189,6 +232,8 @@ impl VersionManager {
                 "openai/codex",
                 "--pattern",
                 &format!("{}.tar.gz", asset_name),
+                "--pattern",
+                &format!("{}.tar.gz", code_mode_host_asset_name),
                 "--dir",
                 tmp_dir.to_str().unwrap_or("/tmp"),
             ]),
@@ -206,6 +251,27 @@ impl VersionManager {
                     asset_name, tag
                 )),
             });
+        }
+
+        let code_mode_host_archive = tmp_dir.join(format!("{}.tar.gz", code_mode_host_asset_name));
+        let extracted_code_mode_host = tmp_dir.join(&code_mode_host_asset_name);
+        if code_mode_host_archive.exists() {
+            let _ = log_tx.send("Extracting Codex Code Mode host...".to_string());
+            let (ok, stdout, stderr) = Self::run_streaming(
+                Command::new("tar")
+                    .args(["xzf", &format!("{}.tar.gz", code_mode_host_asset_name)])
+                    .current_dir(&tmp_dir),
+                &log_tx,
+            )?;
+            if !ok {
+                let _ = fs::remove_dir_all(&tmp_dir);
+                return Ok(InstallResult {
+                    success: false,
+                    stdout,
+                    stderr,
+                    error: Some("Failed to extract Codex Code Mode host tarball".to_string()),
+                });
+            }
         }
 
         // Extract
@@ -248,6 +314,25 @@ impl VersionManager {
         // Atomic install: stage + chmod + rename so switching codex versions
         // while a codex agent is running can't hit ETXTBSY or leave a partial
         // binary at the canonical path.
+        if code_mode_host_archive.exists() {
+            if !extracted_code_mode_host.exists() {
+                let _ = fs::remove_dir_all(&tmp_dir);
+                return Ok(InstallResult {
+                    success: false,
+                    stdout: String::new(),
+                    stderr: format!(
+                        "Expected binary {} not found in archive",
+                        code_mode_host_asset_name
+                    ),
+                    error: Some("Code Mode host not found after extraction".to_string()),
+                });
+            }
+            let _ = log_tx.send("Installing Codex Code Mode host...".to_string());
+            crate::agents::atomic_install_binary(
+                &extracted_code_mode_host,
+                &install_dir.join("codex-code-mode-host"),
+            )?;
+        }
         crate::agents::atomic_install_binary(&extracted_binary, &install_path)?;
 
         let _ = fs::remove_dir_all(&tmp_dir);
@@ -260,7 +345,7 @@ impl VersionManager {
         })
     }
 
-    fn codex_asset_name() -> String {
+    pub(super) fn codex_asset_name() -> String {
         let arch = std::env::consts::ARCH;
         let os = std::env::consts::OS;
 
@@ -277,5 +362,9 @@ impl VersionManager {
         };
 
         format!("codex-{}", target_triple)
+    }
+
+    pub(super) fn codex_code_mode_host_asset_name() -> String {
+        Self::codex_asset_name().replacen("codex-", "codex-code-mode-host-", 1)
     }
 }

--- a/src/version/tests.rs
+++ b/src/version/tests.rs
@@ -545,3 +545,14 @@ fn bench_parallel_vs_sequential_version_fetch() {
         sequential_time.as_secs_f64() / parallel_time.as_secs_f64().max(0.001)
     );
 }
+
+#[test]
+fn codex_code_mode_host_asset_matches_cli_target() {
+    let codex = VersionManager::codex_asset_name();
+    let host = VersionManager::codex_code_mode_host_asset_name();
+    assert_eq!(
+        host,
+        codex.replacen("codex-", "codex-code-mode-host-", 1),
+        "Codex and its Code Mode host must always use the same target triple"
+    );
+}


### PR DESCRIPTION
## What

- preserve the exact v-prefixed GitHub release tag in the Unleash self-updater
- install the version-matched codex-code-mode-host alongside Codex in latest, source-build, and version-picker paths
- install the companion host before exposing the new Codex CLI
- run Claude authentication checks only when launching Claude

## Why

Codex 0.147.0 can select code_mode_only models and fails closed when the separately published host executable is absent. Unleash previously installed only the main Codex archive. Separately, Unleash normalized its own release tag before passing it to gh release download, turning the real v0.1.98 tag into nonexistent 0.1.98.

This was reproduced on Crystal, repaired there with the official version-matched OpenAI release asset, and verified through a real Code Mode command.

## Validation

- cargo test --all-targets: 816 passed, 0 failed, 4 ignored
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- generated self-update script passes bash -n
- isolated real updater install produced Codex 0.147.0 plus executable codex-code-mode-host
- historical Codex release download behavior remains compatible when no host asset exists

## Deployment verification

On Crystal, unleash codex performed a real shell tool call and returned CRYSTAL_CODE_MODE_OK without the Code Mode host warning or the unrelated Claude authentication warning.