### PR TITLE
fix(gateway): release turn gate before terminal event

### DIFF
--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -973,6 +973,7 @@ mod tests {
             delay: Duration::ZERO,
             starts: Arc::clone(&starts),
             pause: None,
+            terminal_barriers: None,
         };
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
@@ -1083,6 +1084,7 @@ mod tests {
             delay: Duration::from_millis(200),
             starts: Arc::clone(&starts),
             pause: None,
+            terminal_barriers: None,
         };
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
@@ -1207,6 +1209,7 @@ mod tests {
             delay: Duration::ZERO,
             starts: Arc::clone(&starts),
             pause: None,
+            terminal_barriers: None,
         };
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
@@ -1310,6 +1313,7 @@ mod tests {
             delay: Duration::ZERO,
             starts: Arc::clone(&starts),
             pause: None,
+            terminal_barriers: None,
         };
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
@@ -1392,6 +1396,7 @@ mod tests {
             delay: Duration::ZERO,
             starts: Arc::clone(&starts),
             pause: Some((80, Duration::from_millis(200))),
+            terminal_barriers: None,
         };
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -56,6 +56,7 @@ pub(crate) enum Driver {
         delay: Duration,
         starts: Arc<std::sync::atomic::AtomicUsize>,
         pause: Option<(usize, std::time::Duration)>,
+        terminal_barriers: Option<Arc<(std::sync::Barrier, std::sync::Barrier)>>,
     },
 }
 
@@ -82,15 +83,29 @@ impl Driver {
         let (sender, receiver) = mpsc::channel(64);
         let driver = self.clone();
         tokio::task::spawn_blocking(move || {
-            let _gate = gate;
-            let result = driver.run_prepared_turn(&prompt, native_gate, |update| {
-                let _ = sender.blocking_send(TurnStreamEvent::Update(update));
-            });
+            // Release the conversation gate before consumers observe a
+            // terminal event. Otherwise an immediate follow-up request can
+            // race worker cleanup and incorrectly receive `instance_busy`.
+            let result = {
+                let _gate = gate;
+                driver.run_prepared_turn(&prompt, native_gate, |update| {
+                    let _ = sender.blocking_send(TurnStreamEvent::Update(update));
+                })
+            };
             let event = match result {
                 Ok(result) => TurnStreamEvent::Complete(result),
                 Err(error) => TurnStreamEvent::Error(error),
             };
             let _ = sender.blocking_send(event);
+            #[cfg(test)]
+            if let Self::Test {
+                terminal_barriers: Some(barriers),
+                ..
+            } = &driver
+            {
+                barriers.0.wait();
+                barriers.1.wait();
+            }
         });
         Ok(receiver)
     }
@@ -229,6 +244,7 @@ impl Driver {
                 delay,
                 starts,
                 pause,
+                ..
             } => {
                 starts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 std::thread::sleep(*delay);
@@ -503,6 +519,52 @@ mod tests {
         assert_eq!(
             sanitize_prompt("one\r\n\u{1b}[201~\u{3}two\tthree"),
             "one\n�[201~�two\tthree"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_event_is_published_after_turn_gate_is_released() {
+        use std::sync::atomic::AtomicUsize;
+
+        let turn_gate = Arc::new(tokio::sync::Mutex::new(()));
+        let guard = Arc::clone(&turn_gate).lock_owned().await;
+        let terminal_barriers = Arc::new((std::sync::Barrier::new(2), std::sync::Barrier::new(2)));
+        let driver = Driver::Test {
+            result: TurnResult {
+                text: "done".into(),
+                usage: history::GatewayUsage {
+                    prompt_tokens: 0,
+                    completion_tokens: 0,
+                    total_tokens: 0,
+                    cached_prompt_tokens: 0,
+                    reasoning_tokens: 0,
+                },
+            },
+            updates: vec![],
+            delay: Duration::ZERO,
+            starts: Arc::new(AtomicUsize::new(0)),
+            pause: None,
+            terminal_barriers: Some(Arc::clone(&terminal_barriers)),
+        };
+
+        let mut events = driver.start_turn("probe".into(), guard).unwrap();
+        loop {
+            match events.recv().await.expect("worker terminal event") {
+                TurnStreamEvent::Update(_) => continue,
+                TurnStreamEvent::Complete(_) => break,
+                TurnStreamEvent::Error(error) => panic!("test driver failed: {error}"),
+            }
+        }
+
+        // The worker is now paused after publishing Complete but before it can
+        // exit. This makes the old ordering deterministic: if the gate were
+        // scoped around the send, it would still be locked at this point.
+        terminal_barriers.0.wait();
+        let gate_was_released = turn_gate.try_lock().is_ok();
+        terminal_barriers.1.wait();
+        assert!(
+            gate_was_released,
+            "a follow-up turn must be admitted as soon as Complete is observable"
         );
     }
 


### PR DESCRIPTION
## Summary
- release the per-instance turn gate before publishing Complete or Error
- prevent immediate follow-up requests from spuriously receiving instance_busy
- add a deterministic barrier-based regression test for the ordering

## Root cause
Scheduled Flaky Test Detection runs 31300028022 and 31244942264 exposed a race in the gateway HTTP surface test. Driver::start_turn retained its OwnedMutexGuard while sending the terminal stream event, so a consumer could receive Complete and immediately submit a new turn before worker cleanup released the gate.

## Validation
- regression test red-proofed against the old ordering
- formerly flaky HTTP test passed 100 consecutive repetitions
- cargo test --all-targets
- cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check

Tracks #442.