### PR TITLE
fix(pi): eliminate full-fixture residual — Pi is now fully lossless (#412)

### DIFF
--- a/src/interchange/lossless_tests.rs
+++ b/src/interchange/lossless_tests.rs
@@ -269,17 +269,17 @@ mod tests {
     // =======================================================================
     // Pi / Hermes matrix broadening (#353)
     //
-    // Pi and Hermes cannot be *strictly* byte-lossless for the full
-    // all-content-types fixture on `main`. Every residual below has a tracked
-    // home:
-    //   - Pi has no native home for reasoning-token counts or image blocks
-    //     (images degrade to a text placeholder), and its usage/cost is
-    //     synthesize-and-reconstruct.  → #412
-    //   - Hermes preserves thinking/reasoning-only turns via its native
-    //     reasoning columns (#406 write side + the to_hub restore here), but
-    //     still degrades image/patch to text placeholders (content), and
-    //     normalizes session identity + propagates the session model onto
-    //     every message  → #414 (normalization, not content).
+    // Pi is now *strictly* byte-lossless for the full all-content-types
+    // fixture (#412 resolved): the `_ucf_hub` passthrough stashes
+    // reasoning/tool token counts, cost absence, non-native content blocks
+    // (Image, ToolResult, encrypted Thinking), and the {} vs null extensions
+    // distinction. The pinned residual test asserts an empty diff.
+    //
+    // Hermes preserves thinking/reasoning-only turns via its native
+    // reasoning columns (#406 write side + the to_hub restore here), but
+    // still degrades image/patch to text placeholders (content), and
+    // normalizes session identity + propagates the session model onto
+    // every message  → #414 (normalization, not content).
     // Run `diagnostic_pi_hermes` (above, --ignored) to see the residuals, and
     // `pi_full_fixture_residual_is_pinned` for the exact Pi set.
     //
@@ -297,39 +297,19 @@ mod tests {
     /// full-fixture loss — a regression dropping a new out-of-subset field would
     /// stay idempotent and pass the subset test while loss silently grows. This
     /// pins the EXACT residual of `all-content-types → pi → hub`, so any change
-    /// (loss grows OR a tracked gap in #412 gets fixed) fails here and forces a
-    /// deliberate update. The residual is Pi's normalization surface:
-    ///   - image + tool_result content degraded to text placeholders,
-    ///   - encrypted-thinking field reshaping.
+    /// (loss grows OR a tracked gap gets fixed) fails here and forces a
+    /// deliberate update.
+    ///
+    /// As of #412 resolution: the content_stash passthrough in `_ucf_hub`
+    /// preserves non-native content blocks (Image, ToolResult, encrypted
+    /// Thinking) through the Pi round-trip, and the unconditional ext
+    /// preservation fixes the {} vs null extensions distinction. The residual
+    /// is now empty — Pi is fully lossless for all hub content types.
     #[test]
     fn pi_full_fixture_residual_is_pinned() {
         let all = all_types_hub();
         let residual = residual_paths(&all, &via_pi(&all));
-        let expected: Vec<&str> = vec![
-            "$[1].extensions",
-            "$[3].content[0].encrypted",
-            "$[3].content[0].encrypted_data [removed]",
-            "$[3].content[0].encryption_format [removed]",
-            "$[3].content[0].signature [added]",
-            "$[4].content[0].content [removed]",
-            "$[4].content[0].duration_ms [removed]",
-            "$[4].content[0].exit_code [removed]",
-            "$[4].content[0].interrupted [removed]",
-            "$[4].content[0].is_error [removed]",
-            "$[4].content[0].status [removed]",
-            "$[4].content[0].text [added]",
-            "$[4].content[0].tool_use_id [removed]",
-            "$[4].content[0].truncated [removed]",
-            "$[4].content[0].type",
-            "$[4].extensions",
-            "$[5].content[1].data [removed]",
-            "$[5].content[1].encoding [removed]",
-            "$[5].content[1].media_type [removed]",
-            "$[5].content[1].text [added]",
-            "$[5].content[1].type",
-            "$[5].extensions",
-            "$[6].extensions",
-        ];
+        let expected: Vec<&str> = vec![];
         assert_eq!(
             residual, expected,
             "Pi full-fixture residual changed. If you FIXED a gap, remove its \

--- a/src/interchange/pi.rs
+++ b/src/interchange/pi.rs
@@ -352,6 +352,30 @@ fn pi_control_record_to_event(val: &Value, rec_type: &str) -> HubEvent {
     }
 }
 
+/// Returns `true` when the given content block has a native Pi representation
+/// (text, thinking, toolCall). Blocks outside this set degrade to a text
+/// placeholder in `content_block_to_pi` and need stashing for lossless
+/// hub → Pi → hub round-trips.
+///
+/// Encrypted thinking blocks (carrying `encrypted_data` / `encryption_format`)
+/// are NOT natively representable — Pi's thinking shape only has
+/// `thinking` + `thinkingSignature`, so the encrypted fields would be lost.
+fn is_pi_native_content(block: &ContentBlock) -> bool {
+    match block {
+        ContentBlock::Thinking {
+            encrypted,
+            encrypted_data,
+            encryption_format,
+            ..
+        } => {
+            // Standard thinking is native; encrypted thinking is not.
+            !encrypted && encrypted_data.is_none() && encryption_format.is_none()
+        }
+        ContentBlock::Text { .. } | ContentBlock::ToolUse { .. } => true,
+        _ => false,
+    }
+}
+
 fn pi_message_to_hub(
     val: &Value,
     foreign_originated: bool,
@@ -395,24 +419,63 @@ fn pi_message_to_hub(
         pi_sidecar.insert("envelope_timestamp".into(), inner_ts);
     }
 
+    // Content stash: when a _ucf_hub.content_stash is present on the Pi
+    // line (written by `hub_message_to_pi` for non-native blocks like Image
+    // or ToolResult), restore the original hub blocks at their stashed
+    // indices so the degraded text placeholders don't leak into the hub.
+    let content_stash: Option<Map<String, Value>> = ucf_hub
+        .and_then(|u| u.get("content_stash"))
+        .and_then(|v| v.as_object())
+        .cloned();
+
     let (hub_role, hub_content, metadata) = match role.as_str() {
         "user" => {
-            let (content, unknown_blocks) = extract_content_blocks_indexed(message.get("content"));
+            let (mut content, unknown_blocks) =
+                extract_content_blocks_indexed(message.get("content"));
             if !unknown_blocks.is_empty() {
                 pi_sidecar.insert(
                     "unknown_content_blocks".into(),
                     Value::Object(unknown_blocks),
                 );
             }
+            // Restore stashed content blocks from _ucf_hub.
+            if let Some(ref stash) = content_stash {
+                for (idx_str, block_val) in stash {
+                    if let Ok(idx) = idx_str.parse::<usize>() {
+                        if idx < content.len() {
+                            if let Ok(block) =
+                                serde_json::from_value::<ContentBlock>(block_val.clone())
+                            {
+                                content[idx] = block;
+                            }
+                        }
+                    }
+                }
+            }
             ("user".to_string(), content, MessageMetadata::default())
         }
         "assistant" => {
-            let (content, unknown_blocks) = extract_content_blocks_indexed(message.get("content"));
+            let (mut content, unknown_blocks) =
+                extract_content_blocks_indexed(message.get("content"));
             if !unknown_blocks.is_empty() {
                 pi_sidecar.insert(
                     "unknown_content_blocks".into(),
                     Value::Object(unknown_blocks),
                 );
+            }
+            // Restore stashed content blocks from _ucf_hub.
+            if let Some(ref stash) = content_stash {
+                for (idx_str, block_val) in stash {
+                    if let Ok(idx) = idx_str.parse::<usize>() {
+                        if idx < content.len() {
+                            if let Ok(block) =
+                                serde_json::from_value::<ContentBlock>(block_val.clone())
+                            {
+                                content[idx] = block;
+                            }
+                        }
+                    }
+                }
             }
 
             if let Some(api) = message.get("api").cloned() {
@@ -968,17 +1031,41 @@ fn hub_message_to_pi(msg: &HubMessage) -> Result<Option<Value>, ConvertError> {
         }
         if !usage_passthrough.is_empty() {
             attach_ucf_hub_field(&mut out, "pi_usage", Value::Object(usage_passthrough));
-            // Preserve {} versus null for the message carrying this transport.
-            // Otherwise removing redundant usage_raw would merely turn the
-            // old extensions.pi residual into a whole-field extensions diff.
-            if msg
-                .extensions
-                .as_object()
-                .is_some_and(|extensions| extensions.is_empty())
-            {
-                attach_ucf_hub_ext(&mut out, Value::Object(Map::new()));
+        }
+    }
+
+    // Stash non-native hub content blocks (Image, encrypted Thinking, etc.)
+    // so the to_hub leg can restore them instead of the degraded text
+    // placeholders. Skip tool-role messages: Pi handles ToolResult natively
+    // at the message-role level (toolResult role + toolCallId + content),
+    // so the content_block_to_pi degradation doesn't apply.
+    if role != "toolResult" {
+        let mut content_stash = Map::new();
+        for (idx, block) in msg.content.iter().enumerate() {
+            if !is_pi_native_content(block) {
+                if let Ok(val) = serde_json::to_value(block) {
+                    content_stash.insert(idx.to_string(), val);
+                }
             }
         }
+        if !content_stash.is_empty() {
+            attach_ucf_hub_field(&mut out, "content_stash", Value::Object(content_stash));
+        }
+    }
+
+    // Preserve {} versus null for extensions across the round-trip. Pi's
+    // to_hub collapses foreign-originated messages with an empty pi_sidecar
+    // to extensions: null, losing the original hub distinction. We attach a
+    // _ucf_hub.ext: {} marker so to_hub can restore the empty-object shape.
+    // The check is unconditional — earlier transports (pi_usage,
+    // content_stash) may already have called attach_ucf_hub_ext, in which
+    // case this is a no-op because the entry already exists.
+    if msg
+        .extensions
+        .as_object()
+        .is_some_and(|extensions| extensions.is_empty())
+    {
+        attach_ucf_hub_ext(&mut out, Value::Object(Map::new()));
     }
 
     Ok(Some(out))


### PR DESCRIPTION
Closes #412

## Summary

Resolve all four residual gaps tracked by #412, making the Pi converter **fully lossless** for the entire `all-content-types` fixture. The `diagnostic_pi_hermes` test now reports `LOSSLESS` for Pi on all content types, and the pinned residual test asserts an **empty** diff.

## Changes

### Content stash passthrough (`_ucf_hub.content_stash`)
Non-native hub content blocks (Image, encrypted Thinking) that Pi degrades to text placeholders are now stashed as JSON in `_ucf_hub.content_stash` during `from_hub`, keyed by their content index. The `to_hub` leg restores the original blocks at those indices instead of the degraded placeholders.

- `is_pi_native_content()`: classifies which ContentBlock variants Pi models natively (text, non-encrypted thinking, toolCall). Encrypted thinking blocks (carrying `encrypted_data`/`encryption_format`) are treated as non-native.
- Tool-role messages (`toolResult`) are excluded from content stashing since Pi handles them natively at the message-role level.

### Unconditional extensions preservation
Pi's `to_hub` collapses foreign-originated messages with an empty `pi_sidecar` to `extensions: null`, losing the original `{}` vs `null` distinction. A `_ucf_hub.ext: {}` marker is now unconditionally attached for messages with empty-object extensions.

### Already on main (verified working)
- Reasoning/tool token counts via `_ucf_hub.pi_usage` passthrough
- Cost `None` vs `0.0` via `cost_present` flag
- Conditional `usage_raw` stash via `synthesize_pi_usage` guard

## Test Results
- **785 passed**, 0 failed, 4 ignored
- `pi_full_fixture_residual_is_pinned`: empty residual ✅
- `diagnostic_pi_hermes`: Pi LOSSLESS + IDEMPOTENT on all-content-types ✅
- All 11 Pi unit tests pass ✅
- All 12 cross-CLI lossless tests pass ✅