### PR TITLE
fix(deps): bump lru 0.18.0 → 0.18.2 (RUSTSEC-2026-0253)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -2975,7 +2975,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.18.0",
+ "lru 0.18.2",
  "palette",
  "serde",
  "strum 0.28.0",


### PR DESCRIPTION
Closes #448

## Summary

Bump the `lru` crate from 0.18.0 to 0.18.2 to resolve [RUSTSEC-2026-0253](https://rustsec.org/advisories/RUSTSEC-2026-0253) — potential use-after-free in `LruCache::pop()` due to lack of panic safety.

## Details

- **lru 0.18.0 → 0.18.2** (transitive via `ratatui-core`): ✅ Fixed
- **lru 0.16.4** (transitive via `tantivy 0.26.1`): ⚠️ Cannot bump — tantivy pins `lru >=0.16, <0.17`. Will be resolved when tantivy releases with `lru >=0.18.2`.

## Change

`Cargo.lock` only — `cargo update lru@0.18.0`.

Acting-Agent: Pilgrim